### PR TITLE
CookieStorage.deleteVar requires domain parameter to delete cookies created 

### DIFF
--- a/system/plugins/CookieStorage.cfc
+++ b/system/plugins/CookieStorage.cfc
@@ -161,10 +161,18 @@ Modification History: March 23,2008 Added new feature to encrypt/decrypt cookie 
 	<!--- Delete a Cookie Value --->
 	<cffunction name="deleteVar" access="public" returntype="boolean" hint="Tries to delete a permanent cookie var." output="false">
 		<!--- ************************************************************* --->
-		<cfargument  name="name" type="string" required="true" 	hint="The variable name to retrieve.">
+		<cfargument name="name" 	type="string" required="true" 	hint="The variable name to retrieve.">
+		<cfargument name="domain"	type="string" required="false"	default=""		hint="Domain in which cookie is valid and to which cookie content can be sent from the user's system.">
 		<!--- ************************************************************* --->
+		<cfset var args		= StructNew() />
 		<cfif exists(arguments.name)>
-			<cfcookie name="#arguments.name#" expires="NOW" value='NULL'>
+			<cfset args["name"] 	= uCase(arguments.name) />
+			<cfset args["expires"]	= "NOW" />
+			<cfset args["value"]	= "" />
+			<cfif len(arguments.domain)>
+				<cfset args["domain"]	= arguments.domain />
+			</cfif>
+			<cfcookie attributeCollection="#args#">
 			<cfset structdelete(cookie, arguments.name)>
 			<cfreturn true>
 		<cfelse>


### PR DESCRIPTION
This will add an optional parameter to the CookieStorage.deleteVar method in order to allow cookies to be deleted on domains that aren't the full hostname (ie. '.domain.com').

In order to update a cookie, the domain for the cookie update needs to match what it was initially created on; otherwise, the cookie won't be updated.

The CookieStorage.deleteVar method needs to have an optional 'domain' parameter that can be used to specify the domain that the cookie was created on in order to delete it.

Recreation steps:
- run test on 'www.domain.com' - create cookie with domain parameter of '.domain.com'
