### PR TITLE
Fixed debugmode=false bug

### DIFF
--- a/system/web/services/DebuggerService.cfc
+++ b/system/web/services/DebuggerService.cfc
@@ -176,7 +176,7 @@ Description :
 			<cfcookie name="#getCookieName()#" value="#getSecretKey()#">
 		<!--- False --->
 		<cfelse>
-			<cfcookie name="#instance.cookieName#" value="_disabled_" expires="#now()#">
+			<cfcookie name="#getCookieName()#" value="_disabled_">
 		</cfif>
 	</cffunction>
 	


### PR DESCRIPTION
Need to leave cookie in place with _disabled_ value to prevent FW from reverting to debuMode setting
