### PR TITLE
WIREBOX-30 bytype namespace and improvements

### DIFF
--- a/system/ioc/Builder.cfc
+++ b/system/ioc/Builder.cfc
@@ -338,6 +338,8 @@ TODO: update dsl consistency, so it is faster.
 				case "entityService"	 : { refLocal.dependency = getEntityServiceDSL(argumentCollection=arguments); break;}
 				// java class
 				case "java"				 : { refLocal.dependency = getJavaDSL(argumentCollection=arguments); break; }
+				// coldfusion type annotation
+				case "bytype"			 : { refLocal.dependency = getByTypeDSL(argumentCollection=arguments); break; }
 				
 				// No internal DSL's found, then check custom DSL's
 				default : {
@@ -347,7 +349,7 @@ TODO: update dsl consistency, so it is faster.
 					}
 					
 					// If no custom DSL's found, let's try to use the name as the empty namespace
-					if( NOT find( ":", arguments.definition.dsl ) ){
+					else if( NOT find( ":", arguments.definition.dsl ) ){
 						arguments.definition.dsl = "id:#arguments.definition.dsl#";
 						refLocal.dependency = getModelDSL(argumentCollection=arguments);
 					}
@@ -528,6 +530,20 @@ TODO: update dsl consistency, so it is faster.
 			
 			// Build provider and return it.
 			return createObject("component","coldbox.system.ioc.Provider").init( argumentCollection=args );
+		</cfscript>
+	</cffunction>
+
+	<!--- getByTypeDSL --->
+	<cffunction name="getByTypeDSL" access="private" returntype="any" hint="Get dependencies using the wirebox dependency DSL" output="false" >
+		<cfargument name="definition" 	required="true"  hint="The dependency definition structure">
+		<cfargument name="targetObject" required="false" hint="The target object we are building the DSL dependency for. If empty, means we are just requesting building"/>
+		
+		<cfscript>
+			var injectType 			=  arguments.definition.type;
+			
+			if (structKeyExists(arguments.definition,"type") && instance.injector.containsInstance(injectType) ){
+				return instance.injector.getInstance(injectType);
+			}
 		</cfscript>
 	</cffunction>
 	

--- a/system/ioc/config/Mapping.cfc
+++ b/system/ioc/config/Mapping.cfc
@@ -1,4 +1,4 @@
-﻿<!-----------------------------------------------------------------------
+﻿﻿<!-----------------------------------------------------------------------
 ********************************************************************************
 Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
 www.coldbox.org | www.luismajano.com | www.ortussolutions.com
@@ -371,6 +371,7 @@ Description :
 		<cfargument name="value" 	required="false" hint="The explicit value of the constructor argument, if passed."/>
     	<cfargument name="javaCast" required="false" hint="The type of javaCast() to use on the value of the argument. Only used if using dsl or ref arguments"/>
     	<cfargument name="required" required="false" default="true" hint="If the argument is required or not, by default we assume required DI arguments."/>
+		<cfargument name="type"		required="false" default="any" hint="The type of the argument."/>
 		<cfscript>
     		var def = getDIDefinition();
 			var x   = 1;
@@ -395,6 +396,7 @@ Description :
 		<cfargument name="value" 	required="false" hint="The explicit value of the method argument, if passed."/>
     	<cfargument name="javaCast" required="false" hint="The type of javaCast() to use on the value of the argument. Only used if using dsl or ref arguments"/>
     	<cfargument name="required" required="false" default="true" hint="If the argument is required or not, by default we assume required DI arguments."/>
+    	<cfargument name="type"		required="false" default="any" hint="The type of the argument."/>
 		<cfscript>
     		var def = getDIDefinition();
 			var x	= 1;
@@ -428,6 +430,7 @@ Description :
     	<cfargument name="javaCast" required="false" hint="The type of javaCast() to use on the value of the property. Only used if using dsl or ref arguments"/>
     	<cfargument name="scope" 	required="false" default="variables" hint="The scope in the CFC to inject the property to. By default it will inject it to the variables scope"/>
     	<cfargument name="required" required="false" default="true" hint="If the property is required or not, by default we assume required DI properties."/>
+		<cfargument name="type"		required="false" default="any" hint="The type of the property."/>
 		<cfscript>
     		var def = getDIDefinition();
 			var x	= 1;
@@ -797,7 +800,7 @@ Description :
 					if( structKeyExists(md.properties[x],"inject") ){
 						// prepare default params, we do this so we do not alter the md as it is cached by cf
 						params = {
-							scope="variables", inject="model", name=md.properties[x].name, required=true
+							scope="variables", inject="model", name=md.properties[x].name, required=true, type=md.properties[x].type
 						};
 						// default injection scope, if not found in object
 						if( structKeyExists(md.properties[x],"scope") ){
@@ -812,7 +815,7 @@ Description :
 							params.required = md.properties[ x ].required;
 						}
 						// Add to property to mappings
-						addDIProperty( name=params.name, dsl=params.inject, scope=params.scope, required=params.required );
+						addDIProperty( name=params.name, dsl=params.inject, scope=params.scope, required=params.required, type=params.type );
 					}
 
 				}
@@ -834,17 +837,16 @@ Description :
 						// Loop Over Arguments to process them for dependencies
 						for(y=1;y lte arrayLen(md.functions[x].parameters); y++){
 
-							// prepare params as we do not alter md as cf caches it
-							params = {
-								required = false, inject="model",name=md.functions[x].parameters[y].name
-							};
-
-							// Check required annotation
-							if( structKeyExists(md.functions[x].parameters[y], "required") ){
-								params.required = md.functions[x].parameters[y].required;
-							}
 							// Check injection annotation, if not found then no injection
 							if( structKeyExists(md.functions[x].parameters[y],"inject") ){
+								// prepare params as we do not alter md as cf caches it
+								params = {
+									required = false, inject="model",name=md.functions[x].parameters[y].name,type=md.functions[x].parameters[y].type
+								};
+								// Check required annotation
+								if( structKeyExists(md.functions[x].parameters[y], "required") ){
+									params.required = md.functions[x].parameters[y].required;
+								}
 
 								// Check if inject has value, else default it to 'model' or 'id' namespace
 								if( len(md.functions[x].parameters[y].inject) ){
@@ -854,7 +856,8 @@ Description :
 								// ADD Constructor argument
 								addDIConstructorArgument(name=params.name,
 														 dsl=params.inject,
-														 required=params.required);
+														 required=params.required,
+														 type=params.type);
 							}
 
 						}


### PR DESCRIPTION
- Fixes bug where inject annotation containing a custom DSL with no
  colons is superseded by the internal model DSL.
- Adds the bytype DSL, which allows the developer to inject based on the
  type annotation instead of the name - this includes modifications to Mapping to make it pass the type annotation from arguments and properties into the DI definition.
