### PR TITLE
Bubble up an invalid HTTP method

### DIFF
--- a/system/interceptors/SES.cfc
+++ b/system/interceptors/SES.cfc
@@ -139,10 +139,8 @@ Description :
 						}
 					}
 					else{
-						getUtil().throwInvalidHTTP(className="SES",
-												   detail="The HTTP method used: #HTTPMethod# is not valid for the current executing resource. Valid methods are: #aRoute.action.toString()#",
-										 		   statusText="Invalid HTTP method: #HTTPMethod#",
-										 		   statusCode="405");
+						// Bubble up the invalid to the controller
+						aRoute.action = "onInvalidHTTPMethod";
 					}
 				}
 				// Create routed event


### PR DESCRIPTION
Instead of throwing a 405 in the SES itself, why not let it bubble up to the function `onInvalidHTTPMethod` in a base Controller, which would allow you to specify a custom controller function to handle this in anyway you can?

For example in our REST API, we have that function in our base Controller:
```
function onInvalidHTTPMethod
( event, rc, prc, faultAction, eventArguments )
{
	// Setup Response
	prc.response = wirebox.getInstance( "beans.response@v1" )
		.setError( true )
		.setErrorCode( 405 )
		.setStatusCode( 405 )
		.setStatusText( "Method Not Allowed" )
		.setData( { "Message" = "The requested resource does not support the HTTP method '#event.getHTTPMethod()#'." } );
	// Render Error Out
	event.renderData
	(
		type		= prc.response.getFormat(),
		data 		= prc.response.getData(),
		contentType = prc.response.getContentType(),
		statusCode 	= prc.response.getStatusCode(),
		statusText 	= prc.response.getStatusText(),
		location 	= prc.response.getLocation(),
		isBinary 	= prc.response.getBinary()
	);
```