### PR TITLE
Fix bug where modules would override the settings struct of config/ColdBox.cfc

### DIFF
--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -727,7 +727,7 @@ I oversee and manage ColdBox modules
 					true
 				);
 			}
-			appSettings[ mConfig.modelNamespace ] = mConfig.settings;
+			appSettings.moduleSettings[ mConfig.modelNamespace ] = mConfig.settings;
 			//Get module datasources
 			mConfig.datasources = oConfig.getPropertyMixin( "datasources", "variables", {} );
 			//Get Interceptors

--- a/test-harness/config/Coldbox.cfc
+++ b/test-harness/config/Coldbox.cfc
@@ -48,7 +48,9 @@
 
 		// custom settings
 		settings = {
-
+			test1 = {
+				display = "not-core"
+			}
 		};
 
 		// environment settings, create a detectEnvironment() method to detect it yourself.

--- a/tests/specs/integration/ModuleTests.cfc
+++ b/tests/specs/integration/ModuleTests.cfc
@@ -71,9 +71,27 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/cbTestHarne
 			it( "should load modules in a bundle", function(){
 				var config = getController().getSetting( "modules" );
 
+				debug( config );
+
 				expect(	config ).toHaveKey( 'layouttest' )
 					.toHaveKey( 'test1' );
 			});
+
+			it( "should merge module settings with framework moduleSettings by default", function() {
+				var config = getController().getSetting( "modules" );
+				var parentSettings = getController().getConfigSettings();
+
+				expect( parentSettings ).toHaveKey( "moduleSettings" );
+				expect( parentSettings.moduleSettings ).toHaveKey( "test1" );
+
+				expect(	config ).toHaveKey( 'test1' );
+				expect( config[ "test1" ] ).toHaveKey( "settings" );
+				
+				expect( config[ "test1" ].settings ).toBe( parentSettings.moduleSettings[ "test1" ] );
+
+				expect( parentSettings ).toHaveKey( "test1" );
+				expect( parentSettings[ "test1" ] ).notToBe( config[ "test1" ].settings );
+			} );
 
 			it( "should not load mdoules that have been excluded, even in bundles", function(){
 				var config = getController().getSetting( "modules" );


### PR DESCRIPTION
This bug was introduced when adding the parse parent settings by convention for modules (https://github.com/ColdBox/coldbox-platform/pull/289).
Instead of updating the module namespace in the `moduleSettings` struct to match, it updated the module namespace in the `settings` struct.
Some modules depended on the old behavior, especially those that rolled their own parse parent settings.

This pull request fixes the behavior so that the module's settings and the module namespace in `moduleSettings` are kept in sync.  `settings` is not touched.