### PR TITLE
dot notation fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /settings.xml
 .project
+.settings/
 test-harness/logs/*.log
 test-harness/logs
 test-harness/test/logs

--- a/system/ioc/config/Binder.cfc
+++ b/system/ioc/config/Binder.cfc
@@ -293,7 +293,7 @@ Description :
  			</cfif>
 
 			<!--- Remove .cfc and /\ with . notation--->
-			<cfset thisTargetPath = arguments.packagePath & "." & reReplace( replaceNoCase( qObjects.name, ".cfc", ""), "(/|\\)", ".", "all")>
+			<cfset thisTargetPath = reReplace( arguments.packagePath & "." & replaceNoCase( qObjects.name, ".cfc", ""), "(/|\\)", ".", "all")>
 
 			<!--- Include/Exclude --->
 			<cfif ( len( arguments.include ) AND reFindNoCase( arguments.include, thisTargetPath ) )


### PR DESCRIPTION
This helps modules with multi-folder mapping (i.e. foo/bar). The Binder will now replace the folder / with a dot