### PR TITLE
Preserve the method signature of a mocked method.  

### DIFF
--- a/system/testing/MockBox.cfc
+++ b/system/testing/MockBox.cfc
@@ -292,6 +292,7 @@ Description		:
 		<cfargument name="method" 	type="string" 	required="true" hint="The method you want to mock or spy on"/>
 		<cfargument name="returns" 	type="any" 		required="false" hint="The results it must return, if not passed it returns void or you will have to do the mockResults() chain"/>
 		<cfargument name="preserveReturnType" type="boolean" required="true" default="true" hint="If false, the mock will make the returntype of the method equal to ANY"/>
+		<cfargument name="preserveMethodSignature" type="boolean" required="true" default="true" hint="If false, the mock will remove all method parameters."/>
 		<cfargument name="throwException" type="boolean" required="false" default="false" hint="If you want the method call to throw an exception"/>
 		<cfargument name="throwType" 	  type="string"  required="false" default="" hint="The type of the exception to throw"/>
 		<cfargument name="throwDetail" 	  type="string"  required="false" default="" hint="The detail of the exception to throw"/>


### PR DESCRIPTION
The new functionality is to allow one to optionally preserve the method signature of a mocked method.  

E.g., you are testing a method that has a call to a mocked method, but the call to the mocked method does not satisfy the mocked method's signature (the required params and their corresponding type).  With my changes it will now throw your standard 'x parameter is required but not passed in' error.

// Here is an example of how you would mock your method to ensure any calls to the mocked method still abide by the method signature's contract.
myComponent.$( method = "someFunction", preserveMethodSignature=true ).$results( true );

// And here is how you would override the mocked method's signature (I.e., the way MockBox works now.)
myComponent.$( method = "someFunction", preserveMethodSignature=false ).$results( true );

I have preserveMethodSignature defaulted to true (in MockBox.cfc), so you could leave it off entirely in the first example above.
