### PR TITLE
SES and Query String Bug Fixed

### DIFF
--- a/system/web/Controller.cfc
+++ b/system/web/Controller.cfc
@@ -387,7 +387,14 @@ Only one instance of a specific ColdBox application exists.
 					routeString = replace(arguments.event,".","/","all");
 					// Convert Query String to convention name value-pairs
 					if( len(trim(arguments.queryString)) ){
-						routeString = routeString & "/" & replace(arguments.queryString,"&","/","all");
+						// If the routestring ends with '/' we do not want to
+						// double append '/'
+						if (right(routeString,1) NEQ "/")
+						{
+							routeString = routeString & "/" & replace(arguments.queryString,"&","/","all");
+						} else {
+							routeString = routeString & replace(arguments.queryString,"&","/","all");
+						}
 						routeString = replace(routeString,"=","/","all");
 					}
 


### PR DESCRIPTION
For setNextEvent, when in SES mode, and a querystring was provided, the resulting URL could include double slashes if the routestring already ended with a '/'. This has been resolved.
