### PR TITLE
Update RequestContext.cfc

### DIFF
--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -1,4 +1,4 @@
-﻿<!-----------------------------------------------------------------------
+<!-----------------------------------------------------------------------
 ********************************************************************************
 Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
 www.coldbox.org | www.luismajano.com | www.ortussolutions.com
@@ -17,17 +17,20 @@ Description :
 	<cffunction name="init" access="public" output="false" hint="constructor" returntype="RequestContext">
 		<cfargument name="properties" type="any" required="true" hint="The context properties struct">
 		<cfargument name="controller"  type="any" required="true" hint="The ColdBox Controller">
-		
+
 		<cfscript>
 			instance = structnew();
-			
+
 			// Store controller;
 			instance.controller = arguments.controller;
-			
+
 			// Create the Collections
 			instance.context		= structnew();
 			instance.privateContext = structnew();
+			instance.threadContext	= structNew();
 
+			// flag if using requestcontext per thread
+			instance.threadDuplication = controller.getSetting( name="RequestContextThreadDuplication", defaultValue=false );
 			// flag if using SES
 			instance.isSES 				= false;
 			// routed SES structures
@@ -80,6 +83,11 @@ Description :
 		<cfscript>
 			// Private Collection
 			if( arguments.private ){
+				if ( !isNull(thread) &&  instance.threadDuplication ) {
+					if ( !structKeyExists(instance.threadContext, thread.name) ) { instance.threadContext[thread.name] = {}; }
+					return instance.threadContext[thread.name];
+				}
+
 				if( arguments.deepCopyFlag ){ return duplicate(instance.privateContext); }
 				return instance.privateContext;
 			}
@@ -92,7 +100,13 @@ Description :
 	<cffunction name="clearCollection" access="public" returntype="any" output="false" hint="Clears the entire collection">
 		<cfargument name="private" type="boolean" required="false" default="false" hint="Use public or private request collection"/>
 		<cfscript>
-			if( arguments.private ) { structClear(instance.privateContext); }
+			if( arguments.private ) {
+				if ( !isNull(thread) &&  instance.threadDuplication ) {
+					if ( !structKeyExists(instance.threadContext, thread.name) ) { instance.threadContext[thread.name] = {}; }
+					return this;
+				}
+				else { structClear(instance.privateContext); }
+			}
 			else { structClear(instance.context); }
 			return this;
 		</cfscript>
@@ -103,7 +117,14 @@ Description :
 		<cfargument name="overwrite"  	type="boolean" 	required="false" default="false" hint="If you need to override data in the collection, set this to true.">
 		<cfargument name="private" 		type="boolean" 	required="false" default="false" hint="Use public or private request collection"/>
 		<cfscript>
-			if( arguments.private ) { structAppend(instance.privateContext,arguments.collection, arguments.overwrite); }
+			if( arguments.private ) {
+				if ( !isNull(thread) &&  instance.threadDuplication ) {
+					if ( !structKeyExists(instance.threadContext, thread.name) ) { structAppend(instance.threadContext[thread.name],arguments.collection, arguments.overwrite); }
+					return this;
+				}
+
+				structAppend(instance.privateContext,arguments.collection, arguments.overwrite);
+			}
 			else { structAppend(instance.context,arguments.collection, arguments.overwrite); }
 			return this;
 		</cfscript>
@@ -112,7 +133,11 @@ Description :
 	<cffunction name="getSize" access="public" returntype="numeric" output="false" hint="Returns the number of elements in the collection">
 		<cfargument name="private" type="boolean" required="false" default="false" hint="Use public or private request collection"/>
 		<cfscript>
-			if( arguments.private ){ return structCount(instance.privateContext); }
+			if( arguments.private ){
+				if ( !isNull(thread) && instance.threadDuplication ) {
+					if ( !structKeyExists(instance.threadContext, thread.name) ) { return structCount(instance.threadContext[thread.name]); }
+				}
+				return structCount(instance.privateContext); }
 			return structCount(instance.context);
 		</cfscript>
 	</cffunction>
@@ -125,7 +150,12 @@ Description :
 			var collection = instance.context;
 
 			// private context switch
-			if( arguments.private ){ collection = instance.privateContext; }
+			if( arguments.private ){
+				if ( !isNull(thread) && instance.threadDuplication ) {
+					if ( !structKeyExists(instance.threadContext, thread.name) ) 	{ collection = instance.threadContext[thread.name]; }
+				}
+				else { collection = instance.privateContext; }
+			}
 
 			// Check if key exists
 			if( structKeyExists(collection, arguments.name) ){
@@ -137,7 +167,7 @@ Description :
 				return arguments.defaultValue;
 			}
 
-			$throw("The variable: #arguments.name# is undefined in the request collection (private=#arguments.private#)",
+			throw("The variable: #arguments.name# is undefined in the request collection (private=#arguments.private#)",
 				   "Keys Found: #structKeyList(collection)#",
 				   "RequestContext.ValueNotFound");
 		</cfscript>
@@ -163,7 +193,12 @@ Description :
 		<cfargument name="private" 	type="boolean" 	required="false" default="false" hint="Use public or private request collection"/>
 		<cfscript>
 			var collection = instance.context;
-			if( arguments.private ) { collection = instance.privateContext; }
+			if( arguments.private ){
+				if ( !isNull(thread) && instance.threadDuplication ) {
+					if ( !structKeyExists(instance.threadContext, thread.name) ) { collection = instance.threadContext[thread.name]; }
+				}
+				else { collection = instance.privateContext; }
+			}
 
 			collection[arguments.name] = arguments.value;
 			return this;
@@ -175,7 +210,12 @@ Description :
 		<cfargument name="private" 	type="boolean" 	required="false" default="false" hint="Use public or private request collection"/>
 		<cfscript>
 			var collection = instance.context;
-			if( arguments.private ){ collection = instance.privateContext; }
+			if( arguments.private ){
+				if ( !isNull(thread) && instance.threadDuplication ) {
+					if ( !structKeyExists(instance.threadContext, thread.name) ) { collection = instance.threadContext[thread.name]; }
+				}
+				else { collection = instance.privateContext; }
+			}
 
 			structDelete(collection,arguments.name);
 
@@ -188,7 +228,12 @@ Description :
 		<cfargument name="private" 	type="boolean" 	required="false" default="false" hint="Use public or private request collection"/>
 		<cfscript>
 			var collection = instance.context;
-			if( arguments.private ){ collection = instance.privateContext; }
+			if( arguments.private ){
+				if ( !isNull(thread) && instance.threadDuplication ) {
+					if ( !structKeyExists(instance.threadContext, thread.name) ) { collection = instance.threadContext[thread.name]; }
+				}
+				else { collection = instance.privateContext; }
+			}
 			return structKeyExists(collection, arguments.name);
 		</cfscript>
 	</cffunction>
@@ -328,7 +373,7 @@ Description :
 	<cffunction name="getCurrentRoutedURL" output="false" access="public" returntype="any" hint="Get the current routed URL that matched the SES route">
     	<cfreturn getValue("currentRoutedURL","",true)>
     </cffunction>
-    
+
     <cffunction name="getCurrentRoutedNamespace" output="false" access="public" returntype="any" hint="Get the current routed namespace that matched the SES route, if any">
     	<cfreturn getValue("currentRoutedNamespace","",true)>
     </cffunction>
@@ -464,7 +509,7 @@ Description :
 		<!--- ************************************************************* --->
 		<cfargument name="linkto" 		required="true" 	type="string"  hint="The event or route you want to create the link to">
 	    <cfargument name="translate"  	required="false" 	type="boolean" default="true" hint="Translate between . and / depending on the ses mode. So you can just use dot notation."/>
-	    <cfargument name="ssl" 			required="false"    type="boolean" default="false" hint="If true, it will change http to https if found in the ses base url."/>
+	    <cfargument name="ssl" 			required="false"    type="boolean" hint="If true, uses SSL, else builds without SSL"/>
 	    <cfargument name="baseURL" 		required="false" 	type="string"  default="" hint="If not using SES, you can use this argument to create your own base url apart from the default of index.cfm. Example: https://mysample.com/index.cfm"/>
 	    <cfargument name="queryString"  required="false" 	type="string"  default="" hint="The query string to append, if needed.">
 		<!--- ************************************************************* --->
@@ -478,9 +523,13 @@ Description :
 		}
 
 		if( isSES() ){
-			/* SSL */
-			if( arguments.ssl OR isSSL() ){
+			/* SSL ON OR TURN IT ON */
+			if( isSSL() OR ( structKeyExists( arguments, "ssl" ) and arguments.ssl ) ){
 				sesBaseURL = replacenocase(sesBaseURL,"http:","https:");
+			}
+			// SSL Turn Off
+			if( structKeyExists( arguments, "ssl" ) and arguments.ssl eq false ){
+				sesBaseURL = replacenocase(sesBaseURL,"https:","http:");
 			}
 			/* Translate link */
 			if( arguments.translate ){
@@ -639,7 +688,7 @@ Description :
 		return this;
 		</cfscript>
 	</cffunction>
-	
+
 	<cffunction name="renderData" access="public" returntype="any" hint="Use this method to tell the framework to render data for you. The framework will take care of marshalling the data for you" output="false" >
 		<!--- ************************************************************* --->
 		<cfargument name="type" 		required="false"  type="string" default="HTML" hint="The type of data to render. Valid types are JSON, JSONP, JSONT, XML, WDDX, PLAIN/HTML, TEXT, PDF. The deafult is HTML or PLAIN. If an invalid type is sent in, this method will throw an error">
@@ -666,7 +715,7 @@ Description :
 		<cfargument name="isBinary" 		type="boolean" 	required="false" default="false" hint="Bit that determines if the data being set for rendering is binary or not."/>
 		<cfscript>
 			var rd = structnew();
-			
+
 			// With Formats?
 			if( isArray( arguments.formats ) OR len( arguments.formats ) ){
 				return renderWithFormats( argumentCollection=arguments );
@@ -674,7 +723,7 @@ Description :
 
 			// Validate rendering type
 			if( not reFindnocase("^(JSON|JSONP|JSONT|WDDX|XML|PLAIN|HTML|TEXT|PDF)$",arguments.type) ){
-				$throw("Invalid rendering type","The type you sent #arguments.type# is not a valid rendering type. Valid types are JSON,JSONP,JSONT,XML,WDDX,TEXT,PLAIN,PDF","RequestContext.InvalidRenderTypeException");
+				throw("Invalid rendering type","The type you sent #arguments.type# is not a valid rendering type. Valid types are JSON,JSONP,JSONT,XML,WDDX,TEXT,PLAIN,PDF","RequestContext.InvalidRenderTypeException");
 			}
 
 			// Default Values for incoming variables
@@ -761,7 +810,7 @@ Description :
 			if( structKeyExists(arguments,"default") ){
 				return arguments.default;
 			}
-			$throw(message="Header #arguments.header# not found in HTTP headers",detail="Headers found: #structKeyList(headers)#",type="RequestContext.InvalidHTTPHeader");
+			throw(message="Header #arguments.header# not found in HTTP headers",detail="Headers found: #structKeyList(headers)#",type="RequestContext.InvalidHTTPHeader");
 		</cfscript>
 	</cffunction>
 
@@ -834,12 +883,12 @@ Description :
     </cffunction>
 
 <!------------------------------------------- PRIVATE ------------------------------------------->
-	
-		<!--- renderWithFormats --->    
-    <cffunction name="renderWithFormats" output="false" access="private" returntype="any" hint="Render With Formats">    
-    	<cfscript>	    
+
+		<!--- renderWithFormats --->
+    <cffunction name="renderWithFormats" output="false" access="private" returntype="any" hint="Render With Formats">
+    	<cfscript>
 			var viewToRender = "";
-			
+
 			// inflate list to array if found
 			if( isSimpleValue( arguments.formats ) ){ arguments.formats = listToArray( arguments.formats ); }
 			// param incoming rc.format to "html"
@@ -864,23 +913,23 @@ Description :
 					}
 					case "pdf" : {
 						arguments.type = "pdf";
-						arguments.data = instance.controller.getPlugin("Renderer").renderView( view=viewToRender);
+						arguments.data = instance.controller.getRenderer().renderView( view=viewToRender);
 						return renderData( argumentCollection=arguments );
 					}
 					case "html" : case "plain" : {
 						return setView( view=viewToRender);
 					}
 				}
-			}					
+			}
 			else{
-				throw(message="The incoming format #instance.context.format# is not a valid registered format", 
-						  detail="Valid incoming formats are #arguments.formats.toString()#", 
+				throw(message="The incoming format #instance.context.format# is not a valid registered format",
+						  detail="Valid incoming formats are #arguments.formats.toString()#",
 						  type="RequestContext.InvalidFormat");
 			}
-    	</cfscript>    
+    	</cfscript>
     </cffunction>
 
-	<cffunction name="$throw" access="private" hint="Facade for cfthrow" output="false">
+	<cffunction name="throw" access="private" hint="Facade for cfthrow" output="false">
 		<cfargument name="message" 	type="string" 	required="yes">
 		<cfargument name="detail" 	type="string" 	required="no" default="">
 		<cfargument name="type"  	type="string" 	required="no" default="Framework">


### PR DESCRIPTION
Make the Private RequestContext ThreadSafe if desired. Just switch the setting: requestContextThreadDuplication  to true and runEvent can call multiple handlers without interference of prc data. 

It does only happen in threads anyway, so dont't be scared for the main thread's prc.
