### PR TITLE
Added utility function convertValueToJavaType

### DIFF
--- a/system/orm/hibernate/BaseORMService.cfc
+++ b/system/orm/hibernate/BaseORMService.cfc
@@ -1252,6 +1252,16 @@ component accessors="true"{
 
 		return arguments.id;
 	}
+	
+	/**
+	* Coverts a value to the correct javaType for the property passed in
+	* The method returns the value in the proper Java Type
+	*/
+	any function convertValueToJavaType(required entityName, required propertyName, required value){
+		var hibernateMD = orm.getSessionFactory(orm.getEntityDatasource(arguments.entityName)).getClassMetaData(arguments.entityName);
+
+		return hibernateMD.getPropertyType(arguments.propertyName).fromStringValue(arguments.value);
+	}
 
 	/**
 	* Get our hibernate org.hibernate.criterion.Restrictions proxy object


### PR DESCRIPTION
Added a function to the BaseORMService that will convert a value to the
proper JavaType for the property passed in.  This can be used instead
of javacasting the property yourself and is handy for cross engine compatibility.
