### PR TITLE
Add app mapping to modules external location

### DIFF
--- a/system/interceptors/SES.cfc
+++ b/system/interceptors/SES.cfc
@@ -248,7 +248,14 @@ Description :
 					// prepare module pivot
 					instance.withModule = arguments.module;
 					// Include it via conventions using declared route
-					includeRoutes(location=mConfig[arguments.module].mapping & "/" & mConfig[arguments.module].routes[x]);
+
+					// add a slash to the beginning of the string if it doesn't already have one
+					var moduleMapping = mConfig[arguments.module].mapping;
+					if ( left( moduleMapping, 1 ) != "/" ) {
+						moduleMapping = "/" & moduleMapping;
+					}
+
+					includeRoutes(location=moduleMapping & "/" & mConfig[arguments.module].routes[x]);
 					// Remove pivot
 					instance.withModule = "";
 				}

--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -340,6 +340,12 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
         }
 
         try{
+        	// If the route is for the home page, use the default event in the config/ColdBox.cfc
+        	if ( arguments.route == "/" ){
+        		arguments.event = getController().getSetting( "defaultEvent" );
+        		arguments.route = "";
+        	}
+
             // if we were passed a route, parse it and prepare the SES interceptor for routing.
             if ( arguments.route != "" ){
             	// enable the SES interceptor

--- a/system/web/config/ApplicationLoader.cfc
+++ b/system/web/config/ApplicationLoader.cfc
@@ -389,6 +389,13 @@ Loads a coldbox cfc configuration file
 				configStruct[ "HandlersExternalLocationPath" ] = ExpandPath( "/" & replace( configStruct[ "HandlersExternalLocation" ],".","/","all" ));
 			}
 
+			// Append the app mapping to each ModulesExternalLocation
+			if( len( configStruct.AppMapping) ){
+				for ( var i = 1; i LTE arrayLen( configStruct.ModulesExternalLocation ); i++ ){
+					configStruct.ModulesExternalLocation[i] = "/#configStruct.AppMapping#/#configStruct.ModulesExternalLocation[i]#";
+				}
+			}
+
 			//Configure the modules locations for the conventions not the external ones.
 			if( len( configStruct.AppMapping) ){
 				configStruct.ModulesLocation 		= "/#configStruct.AppMapping#/#fwSettingsStruct.ModulesConvention#";

--- a/test-harness/modules/test-bundle/routestest/ModuleConfig.cfc
+++ b/test-harness/modules/test-bundle/routestest/ModuleConfig.cfc
@@ -1,0 +1,27 @@
+component{
+    
+    // Module Properties
+    this.title              = "My Test Module";
+    this.aliases            = "routestest";
+    this.author             = "Eric Peterson";
+    this.webURL             = "http://www.coldbox.org";
+    this.description        = "A routing test module";
+    this.version            = "1.0.0";
+    // If true, looks for views in the parent first, if not found, then in the module. Else vice-versa
+    this.viewParentLookup   = true;
+    // If true, looks for layouts in the parent first, if not found, then in module. Else vice-versa
+    this.layoutParentLookup = true;
+    this.entryPoint         = "routestest";
+    // CFML Mapping for this module, the path will be the module root. If empty, none is registered.
+    this.cfmapping          = "routestest";
+
+    function configure(){
+
+        // SES Routes
+        routes = [
+            "config/routes"
+        ];
+
+    }
+
+}

--- a/test-harness/modules/test-bundle/routestest/config/routes.cfm
+++ b/test-harness/modules/test-bundle/routestest/config/routes.cfm
@@ -1,0 +1,3 @@
+<cfscript>
+addRoute( pattern="/custom", handler="RoutesMain", action="index" );
+</cfscript>

--- a/test-harness/modules/test-bundle/routestest/handlers/RoutesMain.cfc
+++ b/test-harness/modules/test-bundle/routestest/handlers/RoutesMain.cfc
@@ -1,0 +1,7 @@
+component{
+
+    function index( event, rc, prc ){
+        event.setView( "RoutesMain/index" );
+    }
+
+}

--- a/test-harness/modules/test-bundle/routestest/views/RoutesMain/index.cfm
+++ b/test-harness/modules/test-bundle/routestest/views/RoutesMain/index.cfm
@@ -1,0 +1,3 @@
+<cfoutput>
+<h1>Welcome to my test routes file module</h1>
+</cfoutput>


### PR DESCRIPTION
I asked this question on Slack, so this might be an unneeded pull request, but here goes.

I was recently trying to use a module in my integration tests.  This usually works when extending `coldbox.system.testing.BaseTestCase`.  In this case, it wasn't.  After some debugging, I found that the module wasn't being loaded because it was in my `modules_app` folder which was loaded from the `ModulesExternalLocation` configuration option and did not have the test app mapping of `/root`.

If this is the desired behavior, this pull request isn't necessary, but maybe a documentation one is.  I have been using the `modules_app` folder as a sort of private modules directory.  ForgeBox and other public modules go in the `modules` directory and are ignored from source control and my private app modules go in the `modules_app` directory and are committed to source control.  I have even heard that approach talked about from Ortus people.

So, if `ModulesExternalLocation` is not supposed to have the `appMapping` appended to it, what is the recommended approach to loading all these modules up in a integration test environment?