### PR TITLE
Update MessageBox.cfc

### DIFF
--- a/system/plugins/MessageBox.cfc
+++ b/system/plugins/MessageBox.cfc
@@ -68,7 +68,7 @@ Description :
 	</cffunction>
 
 	<!--- warn --->
-	<cffunction name="warn" output="false" access="public" returntype="void" hint="Facade to setmessage with warning type">
+	<cffunction name="warning" output="false" access="public" returntype="void" hint="Facade to setmessage with warning type">
 		<!--- ************************************************************* --->
 		<cfargument name="message"  	required="false"  type="string" default="" hint="The message to show.">
 		<cfargument name="messageArray" required="false"  type="Array"  hint="You can also send in an array of messages to render separated by a <br />">


### PR DESCRIPTION
Going by this page: http://wiki.coldbox.org/wiki/Plugins:MessageBox.cfm

The function to set a message with "warning" type behaves a bit different than the other 2. You can set a "warning" type msg like this:
`getPlugin("MessageBox").setMessage( "warning", "This is a warning message" );`
OR
`getPlugin("MessageBox").warn( "This is a warning message" );`

To make them consistent with the other 2, i propose to have the same facade:
`getPlugin("MessageBox").warning( "This is a warning message" );`
