### PR TITLE
binder.mapDirectory now skips hidden dirs

### DIFF
--- a/system/ioc/config/Binder.cfc
+++ b/system/ioc/config/Binder.cfc
@@ -281,6 +281,11 @@ Description :
 
 		<!--- Loop and Register --->
 		<cfloop query="qObjects">
+			<!--- Skip hidden dirs (like .Appledouble) --->
+			<cfif left(qObjects.name,1) eq ".">
+				<cfcontinue />
+			</cfif>
+
 			<!--- Remove .cfc and /\ with . notation--->
 			<cfset thisTargetPath = arguments.packagePath & "." & reReplace( replaceNoCase(qObjects.name,".cfc","") ,"(/|\\)",".","all")>
 


### PR DESCRIPTION
We have an ubuntu (14.04) development server, and connect with AFP (mac osx), can't get rid of the .AppleDouble hidden directories that make wirebox crash.
