### PR TITLE
Fix for Railo incompatibility on DetachedCriteriaBuilder Methods

### DIFF
--- a/system/orm/hibernate/DetachedCriteriaBuilder.cfc
+++ b/system/orm/hibernate/DetachedCriteriaBuilder.cfc
@@ -67,7 +67,7 @@ component accessors="true" extends="coldbox.system.orm.hibernate.BaseBuilder" {
      */
 	private any function getCriteriaJoinWalker( required any translator ) {
 		// get session
-		var ormsession = getPlatform()=="ColdFusion Server" ? orm.getSession().getActualSession() : orm.getSession();
+		var ormsession = orm.getSession();
 		// get session factory
 		var factory = ormsession.getSessionFactory();
 		// get executable criteriaImplementation for detached criteria object
@@ -89,7 +89,7 @@ component accessors="true" extends="coldbox.system.orm.hibernate.BaseBuilder" {
      */
 	private any function getCriteriaQueryTranslator() {
 		// get session
-		var ormsession = getPlatform()=="ColdFusion Server" ? orm.getSession().getActualSession() : orm.getSession();
+		var ormsession = orm.getSession();
 		// get session factory
 		var factory = ormsession.getSessionFactory();
 		// get executable criteriaImplementation for detached criteria object
@@ -136,9 +136,5 @@ component accessors="true" extends="coldbox.system.orm.hibernate.BaseBuilder" {
 			arguments.sql = reReplaceNoCase( arguments.sql, "\?", pvTyped, "one" );
 		}
 		return arguments.sql;
-	}
-	
-	private string function getPlatform() {
-		return server.coldfusion.productname;
 	}
 }

--- a/system/orm/hibernate/util/CFORMUtil.cfc
+++ b/system/orm/hibernate/util/CFORMUtil.cfc
@@ -21,9 +21,11 @@ component implements="coldbox.system.orm.hibernate.util.IORMUtil"{
 
 	public any function getSession(string datasource) {
 		if(StructKeyExists(arguments,"datasource"))
-			return ORMGetSession(arguments.datasource);
+			// get actual session from coldfusion.orm.hibernate.SessionWrapper
+			return ORMGetSession(arguments.datasource).getActualSession();
 		else
-			return ORMGetSession();
+			// get actual session from coldfusion.orm.hibernate.SessionWrapper
+			return ORMGetSession().getActualSession();
 	}
 	
 	public any function getSessionFactory(string datasource) {


### PR DESCRIPTION
While playing with DevBox, I discovered Railo's implementation of getSession()  doesn't appear to be quite the same as ACF. So in the case of Adobe ColdFusion, get actual session from wrapper via
getActualSession(); otherwise, just use getSession();
