### PR TITLE
$reset() bug fixed: counter and logs are cleared rather than replaced

### DIFF
--- a/system/testing/MockBox.cfc
+++ b/system/testing/MockBox.cfc
@@ -381,8 +381,11 @@ Description		:
 	<!--- $reset --->
     <cffunction name="$reset" output="false" access="public" returntype="any" hint="Reset all mock counters and logs on the targeted mock. Injected as $reset">
     	<cfscript>
-    		this._mockMethodCallCounters = structnew();
-			this._mockCallLoggers 		 = structnew();
+    		for(var item in this._mockMethodCallCounters)
+			{
+				this._mockMethodCallCounters[item]	= 0;
+				this._mockCallLoggers[item]			= arrayNew(1);
+			}
 			return this;
 		</cfscript>
     </cffunction>


### PR DESCRIPTION
$reset() bug fixed: counter and logs are cleared rather than replaced. This addresses the issue logged at https://github.com/ColdBox/coldbox-platform/issues/163.
