### PR TITLE
Allow new listeners added to the Binder to also be registered right away

### DIFF
--- a/system/ioc/Injector.cfc
+++ b/system/ioc/Injector.cfc
@@ -838,36 +838,42 @@ Description :
     		var listeners 	= instance.binder.getListeners();
 			var regLen		= arrayLen(listeners);
 			var x			= 1;
-			var thisListener = "";
 
 			// iterate and register listeners
 			for(x=1; x lte regLen; x++){
-				// try to create it
-				try{
-					// create it
-					thisListener = createObject("component", listeners[x].class);
-					// configure it
-					thisListener.configure( this, listeners[x].properties);
-				}
-				catch(Any e){
-					instance.log.error("Error creating listener: #listeners[x].toString()#", e);
-					throw(message="Error creating listener: #listeners[x].toString()#",
-									  detail="#e.message# #e.detail# #e.stackTrace#",
-									  type="Injector.ListenerCreationException");
-				}
+				registerListener( listeners[x] );
+			}
+		</cfscript>
+    </cffunction>
 
-				// Now register listener
-				if( NOT isColdBoxLinked() ){
-					instance.eventManager.register(thisListener,listeners[x].name);
-				}
-				else{
-					instance.eventManager.registerInterceptor(interceptorObject=thisListener,interceptorName=listeners[x].name);
-				}
+	<!--- registerListener --->
+    <cffunction name="registerListener" output="false" access="public" returntype="void" hint="Register all the configured listeners in the configuration file">
+    	<cfargument name="listener" required="true" hint="The listener to register" />
+    	<cfscript>
+			try{
+				// create it
+				var thisListener = createObject("component", listener.class);
+				// configure it
+				thisListener.configure( this, listener.properties);
+			}
+			catch(Any e){
+				instance.log.error("Error creating listener: #listener.toString()#", e);
+				throw(message="Error creating listener: #listener.toString()#",
+								  detail="#e.message# #e.detail# #e.stackTrace#",
+								  type="Injector.ListenerCreationException");
+			}
 
-				// debugging
-				if( instance.log.canDebug() ){
-					instance.log.debug("Injector has just registered a new listener: #listeners[x].toString()#");
-				}
+			// Now register listener
+			if( NOT isColdBoxLinked() ){
+				instance.eventManager.register(thisListener,listener.name);
+			}
+			else{
+				instance.eventManager.registerInterceptor(interceptorObject=thisListener,interceptorName=listener.name);
+			}
+
+			// debugging
+			if( instance.log.canDebug() ){
+				instance.log.debug("Injector has just registered a new listener: #listener.toString()#");
 			}
 		</cfscript>
     </cffunction>

--- a/system/ioc/Injector.cfc
+++ b/system/ioc/Injector.cfc
@@ -840,8 +840,8 @@ Description :
 			var x			= 1;
 
 			// iterate and register listeners
-			for(x=1; x lte regLen; x++){
-				registerListener( listeners[x] );
+			for( x = 1; x lte regLen; x++ ){
+				registerListener( listeners[ x ] );
 			}
 		</cfscript>
     </cffunction>

--- a/system/ioc/config/Binder.cfc
+++ b/system/ioc/config/Binder.cfc
@@ -1005,6 +1005,7 @@ Description :
 		<cfargument name="class" 		required="true"  hint="The class of the listener"/>
 		<cfargument name="properties" 	required="false" default="#structNew()#" hint="The structure of properties for the listner" colddoc:generic="Struct"/>
 		<cfargument name="name" 		required="false" default=""  hint="The name of the listener"/>
+        <cfargument name="registerListener" required="false" default="true"  hint="If ture, registers the listener right away"/>
 		<cfscript>
 			// Name check?
 			if( NOT len(arguments.name) ){
@@ -1012,6 +1013,10 @@ Description :
 			}
 			// add listener
 			arrayAppend(instance.listeners, arguments);
+
+            if ( registerListener ) {
+                getInjector().registerListener( arguments );
+            }
 
 			return this;
 		</cfscript>

--- a/system/ioc/config/Binder.cfc
+++ b/system/ioc/config/Binder.cfc
@@ -1005,7 +1005,7 @@ Description :
 		<cfargument name="class" 		required="true"  hint="The class of the listener"/>
 		<cfargument name="properties" 	required="false" default="#structNew()#" hint="The structure of properties for the listner" colddoc:generic="Struct"/>
 		<cfargument name="name" 		required="false" default=""  hint="The name of the listener"/>
-        <cfargument name="registerListener" required="false" default="true"  hint="If ture, registers the listener right away"/>
+        <cfargument name="registerListener" required="false" default="false"  hint="If true, registers the listener right away"/>
 		<cfscript>
 			// Name check?
 			if( NOT len(arguments.name) ){

--- a/system/ioc/config/Binder.cfc
+++ b/system/ioc/config/Binder.cfc
@@ -1005,7 +1005,7 @@ Description :
 		<cfargument name="class" 		required="true"  hint="The class of the listener"/>
 		<cfargument name="properties" 	required="false" default="#structNew()#" hint="The structure of properties for the listner" colddoc:generic="Struct"/>
 		<cfargument name="name" 		required="false" default=""  hint="The name of the listener"/>
-        <cfargument name="registerListener" required="false" default="false"  hint="If true, registers the listener right away"/>
+        <cfargument name="register" required="false" default="false"  hint="If true, registers the listener right away"/>
 		<cfscript>
 			// Name check?
 			if( NOT len(arguments.name) ){
@@ -1014,7 +1014,7 @@ Description :
 			// add listener
 			arrayAppend(instance.listeners, arguments);
 
-            if ( registerListener ) {
+            if ( arguments.register ) {
                 getInjector().registerListener( arguments );
             }
 

--- a/tests/specs/ioc/config/BinderTest.cfc
+++ b/tests/specs/ioc/config/BinderTest.cfc
@@ -426,7 +426,13 @@
 		assertEquals(3, arrayLen(config.getListeners()));
 		listeners = config.getListeners();
 		assertEquals( "FunkyTown", listeners[3].name);
+	}
 
+	function testActivateListener(){
+		mockInjector.$( "registerListener" ).$args( "models.listener", {}, "configListner", true );
+		config.listener( "models.listener", {}, "configListener", true );
+		config.listener( "models.listener", {}, "configListener2", false );
+		assertTrue( mockInjector.$once( "registerListener" ), "Injector should have only been called once." );
 	}
 
 	function testLoadDataDSL(){


### PR DESCRIPTION
This enables modules to add new listeners (like the AOP listener) and have them activated.
