### PR TITLE
203 Header when rendering Cached Events

### DIFF
--- a/system/Coldbox.cfc
+++ b/system/Coldbox.cfc
@@ -223,7 +223,8 @@ Description :
 					<cfset event.showDebugPanel(false)>
 				</cfif>
 				<!--- Render Content --->
-				<cfoutput>#refResults.eventCaching.renderedContent#</cfoutput>				
+				<cfoutput>#refResults.eventCaching.renderedContent#</cfoutput>
+				<cfheader statuscode="203" statustext="Non-Authoritative Information" />				
 			<cfelse>
 				<!--- Run Default/Set Event not executing an event --->
 				<cfif NOT event.isNoExecution()>


### PR DESCRIPTION
Fixes http://www.assembla.com/spaces/coldbox/tickets/1316-cached-events-return-203-non-authoritative-information#last_comment
