### PR TITLE
Use the default event if the route passed in is the base route (`/`)

### DIFF
--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -340,6 +340,12 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
         }
 
         try{
+        	// If the route is for the home page, use the default event in the config/ColdBox.cfc
+        	if ( arguments.route == "/" ){
+        		arguments.event = getController().getSetting( "defaultEvent" );
+        		arguments.route = "";
+        	}
+
             // if we were passed a route, parse it and prepare the SES interceptor for routing.
             if ( arguments.route != "" ){
             	// enable the SES interceptor


### PR DESCRIPTION
This lets you test like so:

```cfc
var event = execute( route = "/", renderResults = true );
```

Which, by default, would execute `Main.index`.