### PR TITLE
Small change for CF8 compatibility

### DIFF
--- a/system/cache/report/skins/default/CacheContentReport.cfm
+++ b/system/cache/report/skins/default/CacheContentReport.cfm
@@ -20,7 +20,7 @@
 		<tr <cfif x mod 2 eq 0>class="even"</cfif> id="cbox_cache_tr_#urlEncodedFormat(thisKey)#">
 	  	<!--- Link --->
 		<td align="left">
-		  	<a href="javascript:cachebox_openwindow('#URLBase##(Find("?",URLBase) ? '&' : '?')#debugpanel=cacheviewer&cbox_cacheName=#arguments.cacheName#&cbox_cacheEntry=#urlEncodedFormat( thisKey )#','CacheViewer',650,375,'resizable,scrollbars,status')" 
+		  	<a href="javascript:cachebox_openwindow('#URLBase##iif(Find("?", URLBase), DE('&'), DE('?'))#debugpanel=cacheviewer&cbox_cacheName=#arguments.cacheName#&cbox_cacheEntry=#urlEncodedFormat( thisKey )#','CacheViewer',650,375,'resizable,scrollbars,status')" 
 			   title="#thisKey#">
 		  	#thisKey#
 			</a>


### PR DESCRIPTION
When running CF8, the ColdBox debugging output's use of an inline "if" statement throws an error, since that's not supported in CF8.  I replaced it with CF's "iif" function.

**Not supported in CF8:**
(Find("?",URLBase) ? '&' : '?')

**Supported in CF8:**
iif(Find("?", URLBase), DE('&'), DE('?'))
