### PR TITLE
Update Bootstrap.cfc

### DIFF
--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -406,7 +406,7 @@ component serializable="false" accessors="true"{
 
 		if( not isSimpleValue( cbController ) ){
 			// Get Context
-			var event = cbController.getContext();
+			var event = cbController.getRequestService().getContext();
 
 			// Execute interceptors
 			var iData = {


### PR DESCRIPTION
onSessionEnd was throwing "component [coldbox.system.web.Controller] has no  function with name [getContext]" on line 409 of Bootstrap.cfc
You can see where this changed wasn't properly migrated here: https://github.com/sigmaprojects/coldbox-platform/commit/f0d0c06978c13d6898f25beb7867e4b4ba9d565f#diff-72f7f16b3388b51a9c08275aaab3e078L436
This should fix it.
