### PR TITLE
Replaced getMetaData and getComponentMetaData with new utility method ca...

### DIFF
--- a/system/ioc/Injector.cfc
+++ b/system/ioc/Injector.cfc
@@ -406,7 +406,7 @@ Description :
 				// Do we have an incoming target id?
 				if( NOT len(arguments.targetID) ){
 					// need to get metadata to verify identity
-					md = getMetadata(arguments.target);
+					md = instance.utility.getInheritedMetaData(arguments.target,getBinder().getStopRecursions());
 					// We have identity now, use the full location path
 					arguments.targetID = md.path;
 				}
@@ -415,7 +415,7 @@ Description :
 				if( NOT instance.binder.mappingExists( arguments.targetID ) ){
 					// No mapping found, means we need to map this object for the first time.
 					// Is md retreived? If not, retrieve it as we need to register it for the first time.
-					if( isSimpleValue(md) ){ md = getMetadata(arguments.target); }
+					if( isSimpleValue(md) ){ md = instance.utility.getInheritedMetaData(arguments.target,getBinder().getStopRecursions()); }
 					// register new mapping instance
 					registerNewInstance(arguments.targetID,md.path);
 					// get Mapping created

--- a/system/ioc/config/Mapping.cfc
+++ b/system/ioc/config/Mapping.cfc
@@ -539,7 +539,7 @@ Description :
 					md = arguments.metadata;
 				}
 				else{
-					md = getComponentMetadata( instance.path );
+					md = arguments.binder.utility.getInheritedMetaData(instance.path,arguments.binder.getStopRecursions());
 				}
 				
 				// Store Metadata
@@ -831,33 +831,6 @@ Description :
 				}//end loop of functions
 			}//end if functions found
 			
-			// Start Registering inheritances, if the exists
-			if ( structKeyExists(md, "extends")
-				 AND
-				 stopClassRecursion(md.extends.name,arguments.binder) EQ FALSE){
-				// Recursive lookup
-				processDIMetadata(arguments.binder, md.extends, arguments.dependencies);
-			}
-		</cfscript>
-	</cffunction>
-	
-	<!--- stopClassRecursion --->
-	<cffunction name="stopClassRecursion" access="private" returntype="any" hint="Should we stop recursion or not due to class name found: Boolean" output="false" colddoc:generic="Boolean">
-		<cfargument name="classname" 	required="true" hint="The class name to check">
-		<cfargument name="binder" 		required="true" hint="The binder requesting the processing"/>
-		<cfscript>
-			var x 				= 1;
-			var stopRecursions 	= arguments.binder.getStopRecursions();
-			var stopLen			= arrayLen(stopRecursions);
-			
-			// Try to find a match
-			for(x=1;x lte stopLen; x=x+1){
-				if( CompareNoCase( stopRecursions[x], arguments.classname) eq 0){
-					return true;
-				}
-			}
-
-			return false;
 		</cfscript>
 	</cffunction>
 	

--- a/testing/cases/core/util/UtilTest.cfc
+++ b/testing/cases/core/util/UtilTest.cfc
@@ -2,6 +2,7 @@
 <cfscript>
 	function setup(){
 		util = CreateObject("component","coldbox.system.core.util.Util");
+		class1 = CreateObject("component","testing.cases.core.util.class1");
 	}
 	
 	function isInstanceCheck(){
@@ -13,6 +14,131 @@
 		
 		test = createObject("component","coldbox.testing.testhandlers.TestNoInheritance");
 		assertFalse( util.isInstanceCheck( test, "coldbox.system.EventHandler") );		
+	}
+	
+	function testStopClassRecursion(){
+		stopRecursions = ["com.foo.bar","com.foobar","coldbox.system.coldbox"];
+		
+		makePublic(util,"stopClassRecursion");
+		assertFalse( util.stopClassRecursion( "com.google", stopRecursions ) );
+		assertTrue( util.stopClassRecursion( "com.foobar", stopRecursions ) );
+	}
+	
+	function testGetInheritedMetaData(){
+		md = util.getInheritedMetaData(class1);
+		testGetInheritedMetaDataHelper(md);
+		
+		md = util.getInheritedMetaData("class1");
+		testGetInheritedMetaDataHelper(md);
+				
+	}
+	
+	function testGetInheritedMetaDataStopRecursion(){		
+		stopRecursions = ["testing.cases.core.util.class2"];
+		
+		md = util.getInheritedMetaData(class1,stopRecursions);
+		testGetInheritedMetaDataStopRecursionHelper(md);
+		
+		md = util.getInheritedMetaData("class1",stopRecursions);
+		testGetInheritedMetaDataStopRecursionHelper(md);
+		
+	}
+	
+	private function testGetInheritedMetaDataHelper(md){
+		
+		assertTrue( structKeyExists( md, "inheritanceTrail") );
+		assertEquals( arrayLen(md.inheritanceTrail), 4 );
+		assertEquals( md.inheritanceTrail[1], "testing.cases.core.util.class1" );
+		assertEquals( md.inheritanceTrail[2], "testing.cases.core.util.class2" );
+		assertEquals( md.inheritanceTrail[3], "testing.cases.core.util.class3" );
+		assertEquals( md.inheritanceTrail[4], "WEB-INF.cftags.component" );
+		
+		assertEquals( md.output, true );
+		assertEquals( md.scope, "server" );
+		
+		assertTrue( structKeyExists( md, "annotationClass1Only") );
+		assertTrue( structKeyExists( md, "annotationClass2Only") );
+		assertTrue( structKeyExists( md, "annotationClass3Only") );
+		assertTrue( structKeyExists( md, "annotationClass1and2and3") );
+		assertEquals( md.annotationClass1Only, "class1Value" );
+		assertEquals( md.annotationClass2Only, "class2Value" );
+		assertEquals( md.annotationClass3Only, "class3Value" );
+		assertEquals( md.annotationClass1and2and3, "class1Value" );
+		
+		
+		assertEquals( arrayLen(md.functions), 4 );
+		assertTrue( itemExists(md.functions, "funcClass1Only") );
+		assertEquals( getItemKey(md.functions, "funcClass1Only", "hint"), "Function defined in Class1" );
+		assertTrue( itemExists(md.functions, "funcClass2Only") );
+		assertEquals( getItemKey(md.functions, "funcClass2Only", "hint"), "Function defined in Class2" );
+		assertTrue( itemExists(md.functions, "funcClass3Only") );
+		assertEquals( getItemKey(md.functions, "funcClass3Only", "hint"), "Function defined in Class3" );
+		assertTrue( itemExists(md.functions, "funcClass1and2and3") );
+		assertEquals( getItemKey(md.functions, "funcClass1and2and3", "hint"), "Function defined in Class1" );
+				
+		assertEquals( arrayLen(md.properties), 4 );
+		assertTrue( itemExists(md.properties, "propClass1Only") );
+		assertEquals( getItemKey(md.properties, "propClass1Only", "default"), "class1Value" );
+		assertTrue( itemExists(md.properties, "propClass2Only") );
+		assertEquals( getItemKey(md.properties, "propClass2Only", "default"), "class2Value" );
+		assertTrue( itemExists(md.properties, "propClass3Only") );
+		assertEquals( getItemKey(md.properties, "propClass3Only", "default"), "class3Value" );
+		assertTrue( itemExists(md.properties, "propClass1and2and3") );
+		assertEquals( getItemKey(md.properties, "propClass1and2and3", "default"), "class1Value" );		
+		
+	}
+		
+	private function testGetInheritedMetaDataStopRecursionHelper(md){
+				
+		assertTrue( structKeyExists( md, "inheritanceTrail") );
+		assertEquals( arrayLen(md.inheritanceTrail), 1 );
+		assertEquals( md.inheritanceTrail[1], "testing.cases.core.util.class1" );
+		
+		assertEquals( md.output, true );
+		assertEquals( md.scope, "server" );		
+		
+		assertTrue( structKeyExists( md, "annotationClass1Only") );
+		assertFalse( structKeyExists( md, "annotationClass2Only") );
+		assertFalse( structKeyExists( md, "annotationClass3Only") );
+		assertTrue( structKeyExists( md, "annotationClass1and2and3") );
+		assertEquals( md.annotationClass1Only, "class1Value" );
+		assertEquals( md.annotationClass1and2and3, "class1Value" );
+		
+		assertEquals( arrayLen(md.functions), 2 );
+		assertTrue( itemExists(md.functions, "funcClass1Only") );
+		assertEquals( getItemKey(md.functions, "funcClass1Only", "hint"), "Function defined in Class1" );
+		assertFalse( itemExists(md.functions, "funcClass2Only") );
+		assertFalse( itemExists(md.functions, "funcClass3Only") );
+		assertTrue( itemExists(md.functions, "funcClass1and2and3") );
+		assertEquals( getItemKey(md.functions, "funcClass1and2and3", "hint"), "Function defined in Class1" );
+				
+		assertEquals( arrayLen(md.properties), 2 );
+		assertTrue( itemExists(md.properties, "propClass1Only") );
+		assertEquals( getItemKey(md.properties, "propClass1Only", "default"), "class1Value" );
+		assertFalse( itemExists(md.properties, "propClass2Only") );
+		assertFalse( itemExists(md.properties, "propClass3Only") );
+		assertTrue( itemExists(md.properties, "propClass1and2and3") );
+		assertEquals( getItemKey(md.properties, "propClass1and2and3", "default"), "class1Value" );		
+		
+	}
+
+
+	private function itemExists(itemArray, itemName){
+		for(i=1; i<=arrayLen(itemArray); i++){
+			if(itemArray[i].name == itemName){
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function getItemKey(itemArray, itemName, key){
+		for(i=1; i<=arrayLen(itemArray); i++){
+			if(itemArray[i].name == itemName){
+				return itemArray[i][key];
+			}
+		}
+		fail("Item '#itemName#' doesn't exists.");
 	}
 	
 </cfscript>

--- a/testing/cases/core/util/class1.cfc
+++ b/testing/cases/core/util/class1.cfc
@@ -1,0 +1,11 @@
+<cfcomponent extends="class2" displayName="class1" output="true" scope="server" annotationClass1Only="Class1Value" annotationClass1and2and3="class1Value">
+	<cfproperty name="propClass1Only" default="class1Value">
+	<cfproperty name="propClass1and2and3" default="class1Value">
+
+	<cffunction name="funcClass1Only" hint="Function defined in Class1">
+	</cffunction>
+	
+	<cffunction name="funcClass1and2and3" hint="Function defined in Class1">
+	</cffunction>
+	
+</cfcomponent>

--- a/testing/cases/core/util/class2.cfc
+++ b/testing/cases/core/util/class2.cfc
@@ -1,0 +1,11 @@
+<cfcomponent extends="class3" displayName="class2" output="false" scope="session" annotationClass2Only="Class2Value" annotationClass1and2and3="class2Value">
+	<cfproperty name="propClass2Only" default="class2Value">
+	<cfproperty name="propClass1and2and3" default="class2Value">
+
+	<cffunction name="funcClass2Only" hint="Function defined in Class2">
+	</cffunction>
+	
+	<cffunction name="funcClass1and2and3" hint="Function defined in Class2">
+	</cffunction>
+	
+</cfcomponent>

--- a/testing/cases/core/util/class3.cfc
+++ b/testing/cases/core/util/class3.cfc
@@ -1,0 +1,11 @@
+<cfcomponent displayName="class3" scope="request" annotationClass3Only="Class3Value" annotationClass1and2and3="class3Value">
+	<cfproperty name="propClass3Only" default="class3Value">
+	<cfproperty name="propClass1and2and3" default="class3Value">
+
+	<cffunction name="funcClass3Only" hint="Function defined in Class3">
+	</cffunction>
+	
+	<cffunction name="funcClass1and2and3" hint="Function defined in Class3">
+	</cffunction>
+	
+</cfcomponent>

--- a/testing/cases/ioc/InjectorTest.cfc
+++ b/testing/cases/ioc/InjectorTest.cfc
@@ -1,12 +1,15 @@
-﻿<cfcomponent extends="coldbox.system.testing.BaseTestCase">
+<cfcomponent extends="coldbox.system.testing.BaseTestCase">
 <cfscript>
 	
 	function setup(){
 		// init with defaults
 		injector = getMockBox().createMock("coldbox.system.ioc.Injector");
-		
+				
 		// init injector
 		injector.init();
+		
+		util = getMockBox().createMock("coldbox.system.core.util.util").$("getInheritedMetaData").$results({path="path.to.object"});
+		injector.$property("instance.utility","variables",util);
 	}
 		
 	function testbuildBinder(){
@@ -150,7 +153,7 @@
 		assertTrue( isObject(injector.getParent() ));
 	}
 	
-	function removeFromScope(){
+	function testremoveFromScope(){
 		scopeReg = {enabled= true, key = "wirebox",scope="application"};
 		binder = injector.getBinder();
 		getMockBox().prepareMock( binder ).$("getScopeRegistration", scopeReg);
@@ -158,6 +161,16 @@
 		
 		injector.removeFromScope();
 		assertFalse( structKeyExists( application, "wirebox") );
+	}
+	
+	function testAutowireCallsGetInheritedMetaDataForTargetID(){
+		injector.autowire( target=getMockBox().createStub() );
+		assertTrue( util.$once("getInheritedMetaData") );
+	}
+	
+	function testAutowireCallsGetInheritedMetaDataForMD(){
+		injector.autowire( target=getMockBox().createStub() , targetID = "myTargetID");
+		assertTrue( util.$once("getInheritedMetaData") );
 	}
 	
 	


### PR DESCRIPTION
...lled getInheritedMetaData in ioc. This allows component annotations to be inherited. Removed recursion in processDIMetadata since new metadata struct already inlucludes all inherited functions and properties. Also, moved stopClassRecursions out to util.cfc as well. It is required by getInheritedMetaData and it seems the ability to get inherited metadata might be useful elsewhere in the framework, not just the ioc container.
