### PR TITLE
Fixing response URL

### DIFF
--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -770,7 +770,7 @@ component serializable=false accessors="true"{
 	* Get the HTML base URL that is used for the HTML <base> tag. This also accounts for SSL or not.
 	*/
 	string function getHTMLBaseURL(){
-		return replacenocase( buildLink( linkTo='', ssl=isSSL() ), "index.cfm", "" );
+		return REReplaceNoCase( buildLink( linkTo='', ssl=isSSL() ), "index.cfm\/?", "" );
 	}
 
 	/**


### PR DESCRIPTION
In some situations the response from the `getHTMLBaseURL` is returns with a double slash at the end, e.g.:

`http://www.mydomain.com//`

instead of:

`http://www.mydomain.com/`

This change fixes that by changing the replace to a regex replace and adding an optional slash after `index.cfm`.