### PR TITLE
Provide helper methods for system settings that covers both properties (first) and env variables.

### DIFF
--- a/system/core/util/Util.cfc
+++ b/system/core/util/Util.cfc
@@ -146,6 +146,83 @@ Description :
 
     </cffunction>
 
+    <!--- getSystemSetting --->
+    <cffunction name="getSystemSetting" output="false" access="public" returntype="any" hint="Retrieve a Java System property or env value by name.">
+    	<cfargument name="key" required="true" type="string" hint="The name of the setting to look up."/>
+		<cfargument name="defaultValue" required="false" hint="The default value to use if the key does not exist in the system properties or the env" />
+
+		<cfscript>
+			var system = createObject( "java", "java.lang.System" );
+			
+			var value = system.getProperty( arguments.key );
+			if ( ! isNull( value ) ) {
+				return value;
+			}
+			
+			value = system.getEnv( arguments.key );
+			if ( ! isNull( value ) ) {
+				return value;
+			}
+
+			if ( ! isNull( arguments.defaultValue ) ) {
+				return arguments.defaultValue;
+			}
+
+			throw(
+				type = "SystemSettingNotFound",
+				message = "Could not find a Java System property or Env setting with key [#arguments.key#]."
+			);
+		</cfscript>
+    </cffunction>
+
+    <!--- getSystemProperty --->
+    <cffunction name="getSystemProperty" output="false" access="public" returntype="any" hint="Retrieve a Java System property or env value by name.">
+    	<cfargument name="key" required="true" type="string" hint="The name of the setting to look up."/>
+		<cfargument name="defaultValue" required="false" hint="The default value to use if the key does not exist in the system properties" />
+
+		<cfscript>
+			var system = createObject( "java", "java.lang.System" );
+			
+			var value = system.getProperty( arguments.key );
+			if ( ! isNull( value ) ) {
+				return value;
+			}
+
+			if ( ! isNull( arguments.defaultValue ) ) {
+				return arguments.defaultValue;
+			}
+
+			throw(
+				type = "SystemSettingNotFound",
+				message = "Could not find a Java System property with key [#arguments.key#]."
+			);
+		</cfscript>
+    </cffunction>
+
+    <!--- getEnv --->
+    <cffunction name="getEnv" output="false" access="public" returntype="any" hint="Retrieve a Java System property or env value by name.">
+    	<cfargument name="key" required="true" type="string" hint="The name of the setting to look up."/>
+		<cfargument name="defaultValue" required="false" hint="The default value to use if the key does not exist in the env" />
+
+		<cfscript>
+			var system = createObject( "java", "java.lang.System" );
+			
+			var value = system.getEnv( arguments.key );
+			if ( ! isNull( value ) ) {
+				return value;
+			}
+
+			if ( ! isNull( arguments.defaultValue ) ) {
+				return arguments.defaultValue;
+			}
+
+			throw(
+				type = "SystemSettingNotFound",
+				message = "Could not find a env property with key [#arguments.key#]."
+			);
+		</cfscript>
+    </cffunction>
+
 <!------------------------------------------- Taxonomy Utility Methods ------------------------------------------>
 
 	<!--- isFamilyType --->

--- a/system/web/config/ApplicationLoader.cfc
+++ b/system/web/config/ApplicationLoader.cfc
@@ -87,6 +87,9 @@ Loads a coldbox cfc configuration file
 		oConfig.injectPropertyMixin( "controller",instance.controller);
 		oConfig.injectPropertyMixin( "logBoxConfig",instance.controller.getLogBox().getConfig());
 		oConfig.injectPropertyMixin( "appMapping",configStruct.appMapping);
+		oConfig.injectPropertyMixin( "getSystemSetting",instance.util.getSystemSetting );
+		oConfig.injectPropertyMixin( "getSystemProperty",instance.util.getSystemProperty );
+		oConfig.injectPropertyMixin( "getEnv",instance.util.getEnv );
 
 		//Configure it
 		oConfig.configure();

--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -658,15 +658,18 @@ component extends="coldbox.system.web.services.BaseService"{
 		oConfig.getPropertyMixin 	= mixerUtil.getPropertyMixin;
 
 		// MixIn Variables
-		oConfig.injectPropertyMixin( "controller", 		controller );
-		oConfig.injectPropertyMixin( "appMapping", 		controller.getSetting( "appMapping" ) );
-		oConfig.injectPropertyMixin( "moduleMapping", 	mConfig.mapping );
-		oConfig.injectPropertyMixin( "modulePath", 		mConfig.path );
-		oConfig.injectPropertyMixin( "logBox", 			controller.getLogBox() );
-		oConfig.injectPropertyMixin( "log", 			controller.getLogBox().getLogger( oConfig) );
-		oConfig.injectPropertyMixin( "wirebox", 		controller.getWireBox() );
-		oConfig.injectPropertyMixin( "binder", 			controller.getWireBox().getBinder() );
-		oConfig.injectPropertyMixin( "cachebox", 		controller.getCacheBox() );
+		oConfig.injectPropertyMixin( "controller", 		  controller );
+		oConfig.injectPropertyMixin( "appMapping", 		  controller.getSetting( "appMapping" ) );
+		oConfig.injectPropertyMixin( "moduleMapping", 	  mConfig.mapping );
+		oConfig.injectPropertyMixin( "modulePath", 		  mConfig.path );
+		oConfig.injectPropertyMixin( "logBox", 			  controller.getLogBox() );
+		oConfig.injectPropertyMixin( "log", 			  controller.getLogBox().getLogger( oConfig) );
+		oConfig.injectPropertyMixin( "wirebox", 		  controller.getWireBox() );
+		oConfig.injectPropertyMixin( "binder", 			  controller.getWireBox().getBinder() );
+		oConfig.injectPropertyMixin( "cachebox", 		  controller.getCacheBox() );
+		oConfig.injectPropertyMixin( "getSystemSetting",  controller.getUtil().getSystemSetting );
+		oConfig.injectPropertyMixin( "getSystemProperty", controller.getUtil().getSystemProperty );
+		oConfig.injectPropertyMixin( "getEnv",            controller.getUtil().getEnv );
 
 		// Configure the module
 		oConfig.configure();


### PR DESCRIPTION
This pull request is the spiritual successor to https://github.com/ColdBox/coldbox-platform/pull/291

cc @lmajano @bdw429s @jclausen 

Usage:

+ `getSystemSetting( key, defaultValue )` -> looks in properties first, env second. Returns the `defaultValue` if neither exist. 
+ `getSystemProperty( key, defaultValue )` -> Returns the Java System property.  Returns the `defaultValue` if does not exist.
+ `getEnv( key, defaultValue )` -> Returns the Env property.  Returns the `defaultValue` if does not exist.

These helper methods are available in the `config/ColdBox.cfc` file and all `ModuleConfig.cfc` files.