### PR TITLE
Allow passing in of an object to use for the metadata inspection.

### DIFF
--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -40,8 +40,8 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 	* Inspect test case for annotations
 	* @return BaseTestCase
 	*/
-	function metadataInspection(){
-		var md = getMetadata( this );
+	function metadataInspection( metadataObj = this ){
+		var md = getMetadata( metadataObj );
 		// Inspect for appMapping annotation
 		if( structKeyExists( md, "appMapping" ) ){
 			variables.appMapping = md.appMapping;
@@ -68,12 +68,12 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 	/**
 	* The main setup method for running ColdBox Integration enabled tests
 	*/
-	function beforeTests(){
+	function beforeTests( metadataObj = this ){
 		var appRootPath = "";
 		var context		= "";
 
 		// metadataInspection
-		metadataInspection();
+		metadataInspection( metadataObj );
 
 		// Load ColdBox Application for testing?
 		if( this.loadColdbox ){
@@ -112,12 +112,12 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 	/**
 	* This executes before any test method for integration tests
 	*/
-	function setup(){
+	function setup( metadataObj = this ){
 		// Are we doing integration tests
 		if( this.loadColdbox ){
 			// verify ColdBox still exists, else load it again:
 			if( !structKeyExists( application, getColdboxAppKey() ) ){
-				beforeTests();
+				beforeTests( metadataObj );
 			} else {
 				variables.controller = application[ getColdBoxAppKey() ];
 			}
@@ -138,8 +138,8 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 	/**
 	* BDD: The main setup method for running ColdBox Integration enabled tests
 	*/
-	function beforeAll(){
-		beforeTests();
+	function beforeAll( metadataObj = this ){
+		beforeTests( metadataObj );
 	}
 
 	/**


### PR DESCRIPTION
This is related to our discussion on Slack.

I have a test component that is structured like so:

```cfc
component extends='Integrated.BaseSpecs.ColdBoxBaseSpec' appMapping='/quality' {

	function beforeAll() {
		super.beforeAll();
	}

	function afterAll(){
		// do your own stuff here
		super.afterAll();
	}
	
	function run() {
            // Run some tests....
        }
}
```

And the component it extends uses `BaseTestCase` like so:

```cfc
component extends='Integrated.BaseSpecs.AbstractBaseSpec' {

    property name="baseTestCase" type="coldbox.system.testing.BaseTestCase";

    function beforeAll() {
        super.beforeAll();

        variables.baseTestCase = new coldbox.system.testing.BaseTestCase();
        baseTestCase.beforeAll( this );
    }

    function afterAll() {
        super.afterAll();
    }

   // ...
}
```

I need to get the `appMapping` metadata property in to the `BaseTestCase`.  This pull requests allows an optional `metadataObj` to be passed in to the `beforeAll` and `setup` methods that would be used for metadata inspection instead of `this` (which is still default).