### PR TITLE
MixerUtil.cfc - Moving declaration of method variable

### DIFF
--- a/system/core/dynamic/MixerUtil.cfc
+++ b/system/core/dynamic/MixerUtil.cfc
@@ -104,6 +104,7 @@ Description :
 	<!--- methodProxy --->
 	<cffunction name="methodProxy" access="public" hint="a method proxy" returntype="any" output="false">
 		<cfscript>
+			var method = 0;
 			var methodName = getFunctionCalledName();
 
 			if( !structKeyExists( this.$exposedMethods, methodName ) ){
@@ -112,7 +113,7 @@ Description :
 					   type="ExposedMethodProxy" );
 			}
 
-			var method = this.$exposedMethods[ methodName ];
+			method = this.$exposedMethods[ methodName ];
 			return method( argumentCollection=arguments );
 		</cfscript>
 	</cffunction>


### PR DESCRIPTION
Older versions of Coldfusion require that all variable declarations be grouped at the top of functions.  This adjustment fixes error "Local variable method on line 115 must be grouped at the top of the function body."
