### PR TITLE
Elixir function for versioned assets

### DIFF
--- a/system/core/dynamic/HTMLHelper.cfc
+++ b/system/core/dynamic/HTMLHelper.cfc
@@ -1449,7 +1449,24 @@ Description :
 	</cffunction>
 
 	<!--- elixir --->
-	<cffunction name="elixir" output="false" access="public" returntype="string" hint="Finds the versioned path for an asset">
+	<cffunction name="elixir" output="false" access="public" returntype="void" hint="Adds the versioned path for an asset to the view">
+		<cfargument name="fileName" type="string" required="true" hint="The asset path to find relative to the includes convention directory"/>
+		<cfargument name="buildDirectory" type="string" required="false" default="build" hint="The build directory inside the includes convention directory"/>
+		<cfargument name="sendToHeader" type="boolean" required="false" default="true" hint="Send to the header via htmlhead by default, else it returns the content"/>
+		<cfargument name="async" type="boolean" required="false" default="false" hint="HTML5 JavaScript argument: Specifies that the script is executed asynchronously (only for external scripts)"/>
+		<cfargument name="defer" type="boolean" required="false" default="false" hint="HTML5 JavaScript argument: Specifies that the script is executed when the page has finished parsing (only for external scripts)"/>
+		<cfscript>
+			addAsset(
+				elixirPath( arguments.fileName, arguments.buildDirectory ),
+				arguments.sendToHeader,
+				arguments.async,
+				arguments.defer
+			);
+		</cfscript>
+	</cffunction>
+
+	<!--- elixirPath --->
+	<cffunction name="elixirPath" output="false" access="public" returntype="string" hint="Finds the versioned path for an asset">
 		<cfargument name="fileName" type="string" required="true" hint="The asset path to find relative to the includes convention directory"/>
 		<cfargument name="buildDirectory" type="string" required="false" default="build" hint="The build directory inside the includes convention directory"/>
 		<cfscript>

--- a/system/core/dynamic/HTMLHelper.cfc
+++ b/system/core/dynamic/HTMLHelper.cfc
@@ -1454,10 +1454,10 @@ Description :
 		<cfargument name="buildDirectory" type="string" required="false" default="build" hint="The build directory inside the includes convention directory"/>
 		<cfscript>
 			var includesConvention = controller.getSetting( "includesConvention", true );
-			var appMapping = controller.getSetting( "appMapping" );
-			var filePath = expandPath("#appMapping#/#includesConvention#/#arguments.buildDirectory#/rev-manifest.json");
+			var mapping = event.getCurrentModule() != "" ? event.getModuleRoot() : controller.getSetting( "appMapping" );
+			var filePath = expandPath("#mapping#/#includesConvention#/#arguments.buildDirectory#/rev-manifest.json");
 
-			var href = "#appMapping#/#includesConvention#/#arguments.fileName#";
+			var href = "#mapping#/#includesConvention#/#arguments.fileName#";
 			
 			if ( ! fileExists( filePath ) ) {
 				return href;
@@ -1473,7 +1473,7 @@ Description :
 				return href;
 			}
 
-			return "#appMapping#/#includesConvention#/#arguments.buildDirectory#/#json[ arguments.fileName ]#";
+			return "#mapping#/#includesConvention#/#arguments.buildDirectory#/#json[ arguments.fileName ]#";
 		</cfscript>
 	</cffunction>
 

--- a/system/core/dynamic/HTMLHelper.cfc
+++ b/system/core/dynamic/HTMLHelper.cfc
@@ -1470,11 +1470,11 @@ Description :
 		<cfargument name="fileName" type="string" required="true" hint="The asset path to find relative to the includes convention directory"/>
 		<cfargument name="buildDirectory" type="string" required="false" default="build" hint="The build directory inside the includes convention directory"/>
 		<cfscript>
-			var includesConvention = controller.getSetting( "includesConvention", true );
+			var includesLocation = controller.getSetting( "includesLocation", true );
 			var mapping = event.getCurrentModule() != "" ? event.getModuleRoot() : controller.getSetting( "appMapping" );
-			var filePath = expandPath("#mapping#/#includesConvention#/#arguments.buildDirectory#/rev-manifest.json");
+			var filePath = expandPath("#mapping#/#includesLocation#/#arguments.buildDirectory#/rev-manifest.json");
 
-			var href = "#mapping#/#includesConvention#/#arguments.fileName#";
+			var href = "#mapping#/#includesLocation#/#arguments.fileName#";
 			
 			if ( ! fileExists( filePath ) ) {
 				return href;
@@ -1490,7 +1490,7 @@ Description :
 				return href;
 			}
 
-			return "#mapping#/#includesConvention#/#arguments.buildDirectory#/#json[ arguments.fileName ]#";
+			return "#mapping#/#includesLocation#/#arguments.buildDirectory#/#json[ arguments.fileName ]#";
 		</cfscript>
 	</cffunction>
 

--- a/system/core/dynamic/HTMLHelper.cfc
+++ b/system/core/dynamic/HTMLHelper.cfc
@@ -1448,6 +1448,35 @@ Description :
 		</cfscript>
 	</cffunction>
 
+	<!--- elixir --->
+	<cffunction name="elixir" output="false" access="public" returntype="string" hint="Finds the versioned path for an asset">
+		<cfargument name="fileName" type="string" required="true" hint="The asset path to find relative to the includes convention directory"/>
+		<cfargument name="buildDirectory" type="string" required="false" default="build" hint="The build directory inside the includes convention directory"/>
+		<cfscript>
+			var includesConvention = controller.getSetting( "includesConvention", true );
+			var appMapping = controller.getSetting( "appMapping" );
+			var filePath = expandPath("#appMapping#/#includesConvention#/#arguments.buildDirectory#/rev-manifest.json");
+
+			var href = "#appMapping#/#includesConvention#/#arguments.fileName#";
+			
+			if ( ! fileExists( filePath ) ) {
+				return href;
+			}
+
+			var fileContents = fileRead( filePath );
+			if ( ! isJSON( fileContents ) ) {
+				return href;
+			}
+
+			var json = deserializeJSON( fileContents );
+			if ( ! structKeyExists( json, arguments.fileName ) ) {
+				return href;
+			}
+
+			return "#appMapping#/#includesConvention#/#arguments.buildDirectory#/#json[ arguments.fileName ]#";
+		</cfscript>
+	</cffunction>
+
 <!------------------------------------------- PRIVATE ------------------------------------------>
 
 	<!--- arrayToTable --->

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -694,6 +694,29 @@ component accessors="true" serializable="false" extends="coldbox.system.Framewor
 		return locateView(arguments.view);
 	}
 
+	public string function elixir( required string fileName, string buildDirectory = 'build' ) {
+		var includesConvention = controller.getSetting( "includesConvention", true );
+		var filePath = expandPath("#variables.appMapping#/#includesConvention#/#arguments.buildDirectory#/rev-manifest.json");
+
+		var href = "#variables.appMapping#/#includesConvention#/#arguments.fileName#";
+		
+		if ( ! fileExists( filePath ) ) {
+			return href;
+		}
+
+		var fileContents = fileRead( filePath );
+		if ( ! isJSON( fileContents ) ) {
+			return href;
+		}
+
+		var json = deserializeJSON( fileContents );
+		if ( ! structKeyExists( json, arguments.fileName ) ) {
+			return href;
+		}
+
+		return "#variables.appMapping#/#includesConvention#/#arguments.buildDirectory#/#json[ arguments.fileName ]#";
+	}
+
 	/************************************** PRIVATE *********************************************/
 
 	/**

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -694,29 +694,6 @@ component accessors="true" serializable="false" extends="coldbox.system.Framewor
 		return locateView(arguments.view);
 	}
 
-	public string function elixir( required string fileName, string buildDirectory = 'build' ) {
-		var includesConvention = controller.getSetting( "includesConvention", true );
-		var filePath = expandPath("#variables.appMapping#/#includesConvention#/#arguments.buildDirectory#/rev-manifest.json");
-
-		var href = "#variables.appMapping#/#includesConvention#/#arguments.fileName#";
-		
-		if ( ! fileExists( filePath ) ) {
-			return href;
-		}
-
-		var fileContents = fileRead( filePath );
-		if ( ! isJSON( fileContents ) ) {
-			return href;
-		}
-
-		var json = deserializeJSON( fileContents );
-		if ( ! structKeyExists( json, arguments.fileName ) ) {
-			return href;
-		}
-
-		return "#variables.appMapping#/#includesConvention#/#arguments.buildDirectory#/#json[ arguments.fileName ]#";
-	}
-
 	/************************************** PRIVATE *********************************************/
 
 	/**

--- a/system/web/config/ApplicationLoader.cfc
+++ b/system/web/config/ApplicationLoader.cfc
@@ -349,6 +349,7 @@ Loads a coldbox cfc configuration file
 			if( structKeyExists( conventions,"eventAction" ) ){ fwSettingsStruct[ "eventAction" ] = trim( conventions.eventAction); }
 			if( structKeyExists( conventions,"modelsLocation" ) ){ fwSettingsStruct[ "ModelsConvention" ] = trim( conventions.modelsLocation); }
 			if( structKeyExists( conventions,"modulesLocation" ) ){ fwSettingsStruct[ "ModulesConvention" ] = trim( conventions.modulesLocation); }
+			if( structKeyExists( conventions,"includesLocation" ) ){ fwSettingsStruct[ "IncludesConvention" ] = trim( conventions.includesLocation); }
 		</cfscript>
 	</cffunction>
 

--- a/system/web/config/Settings.cfc
+++ b/system/web/config/Settings.cfc
@@ -39,6 +39,7 @@ component{
 	this.modelsConvention	= "models";
 	this.configConvention	= "config.Coldbox";
 	this.modulesConvention	= "modules";
+	this.includesConvention = "includes";
 
 
 	function configure(){}

--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -248,7 +248,8 @@ I oversee and manage ColdBox modules
 						handlersLocation 	= "handlers",
 						layoutsLocation 	= "layouts",
 						viewsLocation 		= "views",
-						modelsLocation      = "models"
+						modelsLocation      = "models",
+						includesLocation    = "includes"
 					},
 					childModules			= [],
 					parent 					= arguments.parent


### PR DESCRIPTION
New elixir function that returns the versioned path for a file.

This allows us to cache bust and version using ColdBox Elixir.
```cfm
<script src="#elixir( 'js/all.js' )#"></script>
// =>
<script src="/includes/build/js/all-dd0e0acd94.js"></script>
```

If we can't find the versioned path, we return the normal convention path.
```cfm
<script src="#elixir( 'css/all.css' )#"></script>
// =>
<script src="/includes/css/all.css"></script>
```

The `appMapping` is also taken into account if there is one:
```cfm
// appMapping = "/testapp"
<script src="#elixir( 'js/all.js' )#"></script>
// =>
<script src="/testapp/includes/build/js/all-dd0e0acd94.js"></script>
```

---

This pull request also introduces a new configurable `includesLocation` option.

`includesConvention` can be overwritten in the ColdBox.cfc config file in the conventions struct along with the other ColdBox conventions by specifying an `includesLocation` key.

The only place using the `includesConvention` so far is this new function, but it is available any where using the standard `controller.getSetting( "includesConvention", true )` call.