### PR TITLE
This will make it easier to extend message types.

### DIFF
--- a/system/plugins/MessageBox.cfc
+++ b/system/plugins/MessageBox.cfc
@@ -327,7 +327,7 @@ Description :
 <!------------------------------------------- PRIVATE ------------------------------------------>
 
     <cffunction name="isValidMessageType" access="private" output="false" returntype="string" hint="Returns a list of valid message types.">
-	<cfargument name="messageType" type="string" required="true" />
+	<cfargument name="type" type="string" required="true" />
 	<cfreturn refindnocase("(error|warning|info)", trim(arguments.type)) /> 
     </cffunction>
 


### PR DESCRIPTION
I'm working on a version with Twitter Bootstrap styling. With this change, there's no need to override setMessage() and renderMessage() just to change the valid message types.
