### PR TITLE
Parse parent settings by convention for modules

### DIFF
--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -228,6 +228,10 @@ I oversee and manage ColdBox modules
 					disabled			= false,
 					// flag that says if this module can be activated or not
 					activate			= true,
+					// flag that determines if the module settings overrides any
+					// module settings in the parent config (ColdBox.cfc) or
+					// if the parent settings get merged (and overwrite the defaults).
+					parseParentSettings = true,
 					// Module Configurations
 					path				 	= modLocation,
 					invocationPath 			= modulesInvocationPath & "." & modName,
@@ -700,11 +704,23 @@ I oversee and manage ColdBox modules
 			if( structKeyExists( oConfig,"activate" ) ){
 				mConfig.activate = oConfig.activate;
 			}
+			// Merge the settings with the parent module settings 
+			if( structKeyExists( oConfig, "parseParentSettings" ) ){
+				mConfig.parseParentSettings = oConfig.parseParentSettings;
+			}
 
 			//Get the parent settings
 			mConfig.parentSettings = oConfig.getPropertyMixin( "parentSettings", "variables", {} );
 			//Get the module settings
 			mConfig.settings = oConfig.getPropertyMixin( "settings", "variables", {} );
+			// Add the module settings to the parent settings under the modules namespace
+			if ( mConfig.parseParentSettings ) {
+				// Merge the parent module settings into module settings
+				var coldboxConfigModuleSettings = controller.getSetting( "ColdBoxConfig" )
+					.getPropertyMixin( mConfig.modelNamespace, "variables", structnew() );
+				structAppend( mConfig.settings, coldboxConfigModuleSettings, true );
+			}
+			appSettings[ mConfig.modelNamespace ] = mConfig.settings;
 			//Get module datasources
 			mConfig.datasources = oConfig.getPropertyMixin( "datasources", "variables", {} );
 			//Get Interceptors

--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -716,9 +716,16 @@ I oversee and manage ColdBox modules
 			// Add the module settings to the parent settings under the modules namespace
 			if ( mConfig.parseParentSettings ) {
 				// Merge the parent module settings into module settings
-				var coldboxConfigModuleSettings = controller.getSetting( "ColdBoxConfig" )
-					.getPropertyMixin( mConfig.modelNamespace, "variables", structnew() );
-				structAppend( mConfig.settings, coldboxConfigModuleSettings, true );
+				var parentModuleSettings = controller.getSetting( "ColdBoxConfig" )
+					.getPropertyMixin( "moduleSettings", "variables", structnew() );
+				if ( ! structKeyExists( parentModuleSettings, mConfig.modelNamespace ) ) {
+					parentModuleSettings[ mConfig.modelNamespace ] = {};
+				}
+				structAppend(
+					mConfig.settings,
+					parentModuleSettings[ mConfig.modelNamespace ],
+					true
+				);
 			}
 			appSettings[ mConfig.modelNamespace ] = mConfig.settings;
 			//Get module datasources


### PR DESCRIPTION
By convention, look for a struct in the `config/ColdBox.cfc` parent configuration's `moduleSettings` struct matching the module's namespace.
If it is found and the `this.parseParentSettings` flag is `true` (default), then merge the parent config struct in to the module settings struct.
Then set the new module settings struct as the settings in the parent configuration.
Otherwise, the module settings override any settings in the `config/ColdBox.cfc`

Examples:

```cfc
// ModuleConfig.cfc
component {
    this.modelNamespace = "cbsvg"; // defaults to module name
    this.parseParentSettings = true; // default value

    function configure() {
        settings = {
            inline = false
            class = "icon"
        };
    }
}

// config/ColdBox.cfc
component {
    function configure() {
        moduleSettings = {
            cbsvg = {
                inline = true
            }
        };
    }
}

// Merged settings in both
cbsvg = {
    inline = true,
    class = "icon"
};
```

```cfc
// ModuleConfig.cfc
component {
    this.modelNamespace = "cbsvg"; // defaults to module name
    this.parseParentSettings = false;

    function configure() {
        settings = {
            inline = false
            class = "icon"
        };
    }
}

// config/ColdBox.cfc
component {
    function configure() {
        moduleSettings = {
            cbsvg = {
                inline = true
            }
        };
    }
}

// Merged settings in both
cbsvg = {
    inline = false,
    class = "icon"
};
```

These settings can be accessed either through the module settings or the ColdBox settings:
```cfc
// Inject all module settings
property name="settings" inject="coldbox:modulesettings:{module}";
// Inject all module settings from the app settings
property name="settings" inject="coldbox:setting:{module}";
// Inject a single module setting
property name="customSetting" inject="coldbox:setting:customSetting@{module}";
```