### PR TITLE
Provide a framework convention for loading env secrets

### DIFF
--- a/system/web/config/ApplicationLoader.cfc
+++ b/system/web/config/ApplicationLoader.cfc
@@ -87,6 +87,7 @@ Loads a coldbox cfc configuration file
 		oConfig.injectPropertyMixin( "controller",instance.controller);
 		oConfig.injectPropertyMixin( "logBoxConfig",instance.controller.getLogBox().getConfig());
 		oConfig.injectPropertyMixin( "appMapping",configStruct.appMapping);
+		oConfig.injectPropertyMixin( "system", createObject( "java", "java.lang.System" ) );
 
 		//Configure it
 		oConfig.configure();

--- a/system/web/config/ApplicationLoader.cfc
+++ b/system/web/config/ApplicationLoader.cfc
@@ -89,6 +89,10 @@ Loads a coldbox cfc configuration file
 		oConfig.injectPropertyMixin( "appMapping",configStruct.appMapping);
 		oConfig.injectPropertyMixin( "system", createObject( "java", "java.lang.System" ) );
 
+		if ( shouldCopyEnvToProperties( oConfig ) ) {
+			copyEnvToProperties();
+		}
+
 		//Configure it
 		oConfig.configure();
 
@@ -860,6 +864,23 @@ Loads a coldbox cfc configuration file
 		<cfscript>
 			return reReplace(arguments.appMapping,"(/|\\)",".","all" );
 		</cfscript>
+    </cffunction>
+
+    <!--- shouldCopyEnvToProperties --->
+    <cffunction name="shouldCopyEnvToProperties" output="false" access="private" returntype="boolean" hint="Returns true if env keys and values should be transferred to Java properties">
+    	<cfargument name="oConfig" type="any" required="true" />
+		<cfreturn ( NOT structKeyExists( oConfig, "copyEnvToProperties" ) OR oConfig.copyEnvToProperties EQ true ) />
+    </cffunction>
+
+    <!--- copyEnvToProperties --->
+    <cffunction name="copyEnvToProperties" output="false" access="private" returntype="void" hint="Copies env keys and values to Java properties">
+    	<cfscript>
+    		var system = createObject( "java", "java.lang.System" );
+			var envs = system.getEnv();
+			for ( var key in envs ) {
+			    system.setProperty( key, envs[ key ] );
+			}
+    	</cfscript>
     </cffunction>
 
 </cfcomponent>

--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -634,6 +634,7 @@ I oversee and manage ColdBox modules
 			oConfig.injectPropertyMixin( "wirebox", 		controller.getWireBox() );
 			oConfig.injectPropertyMixin( "binder", 			controller.getWireBox().getBinder() );
 			oConfig.injectPropertyMixin( "cachebox", 		controller.getCacheBox() );
+			oConfig.injectPropertyMixin( "system",          createObject( "java", "java.lang.System" ) );
 
 			// Configure the module
 			oConfig.configure();


### PR DESCRIPTION
This pull request makes it easier to use secrets stored in the environment.  It does this via two methods:
1. It provides `java.lang.System` as a property injected into the `config/ColdBox.cfc` config file and any module's `ModuleConfig.cfc` file.  This saves the framework user from having to manually instantiate it.
2. It defaults to copying over env keys and values to Java properties.  This can be opted out by specifying `this.copyEnvToProperties = false` on the config file.  The reasons it copies env secrets over to properties is two-fold:
   a. All potential secrets are available in the Java properties instead of having to potentially check two locations.
   b. The `java.lang.System.getProperty` method allows for a second argument of `defaultValue` where `java.lang.System.getEnv` does not.

Things this pull request does not do:
1. It does not set environment secrets.  That must be done either manually or using a tool like [commandbox-dotenv](https://www.forgebox.io/view/commandbox-dotenv).
2. It does not load the Java properties in to the ColdBox settings.  This could be added if desired.

Thoughts on conventions are welcome, as are comments on the code. 😄 
