### PR TITLE
allow for a "useSSL" property that is environment-based

### DIFF
--- a/system/interceptors/Security.cfc
+++ b/system/interceptors/Security.cfc
@@ -47,7 +47,11 @@ For the latest usage, please visit the wiki.
 			if( not propertyExists("preEventSecurity") or not isBoolean(getProperty("preEventSecurity")) ){
 				setProperty("preEventSecurity",false);
 			}
-						
+			// Use SSL property: Defaults to FALSE
+			if( not propertyExists('useSSL') or not isBoolean(getProperty('useSSL')) ){
+				setProperty('useSSL',false);
+			}
+			
 			// Now Call sourcesCheck
 			rulesSourceChecks();
 			
@@ -189,7 +193,7 @@ For the latest usage, please visit the wiki.
 			var rules 		= getProperty('rules');
 			var rulesLen 	= arrayLen(rules);
 			var rc 		 	= event.getCollection();
-			var ssl		 	= false;
+			var ssl		 	= getProperty('useSSL');
 			var matchType   = "event";
 			var matchTarget = "";
 			


### PR DESCRIPTION
useSSL is an option for securityrules.xml.cfm for individual rules. This commit allows the useSSL flag to be set by the interceptor configuration, which can be set per environment.
