### PR TITLE
Format detection from accepts header & redirect event on HTML events with multiple formats

### DIFF
--- a/system/interceptors/SES.cfc
+++ b/system/interceptors/SES.cfc
@@ -767,6 +767,27 @@ Description :
 					}
 				}
 			}
+			// check accepts headers for the best match
+			else{
+				var match = "";
+				for( var accept in listToArray( event.getHTTPHeader( "Accept" ), "," ) ){
+					for( var extension in instance.validExtensions ){
+						if( findNoCase( extension, accept ) > 0 ){
+							match = extension;
+							break;
+						}
+					}
+					if( len( match ) ){
+						break;
+					}
+				}
+
+				if( len( match ) ){
+					// if the user passed in format via the query string,
+					// we'll assume that's the value they actually wanted.
+					event.paramValue( 'format', lcase( match ) );
+				}
+			}
 
 			// return the same request string, extension not found
 			return requestString;

--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -963,6 +963,7 @@ component serializable=false accessors="true"{
 	* @pdfArgs.hint All the PDF arguments to pass along to the CFDocument tag.
 	* @formats.hint The formats list or array that ColdBox should respond to using the passed in data argument. You can pass any of the valid types (JSON,JSONP,JSONT,XML,WDDX,PLAIN,HTML,TEXT,PDF). For PDF and HTML we will try to render the view by convention based on the incoming event
 	* @formatsView.hint The view that should be used for rendering HTML/PLAIN/PDF. By default ColdBox uses the name of the event as an implicit view
+	* @formatsRedirectEvent.hint The arguments that should be passed to setNextEvent as part of a redirect for the HTML action.  If the format is HTML and this struct is not empty, ColdBox will call setNextEvent with these arguments.
 	* @isBinary.hint Bit that determines if the data being set for rendering is binary or not.
 	*/
 	function renderData(
@@ -983,6 +984,7 @@ component serializable=false accessors="true"{
 		struct pdfArgs={},
 		formats="",
 		formatsView="",
+		formatsRedirectEvent={},
 		boolean isBinary=false
 	){
 
@@ -1208,6 +1210,10 @@ component serializable=false accessors="true"{
 					return renderData( argumentCollection=arguments );
 				}
 				case "html" : case "plain" : {
+					if( NOT structIsEmpty( arguments.formatsRedirectEvent ) ){
+						instance.controller.setNextEvent( argumentCollection = arguments.formatsRedirectEvent );
+						return this;
+					}
 					return setView( view=viewToRender);
 				}
 			}

--- a/test-harness/handlers/rendering.cfc
+++ b/test-harness/handlers/rendering.cfc
@@ -1,1 +1,36 @@
-﻿component output="false" singleton{	this.allowedMethods = {		"testHTTPMethod"  = "POST"	};	data = [		{ id = createUUID(), name = "luis" },		{ id = createUUID(), name = "lucas" },		{ id = createUUID(), name = "fernando" }	];	// Default Action	function index( event, rc, prc ){		prc.data = variables.data;		event.renderData( data=prc.data, formats="json,xml,wddx,pdf,html" );	}	function testHTTPMethod( event, rc, prc ){		return "this should not fire";	}	function onInvalidHTTPMethod( faultAction, event, rc, prc ){		return "Yep, onInvalidHTTPMethod works!";	}}
+component output="false" singleton{
+
+	this.allowedMethods = {
+		"testHTTPMethod"  = "POST"
+	};
+
+	data = [
+		{ id = createUUID(), name = "luis" },
+		{ id = createUUID(), name = "lucas" },
+		{ id = createUUID(), name = "fernando" }
+	];
+
+	// Default Action
+	function index( event, rc, prc ){
+		prc.data = variables.data;
+		event.renderData( data=prc.data, formats="json,xml,wddx,pdf,html" );
+	}
+
+	function redirect( event, rc, prc ) {
+		prc.data = variables.data;
+		event.renderData(
+			data = prc.data,
+			formats = "json,html",
+			formatsRedirectEvent = { event = "Main.index" }
+		);
+	}
+
+	function testHTTPMethod( event, rc, prc ){
+		return "this should not fire";
+	}
+
+	function onInvalidHTTPMethod( faultAction, event, rc, prc ){
+		return "Yep, onInvalidHTTPMethod works!";
+	}
+
+}

--- a/test-harness/models/ControllerDecorator.cfc
+++ b/test-harness/models/ControllerDecorator.cfc
@@ -5,6 +5,50 @@ component extends="coldbox.system.web.ControllerDecorator" {
 	function configure(){
 	}
 
+    /**
+    * Set the next event to run and relocate the browser to that event. If you are in SES mode, this method will use routing instead. You can also use this method to relocate to an absolute URL or a relative URI
+    * @event The name of the event to relocate to, if not passed, then it will use the default event found in your configuration file.
+    * @queryString The query string to append, if needed. If in SES mode it will be translated to convention name value pairs
+    * @addToken Wether to add the tokens or not to the relocation. Default is false
+    * @persist What request collection keys to persist in flash RAM automatically for you
+    * @persistStruct A structure of key-value pairs to persist in flash RAM automatically for you
+    * @ssl Whether to relocate in SSL or not. You need to explicitly say TRUE or FALSE if going out from SSL. If none passed, we look at the even's SES base URL (if in SES mode)
+    * @baseURL Use this baseURL instead of the index.cfm that is used by default. You can use this for SSL or any full base url you would like to use. Ex: https://mysite.com/index.cfm
+    * @postProcessExempt Do not fire the postProcess interceptors, by default it does
+    * @URL The full URL you would like to relocate to instead of an event: ex: URL='http://www.google.com'
+    * @URI The relative URI you would like to relocate to instead of an event: ex: URI='/mypath/awesome/here'
+    * @statusCode The status code to use in the relocation
+    */
+    function setNextEvent(
+        event=getSetting( "DefaultEvent" ), 
+        queryString="", 
+        boolean addToken=false, 
+        persist="",
+        struct persistStruct=structnew()
+        boolean ssl, 
+        baseURL="", 
+        boolean postProcessExempt=false, 
+        URL, 
+        URI, 
+        numeric statusCode=0
+    ){
+        var rc = getRequestService().getContext().getCollection();
+
+        // copy over to rc
+        for( var thisArg in arguments ){
+            if( structKeyExists( arguments, thisArg ) ){
+                rc[ "setNextEvent_#thisArg#" ] = arguments[ thisArg ];
+            }
+        }
+
+        // Post Process
+        if( arguments.postProcessExempt ){
+            getInterceptorService().processState("postProcess");
+        }
+
+        throw( message="Relocating via setNextEvent", type="TestController.setNextEvent" );
+    }
+
 	function runEvent(){
 		getLogBox().getLogger( this ).info(" Called decorator runEvent(#arguments.toString()#)" );
 		return getController().runEvent(argumentCollection=arguments);

--- a/tests/specs/integration/RestfulTests.cfc
+++ b/tests/specs/integration/RestfulTests.cfc
@@ -68,6 +68,22 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/cbTestHarne
 				
 			});
 
+			it( "can redirect only for html formats with the `formatsRedirectEvent` parameter", function() {
+				getRequestContext().setValue( "format", "json" );
+				var event = execute( event="rendering.redirect", renderResults=true );
+				var rc = event.getCollection();
+				var prc = event.getCollection( private=true );
+				expect( rc ).notToHaveKey( "setNextEvent_event" );
+				expect( prc.cbox_renderData ).toBeStruct();
+				expect( prc.cbox_renderData.contenttype ).toMatch( "json" );
+
+				getRequestContext().setValue( "format", "html" );
+				var event = execute( event="rendering.redirect", renderResults=true );
+				var rc = event.getCollection();
+				expect( rc ).toHaveKey( "setNextEvent_event" );
+				expect( rc[ "setNextEvent_event" ] ).toBe( "Main.index" );
+			} );
+
 		});
 
 	}

--- a/tests/specs/interceptors/SESTest.cfc
+++ b/tests/specs/interceptors/SESTest.cfc
@@ -75,6 +75,67 @@ www.coldbox.org | www.luismajano.com | www.ortussolutions.com
 		assertEquals( "/somefolder/index",  results.pathInfo);
 	}
 
+	function testDetectFormat() {
+		var mockLog = getMockBox().createStub().$( "canDebug", false );
+		ses.$property( propertyName = "log", mock = mockLog );
+		ses.$("getSetting").$args("AppMapping").$results("/coldbox/test-harness")
+			.$("getSetting").$args("eventName").$results("event")
+			.$("importConfiguration")
+			.$("setSetting");
+		ses.setBaseURL("http://localhost");
+		ses.configure();
+		var mockController = getMockBox().createMock( "system.web.Controller" );
+		var mockEvent = getMockBox().createMock( "system.web.context.RequestContext" ).init( controller = mockController, properties = {
+				defaultLayout = "Main.cfm",
+				defaultView = "",
+				eventName = "event",
+				modules = {}
+			} );
+		var mockInterceptData = {};
+
+		// default format
+		ses.$( "getCleanedPaths", {
+			pathInfo = "/Main/index",
+			scriptName = ""
+		} );
+		ses.onRequestCapture( mockEvent, mockInterceptData );
+		expect( mockEvent.valueExists( "format" ) ).toBeTrue();
+		expect( mockEvent.getValue( "format" ) ).toBe( "html" );
+		mockEvent.removeValue( "format" );
+
+		// extension detection
+		ses.$( "getCleanedPaths", {
+			pathInfo = "/Main/index.xml",
+			scriptName = ""
+		} );
+		ses.onRequestCapture( mockEvent, mockInterceptData );
+		expect( mockEvent.valueExists( "format" ) ).toBeTrue();
+		expect( mockEvent.getValue( "format" ) ).toBe( "xml" );
+		mockEvent.removeValue( "format" );
+
+		// Accept header parsing
+		mockEvent.$( "getHTTPHeader" ).$args( "Accept" ).$results( "application/json" );
+		ses.$( "getCleanedPaths", {
+			pathInfo = "/Main/index",
+			scriptName = ""
+		} );
+		ses.onRequestCapture( mockEvent, mockInterceptData );
+		expect( mockEvent.valueExists( "format" ) ).toBeTrue();
+		expect( mockEvent.getValue( "format" ) ).toBe( "json" );
+		mockEvent.removeValue( "format" );
+
+		// uses extension over Accept header
+		mockEvent.$( "getHTTPHeader" ).$args( "Accept" ).$results( "application/json" );
+		ses.$( "getCleanedPaths", {
+			pathInfo = "/Main/index.xml",
+			scriptName = ""
+		} );
+		ses.onRequestCapture( mockEvent, mockInterceptData );
+		expect( mockEvent.valueExists( "format" ) ).toBeTrue();
+		expect( mockEvent.getValue( "format" ) ).toBe( "xml" );
+		mockEvent.removeValue( "format" );
+	}
+
 </cfscript>
 </cfcomponent>
 


### PR DESCRIPTION
This pull request has two main parts:

1. If format isn't set in the `rc` scope and isn't detected via an extension `users.json`, the SES interceptor will attempt to use the `Accept` header to figure out what format to use.
2. If using `renderData` with multiple `formats` and new parameter of `formatsRedirectEvent` is allowed to redirect ONLY for HTML formats.  The struct is passed as the `argumentCollection` for `setNextEvent`.

See https://ortussolutions.atlassian.net/browse/COLDBOX-36