### PR TITLE
Invalid construct.A script statement must end with ";"

### DIFF
--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -831,7 +831,7 @@ component extends="coldbox.system.web.services.BaseService"{
 						invocationPath 	= replace( reReplace( arguments.dirPath, "^/", "" ), "/", ".", "all" )
 					};
 				} else {
-					variables.logger.debug( "Found duplicate module: #thisModule.name# in #arguments.dirPath#. Skipping its registration in our module registry, order of preference given." )
+					variables.logger.debug( "Found duplicate module: #thisModule.name# in #arguments.dirPath#. Skipping its registration in our module registry, order of preference given." );
 				}
 			}
 		}


### PR DESCRIPTION
Perfect example of why it is necessary to test with cfengine=adobe@11 - this causes cbox-debugger to fail to load the app entirely.