### PR TITLE
Update RequestService.cfc

### DIFF
--- a/system/web/services/RequestService.cfc
+++ b/system/web/services/RequestService.cfc
@@ -158,8 +158,16 @@ Modification History:
 	<!--- Get the context --->
 	<cffunction name="getContext" access="public" output="false" returntype="any" hint="Get the Request context from request scope or create a new one.">
 		<cfscript>
-			if ( structKeyExists(request,"cb_requestContext") ){ return request.cb_requestContext; }
-			return createContext();
+			var oContext = '';
+			if ( structKeyExists(request,"cb_requestContext") )		oContext =  request.cb_requestContext; 
+			else 								oContext = createContext();
+
+			if ( !isNull(thread) ) {
+				if ( !structKeyExists(request, thread.name) ) 		request[thread.name] = duplicate( oContext );
+				oContext = request[thread.name];
+			}
+
+			return oContext;
 		</cfscript>
 	</cffunction>
 


### PR DESCRIPTION
Since runevent is not threadsafe because of the shared usage of the requestcontext. This approach offers each thread an individual scope where threads can run events without taking care of interference in the whole process.