### PR TITLE
getFileInfo() requires "Absolute on-disk or in-memory path"

### DIFF
--- a/system/aop/Mixer.cfc
+++ b/system/aop/Mixer.cfc
@@ -76,7 +76,7 @@ component accessors="true"{
 
 		// Default Generation Path?
 		if( NOT structKeyExists( variables.properties, "generationPath" ) ){
-			variables.properties.generationPath = "/coldbox/system/aop/tmp";
+			variables.properties.generationPath = expandPath("/coldbox/system/aop/tmp");
 		}
 
 		// Check if we can write to generation path

--- a/system/aop/Mixer.cfc
+++ b/system/aop/Mixer.cfc
@@ -76,11 +76,11 @@ component accessors="true"{
 
 		// Default Generation Path?
 		if( NOT structKeyExists( variables.properties, "generationPath" ) ){
-			variables.properties.generationPath = expandPath("/coldbox/system/aop/tmp");
+			variables.properties.generationPath = "/coldbox/system/aop/tmp";
 		}
 
 		// Check if we can write to generation path
-		if( !getFileInfo( variables.properties.generationPath ).canWrite ){
+		if( !getFileInfo( expandPath(variables.properties.generationPath) ).canWrite ){
 			throw( message="The AOP generation directory: '#variables.properties.generationPath#' is not writable, cannot continue." );
 		}
 


### PR DESCRIPTION
`getFileInfo()` requires "Absolute on-disk or in-memory path". fixed for CF9+