### PR TITLE
Fix for a bug on occasional first load redirect

### DIFF
--- a/system/web/Controller.cfc
+++ b/system/web/Controller.cfc
@@ -447,6 +447,9 @@ Only one instance of a specific ColdBox application exists.
 
 					// Get Base relocation URL from context
 					relocationURL = oRequestContext.getSESBaseURL();
+					//if the sesBaseURL is nothing, set it to the setting
+					if(!len(relocationURL)){relocationURL = getSetting('sesBaseURL');}
+					//add the trailing slash if there isnt one
 					if( right(relocationURL,1) neq "/" ){ relocationURL = relocationURL & "/"; }
 
 					// Check SSL?


### PR DESCRIPTION
Sometimes when a app starts up the sesBaseURL isn't set in the context yet when a redirect happens.
This fix will fall back to the setting (which has been set) in those cases.
I have seen this issue with applications that have the security interceptor and the first hit
is to a secured page.
