### PR TITLE
Update DBAppender.cfc

### DIFF
--- a/system/logging/appenders/DBAppender.cfc
+++ b/system/logging/appenders/DBAppender.cfc
@@ -142,7 +142,7 @@ If you are building a mapper, the map must have the above keys in it.
 			INSERT INTO #getTable()# (#cols#) VALUES (
 				<cfqueryparam cfsqltype="cf_sql_varchar" value="#instance.uuid.randomUUID().toString()#">,
 				<cfqueryparam cfsqltype="cf_sql_varchar" value="#severityToString(loge.getseverity())#">,
-				<cfqueryparam cfsqltype="cf_sql_varchar" value="#category#">,
+				<cfqueryparam cfsqltype="cf_sql_varchar" value="#left(category,100)#">,
 				<cfqueryparam cfsqltype="cf_sql_timestamp" value="#loge.getTimestamp()#">,
 				<cfqueryparam cfsqltype="cf_sql_varchar" value="#left(getName(),100)#">,
 				<cfqueryparam cfsqltype="cf_sql_varchar" value="#loge.getMessage()#">,


### PR DESCRIPTION
Use the left function around the category value for the insert statement on line 145 (similar to the appendername on line 147).  The category length is 100 in the database but depending on what is passed in for category, there is a potential to be longer than 100 and cause an insert error.
