### PR TITLE
Bug report enhancements

### DIFF
--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -535,8 +535,9 @@ component serializable="false" accessors="true"{
 		for( var aString in aMatches ){
 			arguments.str = replacenocase( arguments.str, aString, "<span class='method'>#aString#</span>", "all" );
 		}
-		arguments.str = replaceNoCase( arguments.str, chr(13), "<br>", "all" );
-		arguments.str = replaceNoCase( arguments.str, chr(10), "<br>", "all" );
+		arguments.str = replace( arguments.str, chr( 13 ) & chr( 10 ), chr( 13 ) , 'all' );
+		arguments.str = replace( arguments.str, chr( 10 ), chr( 13 ) , 'all' );
+		arguments.str = replace( arguments.str, chr( 13 ), '<br>' , 'all' );
 		arguments.str = replaceNoCase( arguments.str, chr(9), repeatString( "&nbsp;", 4 ), "all" );
 		return arguments.str;
 	}

--- a/system/includes/BugReport-Public.cfm
+++ b/system/includes/BugReport-Public.cfm
@@ -34,7 +34,7 @@ A public error template that just shows that an exception ocurred.
 	</div>
 
 	<div style="margin:10px; color:gray">
-		<em>* The full robust errors can be seen by switching the error template in your configuration file (ColdBox.cfc).</em>
+		<em>* The full robust errors can be seen by switching the <strong>coldbox.customErrorTemplate</strong> in your configuration file (/config/ColdBox.cfc) to "/coldbox/system/includes/BugReport.cfm" and reloading the application.</em>
 	</div>
 </div>
 </cfoutput>

--- a/system/includes/BugReport.cfm
+++ b/system/includes/BugReport.cfm
@@ -70,22 +70,32 @@ A reporting template about exceptions in your ColdBox Apps
 	<div class="extended">
 		<!--- TAG CONTEXT --->
 		<h2>Tag Context:</h2>
-		<table class="table" align="center">
+		<table class="table" align="center" cellspacing="0">
 		<cfif ArrayLen( oException.getTagContext() )>
 			  <cfset arrayTagContext = oException.getTagContext()>
 			  <cfloop from="1" to="#arrayLen(arrayTagContext)#" index="i">
+				  <!--- Don't clutter the screen with this information unless it's actually useful --->
+			  	  <cfif structKeyExists( arrayTagContext[i], "ID" ) and len( arrayTagContext[i].ID ) and arrayTagContext[i].ID neq "??">
 			  <tr >
-				<td align="right" class="info">ID:</td>
-			    <td ><cfif not structKeyExists(arrayTagContext[i], "ID")>??<cfelse>#arrayTagContext[i].ID#</cfif></td>
+						<td align="right" class="info">Tag:</td>
+					    <td>#arrayTagContext[i].ID#</td>
 			  </tr>
+				  </cfif>
 			   <tr >
+					<td align="right" class="info">Template:</td>
+				    <td style="color:green;"><strong>#arrayTagContext[i].Template#</strong></td>
+				   </tr>
+			  	  <cfif structKeyExists( arrayTagContext[i], "codePrintHTML" )>
+					  <tr class="tablebreak">
 				<td align="right" class="info">LINE:</td>
-			    <td ><strong>#arrayTagContext[i].LINE#</strong></td>
+					    <td>#arrayTagContext[i].codePrintHTML#</td>
 			   </tr>
+				  <cfelse>
 			   <tr class="tablebreak">
-				<td align="right" class="info">Template:</td>
-			    <td style="color:green;"><strong>#arrayTagContext[i].Template#</strong></td>
+						<td align="right" class="info">Line:</td>
+					    <td ><strong>#arrayTagContext[i].LINE#</strong></td>
 			   </tr>
+				  </cfif>
 			  </cfloop>
 		</cfif>
 		</table>

--- a/system/includes/css/cbox-debugger.css.cfm
+++ b/system/includes/css/cbox-debugger.css.cfm
@@ -46,7 +46,7 @@ body{ margin: 0px; }
 .cb-container table td{
 	background-color: #ffffff;
 	border: 1px dotted #eaeaea;
-	padding: 10px
+	padding: 5px
 }
 .cb-container table td.info{
 	background-color: #f5f5f5;


### PR DESCRIPTION
- Stacktrace was getting double line breaks on Window since it uses CR and LF
- Enhanced instructions on public bug template
- Reduced ridiculously large  table padding that was making tag context take up large amounts of space on the screen
- Only show the ID if it is present, and call it what it actually is: "tag"
- Railo supports enhanced line numbers that actually show code where error occured.  Show this instead of just the line number if it is available.
