### PR TITLE
Fixed Bug in encode() funciton in JSON.cfc

### DIFF
--- a/system/core/conversion/JSON.cfc
+++ b/system/core/conversion/JSON.cfc
@@ -299,7 +299,7 @@ Modifications:
 			<cfset dJSONString = createObject('java','java.lang.StringBuffer').init("") />
 			<cfloop from="1" to="#ArrayLen(_data)#" index="i">
 				<!--- Null Checks --->
-				<cfif _data.get(i-1) EQ JavaCast("null","")>
+				<cfif isSimpleValue(_data.get(i-1)) AND _data.get(i-1) EQ JavaCast("null","")>
 					<cfset tempVal = "null">
 				<cfelse>
 					<cfset tempVal = encode( _data[i], arguments.queryFormat, arguments.queryKeyCase, arguments.stringNumbers, arguments.formatDates, arguments.columnListFormat ) />


### PR DESCRIPTION
Null check in encode function, for arrays, was throwing an error when an object (specifically from ORM) was evaluated.  Since we have to support ColdFusion 7 & 8, we can't use isNull.  Added isSimpleValue check.
