### PR TITLE
Fix parameters passed to AOP mixing exception

### DIFF
--- a/system/aop/Mixer.cfc
+++ b/system/aop/Mixer.cfc
@@ -293,7 +293,11 @@ Description :
 					instance.log.error("Exception mixing in AOP aspect for (#mappingName#): #e.message# #e.detail#", e);
 				}
 				// throw the exception
-				throw("Exception mixing in AOP aspect for (#mappingName#)",e.message & e.detail & e.stacktrace,"WireBox.aop.Mixer.MixinException");
+				throw(
+                    message = "Exception mixing in AOP aspect for (#mappingName#)",
+                    type = "WireBox.aop.Mixer.MixinException",
+                    detail = e.message & e.detail & e.stacktrace
+                );
 			}
     	</cfscript>
     </cffunction>


### PR DESCRIPTION
The parameters passed to the AOP mixing exception were in the wrong
order.  Use named parameters to fix this issue in the future.

I uncovered this because the error was hidden under `type` in TestBox.  It also made it very hard to read when the error occurred in ColdBox. (The error message caused the debug box to span on horizontally for what seemed like forever.)

(See http://dev.elpete.com/2015/11/13/reserved-words-in-aop-aspects/ for more details)