### PR TITLE
Remote concurrency fix

### DIFF
--- a/system/remote/ColdboxProxy.cfc
+++ b/system/remote/ColdboxProxy.cfc
@@ -28,12 +28,18 @@ Description :
 		<!--- There are no arguments defined as they come in as a collection of arguments. --->
 		<cfset var cbController = "">
 		<cfset var event = "">
+		<cfset var createNewRC = true>
 		<cfset var refLocal = structnew()>
 		<cfset var interceptData = structnew()>
 		<cfsetting showdebugoutput="false">
 
 		<cftry>
 			<cfscript>
+			// ensures each remote request is processed with a unique request context
+			if(createNewRC){
+				structDelete(request,"cb_requestContext"); 
+			}
+				
 			// Locate ColdBox Controller
 			cbController = getController();
 


### PR DESCRIPTION
Added simple fix to deal with multiple concurrent remote proxy requests during a single http request.

_The Problem:_
In Flex/Flash, multiple RemoteObject requests to the same destination can be batched together into a single http request which will cause problems with cross-request contamination (because it's via one http request, each event will be, by default, handled within a common request context). 

_The Solution:_
Each time an remote proxy calls 'process', a new request context should be created. Due to the way these are stored, this simple approach just removes 'cb_requestContext' from the request scope which allows a new RC to be created. Just in case someone would ever need to maintain the shared RC, I have gone ahead and made an optional parameter for process which will allow a user to opt-out of creating this unique RC.
