### PR TITLE
Add support for wrapperAttrs, labelWrapperAttrs, and groupWrapperAttr…

### DIFF
--- a/system/core/dynamic/HTMLHelper.cfc
+++ b/system/core/dynamic/HTMLHelper.cfc
@@ -658,13 +658,14 @@ Description :
 		<cfargument name="field" 		type="string" required="true"	hint="The for who attribute"/>
 		<cfargument name="content" 		type="string" required="false" default="" hint="The label content. If not passed the field is used"/>
 		<cfargument name="wrapper" 		type="string" required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct" required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="data"			type="struct" required="false" default="#structNew()#"	hint="A structure that will add data-{key} elements to the HTML control"/>
 		<cfargument name="class"		type="string" required="false" default="" hint="The class to be applied to the label">
 		<cfscript>
 			var buffer = createObject("java","java.lang.StringBuilder").init('');
 
 			// wrapper?
-			wrapTag(buffer,arguments.wrapper);
+			wrapTag(buffer,arguments.wrapper,0,arguments.wrapperAttrs);
 
 			// get content
 			if( NOT len(content) ){ arguments.content = makePretty(arguments.field); }
@@ -690,9 +691,12 @@ Description :
 		<cfargument name="disabled" 	type="boolean" 	required="false" default="false" hint="Disabled"/>
 		<cfargument name="readonly" 	type="boolean" 	required="false" default="false" hint="Readonly"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct" required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfargument name="bind" 		type="any" 		required="false" default="" hint="The entity binded to this control, the value comes by convention from the name attribute"/>
 		<cfargument name="bindProperty" type="any" 		required="false" default="" hint="The property to use for the value, by convention we use the name attribute"/>
@@ -703,12 +707,12 @@ Description :
 			// ID Normalization
 			normalizeID(arguments);
 			// group wrapper?
-			wrapTag(buffer,arguments.groupWrapper);
+			wrapTag(buffer,arguments.groupWrapper,0,arguments.groupWrapperAttrs);
 			// label?
-			if( len(arguments.label) ){ buffer.append( this.label(field=arguments.id,content=arguments.label,wrapper=arguments.labelWrapper,class=arguments.labelClass) ); }
+			if( len(arguments.label) ){ buffer.append( this.label(field=arguments.id,content=arguments.label,wrapper=arguments.labelWrapper,wrapperAttrs=arguments.labelWrapperAttrs,class=arguments.labelClass) ); }
 
 			//wrapper?
-			wrapTag(buffer,arguments.wrapper);
+			wrapTag(buffer,arguments.wrapper,0,arguments.wrapperAttrs);
 
 			// disabled fix
 			if( arguments.disabled ){ arguments.disabled = "disabled"; }
@@ -739,9 +743,12 @@ Description :
 		<cfargument name="disabled" 	type="boolean" 	required="false" default="false" hint="Disabled"/>
 		<cfargument name="readonly" 	type="boolean" 	required="false" default="false" hint="Readonly"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct"	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfargument name="bind" 		type="any" 		required="false" default="" hint="The entity binded to this control"/>
 		<cfargument name="bindProperty" type="any" 		required="false" default="" hint="The property to use for the value, by convention we use the name attribute"/>
@@ -758,9 +765,12 @@ Description :
 		<cfargument name="disabled" 	type="boolean" 	required="false" default="false" hint="Disabled"/>
 		<cfargument name="readonly" 	type="boolean" 	required="false" default="false" hint="Readonly"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct"	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfargument name="bind" 		type="any" 		required="false" default="" hint="The entity binded to this control"/>
 		<cfargument name="bindProperty" type="any" 		required="false" default="" hint="The property to use for the value, by convention we use the name attribute"/>
@@ -777,9 +787,12 @@ Description :
 		<cfargument name="disabled" 	type="boolean" 	required="false" default="false" hint="Disabled"/>
 		<cfargument name="readonly" 	type="boolean" 	required="false" default="false" hint="Readonly"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct"	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfargument name="bind" 		type="any" 		required="false" default="" hint="The entity binded to this control"/>
 		<cfargument name="bindProperty" type="any" 		required="false" default="" hint="The property to use for the value, by convention we use the name attribute"/>
@@ -794,9 +807,12 @@ Description :
 		<cfargument name="name" 		type="string" 	required="false" default="" hint="The name of the field"/>
 		<cfargument name="value" 		type="string"	required="false" default="" hint="The value of the field"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct"	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfargument name="bind" 		type="any" 		required="false" default="" hint="The entity binded to this control"/>
 		<cfargument name="bindProperty" type="any" 		required="false" default="" hint="The property to use for the value, by convention we use the name attribute"/>
@@ -813,9 +829,12 @@ Description :
 		<cfargument name="disabled" 	type="boolean" 	required="false" default="false" hint="Disabled"/>
 		<cfargument name="readonly" 	type="boolean" 	required="false" default="false" hint="Readonly"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct" 	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfargument name="bind" 		type="any" 		required="false" default="" hint="The entity binded to this control"/>
 		<cfargument name="bindProperty" type="any" 		required="false" default="" hint="The property to use for the value, by convention we use the name attribute"/>
@@ -830,11 +849,14 @@ Description :
 		<cfargument name="name" 		type="string" 	required="false" default="" hint="The name of the field"/>
 		<cfargument name="value" 		type="string"	required="false" default="" hint="The value of the field"/>
 		<cfargument name="disabled" 	type="boolean" 	required="false" default="false" hint="Disabled button or not?"/>
-		<cfargument name="type" 		type="string"	 required="false" default="button" hint="The type of button to create: button, reset or submit"/>
+		<cfargument name="type" 		type="string"	required="false" default="button" hint="The type of button to create: button, reset or submit"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct"	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="data"			type="struct" required="false" default="#structNew()#"	hint="A structure that will add data-{key} elements to the HTML control"/>
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfscript>
@@ -843,12 +865,12 @@ Description :
 			// ID Normalization
 			normalizeID(arguments);
 			// group wrapper?
-			wrapTag(buffer,arguments.groupWrapper);
+			wrapTag(buffer,arguments.groupWrapper,0,arguments.groupWrapperAttrs);
 			// label?
-			if( len(arguments.label) ){ buffer.append( this.label(field=arguments.id,content=arguments.label,wrapper=arguments.labelWrapper,class=arguments.labelClass) ); }
+			if( len(arguments.label) ){ buffer.append( this.label(field=arguments.id,content=arguments.label,wrapper=arguments.labelWrapper,wrapperAttrs=arguments.labelWrapperAttrs,class=arguments.labelClass) ); }
 
 			//wrapper?
-			wrapTag(buffer,arguments.wrapper);
+			wrapTag(buffer,arguments.wrapper,0,arguments.wrapperAttrs);
 
 			// disabled fix
 			if( arguments.disabled ){ arguments.disabled = "disabled"; }
@@ -873,9 +895,12 @@ Description :
 		<cfargument name="disabled" 	type="boolean" 	required="false" default="false" hint="Disabled"/>
 		<cfargument name="readonly" 	type="boolean" 	required="false" default="false" hint="Readonly"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct" 	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfscript>
 			arguments.type="file";
@@ -890,9 +915,12 @@ Description :
 		<cfargument name="disabled" 	type="boolean" 	required="false" default="false" hint="Disabled"/>
 		<cfargument name="checked" 		type="boolean" 	required="false" default="false" hint="Checked"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct" 	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfargument name="bind" 		type="any" 		required="false" default="" hint="The entity binded to this control"/>
 		<cfargument name="bindProperty" type="any" 		required="false" default="" hint="The property to use for the value, by convention we use the name attribute"/>
@@ -909,9 +937,12 @@ Description :
 		<cfargument name="disabled" 	type="boolean" 	required="false" default="false" hint="Disabled"/>
 		<cfargument name="checked" 		type="boolean" 	required="false" default="false" hint="Checked"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct" 	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfargument name="bind" 		type="any" 		required="false" default="" hint="The entity binded to this control"/>
 		<cfargument name="bindProperty" type="any" 		required="false" default="" hint="The property to use for the value, by convention we use the name attribute"/>
@@ -927,9 +958,12 @@ Description :
 		<cfargument name="value" 		type="string"	required="false" default="Submit" hint="The value of the field"/>
 		<cfargument name="disabled" 	type="boolean" 	required="false" default="false" hint="Disabled"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct" 	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfscript>
 			arguments.type="submit";
@@ -943,9 +977,12 @@ Description :
 		<cfargument name="value" 		type="string"	required="false" default="Reset" hint="The value of the field"/>
 		<cfargument name="disabled" 	type="boolean" 	required="false" default="false" hint="Disabled"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct" 	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfscript>
 			arguments.type="reset";
@@ -959,9 +996,12 @@ Description :
 		<cfargument name="name" 		type="string" 	required="false" default=""	hint="The name of the field"/>
 		<cfargument name="disabled" 	type="boolean" 	required="false" default="false" hint="Disabled"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct" 	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfscript>
 			arguments.type="image";
@@ -1080,9 +1120,12 @@ Description :
 		<cfargument name="disabled" 	type="boolean" 	required="false" default="false" hint="Disabled button or not?"/>
 		<cfargument name="multiple" 	type="boolean" 	required="false" default="false" hint="multiple button or not?"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct" 	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="data"			type="struct" required="false" default="#structNew()#"	hint="A structure that will add data-{key} elements to the HTML control"/>
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 
@@ -1092,12 +1135,12 @@ Description :
 			// ID Normalization
 			normalizeID(arguments);
 			// group wrapper?
-			wrapTag(buffer,arguments.groupWrapper);
+			wrapTag(buffer,arguments.groupWrapper,0,arguments.groupWrapperAttrs);
 			// label?
-			if( len(arguments.label) ){ buffer.append( this.label(field=arguments.id,content=arguments.label,wrapper=arguments.labelWrapper,class=arguments.labelClass) ); }
+			if( len(arguments.label) ){ buffer.append( this.label(field=arguments.id,content=arguments.label,wrapper=arguments.labelWrapper,wrapperAttrs=arguments.labelWrapperAttrs,class=arguments.labelClass) ); }
 
 			//wrapper?
-			wrapTag(buffer,arguments.wrapper);
+			wrapTag(buffer,arguments.wrapper,0,arguments.wrapperAttrs);
 
 			// disabled fix
 			if( arguments.disabled ){ arguments.disabled = "disabled"; }
@@ -1145,9 +1188,12 @@ Description :
 		<cfargument name="checked" 		type="boolean" 	required="false" default="false" hint="Checked"/>
 		<cfargument name="readonly" 	type="boolean" 	required="false" default="false" hint="Readonly"/>
 		<cfargument name="wrapper" 		type="string" 	required="false" default="" hint="The wrapper tag to use around the tag. Empty by default">
+		<cfargument name="wrapperAttrs"	type="struct" 	required="false" default="#structNew()#" hint="Attributes to add to the wrapper tag. Empty by default">
 		<cfargument name="groupWrapper" type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="label" 		type="string"	required="false" default="" hint="If Passed we will prepend a label tag"/>
 		<cfargument name="labelwrapper" type="string"	required="false" default="" hint="The wrapper tag to use around the label. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 	type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfargument name="bind" 		type="any" 		required="false" default="" hint="The entity binded to this control"/>
 		<cfargument name="bindProperty" type="any" 		required="false" default="" hint="The property to use for the value, by convention we use the name attribute"/>
@@ -1159,11 +1205,11 @@ Description :
 			// ID Normalization
 			normalizeID( arguments );
 			// group wrapper?
-			wrapTag( buffer, arguments.groupWrapper );
+			wrapTag( buffer, arguments.groupWrapper, 0, arguments.groupWrapperAttrs );
 			// label?
-			if( len( arguments.label ) ){ buffer.append( this.label( field=arguments.id, content=arguments.label, wrapper=arguments.labelWrapper, class=arguments.labelClass ) ); }
+			if( len( arguments.label ) ){ buffer.append( this.label( field=arguments.id, content=arguments.label, wrapper=arguments.labelWrapper, wrapperAttrs=arguments.labelWrapperAttrs, class=arguments.labelClass ) ); }
 			//wrapper?
-			wrapTag( buffer, arguments.wrapper );
+			wrapTag( buffer, arguments.wrapper, 0, arguments.wrapperAttrs );
 
 			// disabled fix
 			if( arguments.disabled ){ arguments.disabled = "disabled"; }
@@ -1195,8 +1241,11 @@ Description :
 	<cffunction name="entityFields" output="false" access="public" returntype="any" hint="Create fields based on entity properties">
 		<cfargument name="entity" 			type="any" 		required="true" hint="The entity binded to this control"/>
 		<cfargument name="groupWrapper" 	type="string" 	required="false" default="" hint="The wrapper tag to use around the tag and label. Empty by default">
+		<cfargument name="groupWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the group wrapper tag. Empty by default">
 		<cfargument name="fieldwrapper" 	type="any"		required="false" default="" hint="The wrapper tag to use around the field items. Empty by default"/>
+		<cfargument name="fieldWrapperAttrs"	type="struct" 	required="false" default="#structNew()#" hint="Attributes to add to the field wrapper tag. Empty by default">
 		<cfargument name="labelwrapper" 	type="any"		required="false" default="" hint="The wrapper tag to use around the label items. Empty by default"/>
+		<cfargument name="labelWrapperAttrs" type="struct" required="false" default="#structNew()#" hint="Attributes to add to the label wrapper tag. Empty by default">
 		<cfargument name="labelClass" 		type="string"	required="false" default="" hint="The class to be applied to the label"/>
 		<cfargument name="textareas" 		type="any"		required="false" default="" hint="A list of property names that you want as textareas"/>
 		<cfargument name="booleanSelect" 	type="boolean" 	required="false" default="true" hint="If a boolean is detected a dropdown is generated, if false, then radio buttons"/>
@@ -1303,8 +1352,8 @@ Description :
 						// generation args
 						args = {
 							name=prop.name, options=entityLoad( prop.cfc, loc.criteria, loc.sortorder ), column=loc.column, nameColumn=loc.nameColumn,
-							multiple=true, label=prop.name, labelwrapper=arguments.labelWrapper, labelClass=arguments.labelClass, wrapper=arguments.fieldwrapper,
-							groupWrapper=arguments.groupWrapper, selectedValue=arrayToList( loc.values )
+							multiple=true, label=prop.name, labelwrapper=arguments.labelWrapper, labelWrapperAttrs=arguments.labelWrapperAttrs, labelClass=arguments.labelClass, wrapper=arguments.fieldwrapper, wrapperAttrs=arguments.fieldWrapperAttrs,
+							groupWrapper=arguments.groupWrapper, groupWrapper=arguments.groupWrapperAttrs, selectedValue=arrayToList( loc.values )
 						};
 						structAppend(args,arguments);
 						buffer.append( this.select(argumentCollection=args) );
@@ -1410,8 +1459,8 @@ Description :
 						args = {
 							name=prop.name, options=entityLoad( prop.cfc, loc.criteria, loc.sortorder ),
 							column=loc.column, nameColumn=loc.nameColumn,
-							label=prop.name, bind=arguments.entity, labelwrapper=arguments.labelWrapper, labelClass=arguments.labelClass,
-							wrapper=arguments.fieldwrapper, groupWrapper=arguments.groupWrapper
+							label=prop.name, bind=arguments.entity, labelwrapper=arguments.labelWrapper, labelWrapperAttrs=arguments.labelWrapperAttrs, labelClass=arguments.labelClass,
+							wrapper=arguments.fieldwrapper, wrapperAttrs=arguments.fieldWrapperAttrs, groupWrapper=arguments.groupWrapper, groupWrapperAttrs=arguments.groupWrapperAttrs
 						};
 						structAppend(args,arguments);
 						buffer.append( this.select(argumentCollection=args) );
@@ -1425,16 +1474,16 @@ Description :
 							// boolean select or radio buttons
 							if( arguments.booleanSelect ){
 								args = {
-									name=prop.name, options=[true,false], label=prop.name, bind=arguments.entity, labelwrapper=arguments.labelWrapper, labelClass=arguments.labelClass,
-									wrapper=arguments.fieldwrapper, groupWrapper=arguments.groupWrapper
+									name=prop.name, options=[true,false], label=prop.name, bind=arguments.entity, labelwrapper=arguments.labelWrapper, labelWrapperAttrs=arguments.labelWrapperAttrs, labelClass=arguments.labelClass,
+									wrapper=arguments.fieldwrapper, wrapperAttrs=arguments.wrapperAttrs, groupWrapper=arguments.groupWrapper, groupWrapperAttrs=arguments.groupWrapperAttrs
 								};
 								structAppend(args,arguments);
 								buffer.append( this.select(argumentCollection=args) );
 							}
 							else{
 								args = {
-									name=prop.name, value="true", label="True", bind=arguments.entity, labelwrapper=arguments.labelWrapper, labelClass=arguments.labelClass,
-									groupWrapper=arguments.groupWrapper, wrapper=arguments.fieldWrapper
+									name=prop.name, value="true", label="True", bind=arguments.entity, labelwrapper=arguments.labelWrapper, labelWrapperAttrs=arguments.labelWrapperAttrs, labelClass=arguments.labelClass,
+									groupWrapper=arguments.groupWrapper, groupWrapperAttrs = arguments.groupWrapperAttrs, wrapper=arguments.fieldWrapper, wrapperAttrs=arguments.fieldWrapperAttrs
 								};
 								structAppend(args,arguments);
 								buffer.append( this.radioButton(argumentCollection=args) );
@@ -1446,8 +1495,8 @@ Description :
 						}
 						// text args
 						args = {
-							name=prop.name, label=prop.name, bind=arguments.entity, labelwrapper=arguments.labelWrapper, labelClass=arguments.labelClass,
-							wrapper=arguments.fieldwrapper, groupWrapper=arguments.groupWrapper
+							name=prop.name, label=prop.name, bind=arguments.entity, labelwrapper=arguments.labelWrapper, labelWrapperAttrs=arguments.labelWrapperAttrs, labelClass=arguments.labelClass,
+							wrapper=arguments.fieldwrapper, wrapperAttrs=arguments.fieldWrapperAttrs, groupWrapper=arguments.groupWrapper, groupWrapperAttrs=arguments.groupWrapperAttrs
 						};
 						structAppend(args,arguments);
 						// text and textarea fields
@@ -1690,11 +1739,18 @@ Description :
 		<cfargument name="buffer">
 		<cfargument name="tag">
 		<cfargument name="end" required="false" default="false">
+		<cfargument name="attrs" type="struct" required="false" hint="Key/value pairs of attributes to add to the tag">
 		<cfscript>
 			var slash = "";
 			if( len( arguments.tag ) ){
 				if( arguments.end ){ slash = "/"; }
-				arguments.buffer.append("<#slash##arguments.tag#>");
+				arguments.buffer.append("<#slash##arguments.tag#");
+				if (!arguments.end && !isNull(arguments.attrs)) {
+					for (var attr in structKeyArray(arguments.attrs)) {
+						arguments.buffer.append(' ' & attr & '="' & structFind(arguments.attrs,attr) & '"');
+					}
+				} 
+				arguments.buffer.append(">");
 			}
 		</cfscript>
 	</cffunction>
@@ -1753,7 +1809,7 @@ Description :
 			var datakey = "";
 
 			// global exclusions
-			arguments.excludes &= ",fieldWrapper,labelWrapper,entity,booleanSelect,textareas,manytoone,onetomany,sendToHeader,bind";
+			arguments.excludes &= ",fieldWrapper,labelWrapper,wrapperAttrs,fieldWrapperAttrs,labelWrapperAttrs,groupWrapperAttrs,entity,booleanSelect,textareas,manytoone,onetomany,sendToHeader,bind";
 
 			for(key in arguments.target){
 				// Excludes


### PR DESCRIPTION
The only thing I wasn't able to test myself was entityFields (as we don't have any code that uses them).

Note that this does not "fix" the bug in which HTMLHelper will close tags and append attributes -- it merely provides a dedicated mechanism of supplying those attributes such that the only values that ought to go in 'wrapper' and 'groupWrapper' and 'labelWrapper' fields are tag names with nothing else.

To do this any other way would likely have broken backwards-compatibility or else required some ugly regex, though honestly I didn't spend any time trying to solve this directly -- instead, I wanted to remove the impetus to supply 'div class="thing"' as a value for a wrapper attribute in the first place.
