### PR TITLE
Modules can override flashRAM settings

### DIFF
--- a/system/web/services/LoaderService.cfc
+++ b/system/web/services/LoaderService.cfc
@@ -119,6 +119,10 @@ Modification History:
 		var javaLoader 			= "";
 		var validationManager 	= "";
 		var validationData 		= controller.getSetting("validation");
+		var services 			= controller.getServices();
+		
+		// create the flash RAM
+		services.RequestService.setFlashScope();
 
 		// if engine allows it, create validation engine
 		if( controller.getCFMLEngine().isValidationSupported() ){

--- a/system/web/services/RequestService.cfc
+++ b/system/web/services/RequestService.cfc
@@ -33,40 +33,6 @@ Modification History:
 	
 	<cffunction name="onConfigurationLoad" access="public" output="false" returntype="void">
 		<cfscript>
-			// Let's determine the flash type and create our flash ram object
-			var flashData = controller.getSetting("flash");
-			var flashPath = "";
-			
-			// Shorthand Flash Types
-			switch(flashData.scope){
-				case "session" : {
-					flashpath = "coldbox.system.web.flash.SessionFlash";
-					break;
-				}
-				case "client" : {
-					flashpath = "coldbox.system.web.flash.ClientFlash";
-					break;
-				}
-				case "cluster" : {
-					flashpath = "coldbox.system.web.flash.ClusterFlash";
-					break;
-				}
-				case "cache" : {
-					flashpath = "coldbox.system.web.flash.ColdboxCacheFlash";
-					break;
-				}
-				case "mock" : {
-					flashpath = "coldbox.system.web.flash.MockFlash";
-					break;
-				}
-				default : { 
-					flashPath = flashData.scope;
-				}
-			}
-			
-			// Create Flash RAM object
-			instance.flashScope = createObject("component", flashPath).init( controller, flashData );
-			
 			// Request Context Decorator?
 			if ( controller.settingExists( "RequestContextDecorator" ) and len( controller.getSetting( "RequestContextDecorator" ) ) ){
 				instance.decorator = controller.getSetting("RequestContextDecorator");
@@ -233,6 +199,45 @@ Modification History:
 			return structKeyExists(request,"cb_requestContext");
 		</cfscript>
 	</cffunction>
+	
+	<!--- createFlashScope --->
+	<cffunction name="setFlashScope" output="false" access="public" returntype="void" hint="create the Flash Ram Scope of base type:coldbox.system.web.flash.AbstractFlashScope">
+		<cfscript>
+			// Let's determine the flash type and create our flash ram object
+			var flashData = controller.getSetting("flash");
+			var flashPath = "";
+			
+			// Shorthand Flash Types
+			switch(flashData.scope){
+				case "session" : {
+					flashpath = "coldbox.system.web.flash.SessionFlash";
+					break;
+				}
+				case "client" : {
+					flashpath = "coldbox.system.web.flash.ClientFlash";
+					break;
+				}
+				case "cluster" : {
+					flashpath = "coldbox.system.web.flash.ClusterFlash";
+					break;
+				}
+				case "cache" : {
+					flashpath = "coldbox.system.web.flash.ColdboxCacheFlash";
+					break;
+				}
+				case "mock" : {
+					flashpath = "coldbox.system.web.flash.MockFlash";
+					break;
+				}
+				default : { 
+					flashPath = flashData.scope;
+				}
+			}
+
+			// Create Flash RAM object
+			instance.flashScope = createObject("component", flashPath).init( controller, flashData );			
+		</cfscript>
+    </cffunction>
 	
 	<!--- getFlashScope --->
     <cffunction name="getFlashScope" output="false" access="public" returntype="any" hint="Get the current running Flash Ram Scope of base type:coldbox.system.web.flash.AbstractFlashScope">


### PR DESCRIPTION
Delay the creation of the flash scope until the LoaderService.registerAspects is called.
This way modules can alter the flash configuration struct first.
