### PR TITLE
Update MessageBox.cfc

### DIFF
--- a/system/plugins/MessageBox.cfc
+++ b/system/plugins/MessageBox.cfc
@@ -1,4 +1,4 @@
-﻿<!-----------------------------------------------------------------------
+<!-----------------------------------------------------------------------
 ********************************************************************************
 Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
 www.coldbox.org | www.luismajano.com | www.ortussolutions.com
@@ -119,7 +119,7 @@ Description :
 			var newMessage = "";
 
 			// Do we have a message?
-			if( isEmpty() ){
+			if( isEmptyMessage() ){
 				// Set default message
 				setMessage('info',arguments.message);
 			}
@@ -144,7 +144,7 @@ Description :
 			var newMessage = "";
 
 			// Do we have a message?
-			if( isEmpty() ){
+			if( isEmptyMessage() ){
 				// Set default message
 				setMessage(type='info',messageArray=arguments.messageArray);
 			}
@@ -169,7 +169,7 @@ Description :
 			var newMessage = "";
 
 			// Do we have a message?
-			if( isEmpty() ){
+			if( isEmptyMessage() ){
 				// Set default message
 				setMessage(type='info',messageArray=arguments.messageArray);
 			}
@@ -210,7 +210,7 @@ Description :
 	</cffunction>
 
 	<!--- Is Empty --->
-	<cffunction name="isEmpty" access="public" hint="Checks wether the MessageBox is empty or not." returntype="boolean" output="false">
+	<cffunction name="isEmptyMessage" access="public" hint="Checks wether the MessageBox is empty or not." returntype="boolean" output="false">
 		<cfscript>
 			var msgStruct = getMessage();
 


### PR DESCRIPTION
Railo has implemented isEmpty() in release 4.1 therefore does coldbox overwrite the function here which leads to incompatibilities.

Fixed through isEmptyMessage()
