### PR TITLE
Add postReinit interception point

### DIFF
--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -104,6 +104,11 @@ component serializable="false" accessors="true"{
 
 					// Reload ColdBox
 					loadColdBox();
+					// If we are Reiniting, fire the postReinit interception point
+					if( structkeyExists( application, appKey ) AND application[ appKey ].getColdboxInitiated() AND needReinit ){
+						// process postReinit interceptors
+						application[ appKey ].getInterceptorService().processState( "postReinit" );
+					}
 					// Remove any context stragglers
 					structDelete( request, "cb_requestContext" );
 				}

--- a/system/web/services/InterceptorService.cfc
+++ b/system/web/services/InterceptorService.cfc
@@ -24,7 +24,7 @@ Description :
 			// Register the interception points ENUM
 			instance.interceptionPoints = [
 				// Application startup points
-				"afterConfigurationLoad", "afterAspectsLoad", "preReinit",
+				"afterConfigurationLoad", "afterAspectsLoad", "preReinit", "postReinit",
 				// On Actions
 				"onException", "onRequestCapture", "onInvalidEvent",
 				// After FW Object Creations


### PR DESCRIPTION
Add a postReinit interception point that fires after the `loadColdBox` method finishes.

My specific use case for this is to have an interceptor call `ormReload` on a `fwreinit`, but only after the configuration file (`config/ColdBox.cfc`) has been loaded.  This is because I am using the `cfapplication` tag to update my default datasource based on the environment (`cfapplication( action="update", datasource="my_env_specific_datasource" );`)  Calling `ormReload` in the `preReinit` interception point is too early as the datasource has not been updated.

There are likely other use cases as well.  Looking forward to your feedback.