### PR TITLE
Global "/coldbox/system/modules" modules should be loaded before + COLDBOX-475

### DIFF
--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -305,16 +305,25 @@ component accessors="true" serializable="false" extends="coldbox.system.Framewor
 			variables._items = arguments.collectionMaxRows;
 		}
 
+		//local counter when using startrow is greater than one x values is reletive to lookup
+		var _localCounter = 1;
 		for( x=arguments.collectionStartRow; x lte ( arguments.collectionStartRow+variables._items )-1; x++){
 			// setup local cvariables
-			variables._counter  = arguments.collection.currentRow;
-			variables[ arguments.collectionAs ] = arguments.collection;
+			variables._counter  = _localCounter;
+
+			var columnList = arguments.collection.ColumnList;
+			for(var j=1; j <= ListLen(columnList); j++){
+				variables[ arguments.collectionAs ][ListGetAt(columnList,j)] = arguments.collection[ListGetAt(columnList,j)][x];
+			}
+			
 			// prepend the delim
 			if ( variables._counter NEQ 1 ) {
 				buffer.append( arguments.collectionDelim );
 			}
+			
 			// render item composite
 			buffer.append( renderViewComposite( arguments.view, arguments.viewPath, arguments.viewHelperPath, arguments.args) );
+			_localCounter++;
 		}
 
 		return buffer.toString();

--- a/system/web/context/ExceptionBean.cfc
+++ b/system/web/context/ExceptionBean.cfc
@@ -35,7 +35,7 @@ component accessors="true"{
 		any extraMessage = "",
 		any extraInfo = ""
 	){
-		variables.exceptionStruct = duplicate(arguments.errorStruct);
+		variables.exceptionStruct = arguments.errorStruct;
 		if( !isStruct( variables.exceptionStruct ) ){
 			variables.exceptionStruct = {};
 		}

--- a/system/web/context/ExceptionBean.cfc
+++ b/system/web/context/ExceptionBean.cfc
@@ -35,7 +35,7 @@ component accessors="true"{
 		any extraMessage = "",
 		any extraInfo = ""
 	){
-		variables.exceptionStruct = arguments.errorStruct;
+		variables.exceptionStruct = duplicate(arguments.errorStruct);
 		if( !isStruct( variables.exceptionStruct ) ){
 			variables.exceptionStruct = {};
 		}

--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -70,7 +70,7 @@ I oversee and manage ColdBox modules
 			// Add the application's external locations array.
 			modLocations.addAll( controller.getSetting( "ModulesExternalLocation" ) );
 			// Add the ColdBox Core Modules Location
-			arrayAppend( modLocations, "/coldbox/system/modules" );
+			arrayPrepend( modLocations, "/coldbox/system/modules" );
 			// iterate through locations and build the module registry in order
 			buildRegistry( modLocations );
 		</cfscript>


### PR DESCRIPTION
Global "/coldbox/system/modules" modules should be loaded before other modules, otherwise dependencies fails...

COLDBOX-475 https://ortussolutions.atlassian.net/browse/COLDBOX-475
Rendering query-based view collections and collection will treated as struct in view files.

```
return renderView(view="home/people", collection=prc.qry, collectionAs='people', collectionStartRow=2, collectionMaxRows=5);

<cfoutput>
<h1>Title: #people.Title# (#_counter# of #_items#)</h1>
<p>Author: #people.FirstName#</p>
</cfoutput>
```
'''