### PR TITLE
Added LF to tagcontext exceptions to make it UNIX friendly.

### DIFF
--- a/system/web/context/ExceptionBean.cfc
+++ b/system/web/context/ExceptionBean.cfc
@@ -155,7 +155,7 @@ Modification History:
 		<cfset var tagContextLength = ArrayLen(arrayTagContext)>
 		<cfif structkeyExists(instance.exceptionStruct, "TagContext") and tagContextLength>
 			<cfloop from="1" to="#tagContextLength#" index="i">
-			  <cfsavecontent variable="entry"><cfoutput>ID: <cfif not structKeyExists(arrayTagContext[i], "ID")>N/A<cfelse>#arrayTagContext[i].ID#</cfif>; LINE: #arrayTagContext[i].LINE#; TEMPLATE: #arrayTagContext[i].Template# #chr(13)#</cfoutput></cfsavecontent>
+			  <cfsavecontent variable="entry"><cfoutput>ID: <cfif not structKeyExists(arrayTagContext[i], "ID")>N/A<cfelse>#arrayTagContext[i].ID#</cfif>; LINE: #arrayTagContext[i].LINE#; TEMPLATE: #arrayTagContext[i].Template# #chr(13)##chr(10)#</cfoutput></cfsavecontent>
 			  <cfset rtnString = rtnString & entry>
 			</cfloop>
 			<cfreturn rtnString>


### PR DESCRIPTION
Made error-output behave better on UNIX devices. Right now you _have_ to use "sed -e 's/^M/\r\n/g'" to get readable outputs. That's not necessary with this change. 
