### PR TITLE
Explicit Module view rendering

### DIFF
--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -146,7 +146,8 @@ component accessors="true" serializable="false" extends="coldbox.system.Framewor
 		numeric collectionStartRow="1",
 		numeric collectionMaxRows=0,
 		collectionDelim="",
-		boolean prePostExempt=false
+		boolean prePostExempt=false,
+		boolean renderExplicitModuleView=true
 	){
 		var viewCacheKey 		= "";
 		var viewCacheEntry 		= "";
@@ -165,7 +166,7 @@ component accessors="true" serializable="false" extends="coldbox.system.Framewor
 				arguments.module = event.getCurrentModule();
 			}
 		} else {
-			explicitModule = true;
+			explicitModule = arguments.renderExplicitModuleView;
 		}
 
 		// Rendering an explicit view or do we need to get the view from the context or explicit context?

--- a/system/web/services/HandlerService.cfc
+++ b/system/web/services/HandlerService.cfc
@@ -261,6 +261,28 @@ Description :
 		// Verify if this is a module call
 		if( find(":", arguments.event) ){
 			moduleReceived = listFirst(arguments.event,":");
+
+			// Add module handler over-rides
+      ParentHandlerReceived = "modules.#moduleReceived#.#HandlerReceived#";
+      customHandlerIndex = listFindNoCase(handlersList, ParentHandlerReceived);
+
+      // Check for conventions location
+      if ( customHandlerIndex ){
+        return HandlerBean
+          .setHandler(listgetAt(handlersList,customHandlerIndex))
+          .setMethod(MethodReceived);
+      }
+
+      // Check for external location
+      customHandlerExternalIndex = listFindNoCase(handlersExternalList, ParentHandlerReceived);
+      if( customHandlerExternalIndex ){
+        return HandlerBean
+          .setInvocationPath(instance.handlersExternalLocation)
+          .setHandler(listgetAt(handlersExternalList,customHandlerExternalIndex))
+          .setMethod(MethodReceived);
+      }
+      // End CUSTOM
+
 			// Does this module exist?
 			if( structKeyExists(moduleSettings,moduleReceived) ){
 				// Verify handler in module handlers


### PR DESCRIPTION
I think I should be able to render a module view, and for it to use my conventions and not always be explicit. If I do renderView(view="myView",module="myModule") then it *always* takes the view from my external views location - this is never desired behavior for me - so I've added in here an option to override this for my use case and possibly others. 