### PR TITLE
Updated Monitor.cfm to include Scope for debugPanel variable

### DIFF
--- a/system/cache/report/monitor.cfm
+++ b/system/cache/report/monitor.cfm
@@ -68,7 +68,7 @@ ATTRIBUTES:
 </cfif>
 
 <!--- Render Reports According To Panel Requested --->
-<cfswitch expression="#debugPanel#">
+<cfswitch expression="#url.debugPanel#">
 	<cfcase value="cache">
 		<cfset ajaxRender = false>
 		<cfset report = reportHandler.renderCachePanel()>


### PR DESCRIPTION
Added the URL param for the debug panel, to use the URL scope, which will help ColdBox pass a test for Strict Variables (like in Railo 4.1)
