### PR TITLE
assertIsArray, assertIsArray, assertIsTypeOf backwards compat.

### DIFF
--- a/system/testing/mxunit/framework/TestCase.cfc
+++ b/system/testing/mxunit/framework/TestCase.cfc
@@ -137,4 +137,11 @@ component extends="coldbox.system.testing.BaseSpec"{
 		this.$assert.typeOf( "struct", arguments.actual, arguments.message );
 	}
 
+	/**
+	* Assert something is of a certrain object type
+	*/
+	function assertIsTypeOf( required actual, required typeName, message="" ){
+		this.$assert.instanceOf( arguments.actual, arguments.typeName, arguments.message );
+	}
+
 }


### PR DESCRIPTION
assertIsArray, assertIsArray, assertIsTypeOf backwards compat.

assertIsTypeOf uses isIntanceOf for now.  This might not work in every case as the old MXUnit one searched the inheritance tree, but gives us a start.
