### PR TITLE
WIREBOX-45 Update the documentation URL in box.json

### DIFF
--- a/box-wirebox-cachebox.json
+++ b/box-wirebox-cachebox.json
@@ -7,7 +7,7 @@
 	"packageDirectory"	: "wirebox",
 	"keywords"			: "di,aop,dependeny injection,ioc,caching",
 	"homepage"			: "http://www.coldbox.org",
-	"documentation"		: "http://wiki.coldbox.org",
+	"documentation"		: "http://wirebox.ortusbooks.com",
 	"repository"		: { "type" : "git", "url" : "https://github.com/coldbox/coldbox-platform" },
 	"bugs"				: "https://ortussolutions.atlassian.net/browse/WIREBOX",
 	"shortDescription"	: "AOP and Dependency Injection Framework with CacheBox Included",

--- a/box-wirebox.json
+++ b/box-wirebox.json
@@ -7,7 +7,7 @@
 	"packageDirectory"	: "wirebox",
 	"keywords"			: "di,aop,dependeny injection,ioc",
 	"homepage"			: "http://www.coldbox.org",
-	"documentation"		: "http://wiki.coldbox.org",
+	"documentation"		: "http://wirebox.ortusbooks.com",
 	"repository"		: { "type" : "git", "url" : "https://github.com/coldbox/coldbox-platform" },
 	"bugs"				: "https://ortussolutions.atlassian.net/browse/WIREBOX",
 	"shortDescription"	: "AOP and Dependency Injection Framework",


### PR DESCRIPTION
Just a super simple housekeeping PR to satisfy the requirements of https://ortussolutions.atlassian.net/browse/WIREBOX-45.

The document links are now up to date.