### PR TITLE
Resolves issue #1237 - CFProvider Places to much trust in ObjectStore for Lookup

### DIFF
--- a/system/cache/providers/CFProvider.cfc
+++ b/system/cache/providers/CFProvider.cfc
@@ -293,7 +293,9 @@ component serializable="false" implements="coldbox.system.cache.ICacheProvider"{
     * check if object in cache with no stats
     */
     any function lookupQuiet(required any objectKey) output=false{
-		return getObjectStore().isKeyInCache( ucase(arguments.objectKey) );
+		// Don't consult the object store like other provides since this
+		// provider uses the CF methods to set/get from cache.
+		return !isNull(cacheGet( arguments.objectKey ));
 	}
 	
 	/**


### PR DESCRIPTION
Resolves issue #1237. The CFProvider was asking the ObjectStore if something existed in the cache; however, the CFProvider goes direct to ColdFusion to get/set items into the cache. This update asks ColdFusion if something exists in the cache.

This resolves a bug I have been experiencing that has held me back from deploying ColdBox 3.0 to my production servers. I experienced it on a cached viewlet.

I've committed this to the master branch as I believe it is a critical fix.

Thank you.
