### PR TITLE
Adding an addResource method which creates the RESTful routes for a resource

### DIFF
--- a/system/interceptors/SES.cfc
+++ b/system/interceptors/SES.cfc
@@ -393,6 +393,14 @@ component extends="coldbox.system.Interceptor" accessors="true"{
 		return this;
 	}
 
+    /**
+     * Create all RESTful routes for a resource
+     * @name The name of the resource.
+     * @handler The handler for the route. Defaults to the resource name.
+     * @parameterName The name of the id/parameter for the resource. Defaults to id.
+     * @only Limit routes created with only
+     * @except Exclude routes with except
+     */
     function addResource(
         required name,
         handler=arguments.name,
@@ -431,35 +439,6 @@ component extends="coldbox.system.Interceptor" accessors="true"{
         }
 
         return this;
-    }
-
-    function filterRouteActions( required struct initial, array only = [], array except = [] ) {
-        var actionSet = initial;
-
-        if ( structKeyExists( arguments, "only" ) && ! isNull( arguments.only ) && ! arrayIsEmpty( arguments.only ) ) {
-            actionSet = {};
-            for ( var httpVerb in initial ) {
-                var methodName = initial[ httpVerb ];
-                for ( var onlyAction in only ) {
-                    if ( compareNoCase( methodName, onlyAction ) == 0 ) {
-                        structInsert( actionSet, httpVerb, onlyAction );
-                    }
-                }
-            }
-        }
-
-        if ( structKeyExists( arguments, "except" ) && ! isNull( arguments.except ) && ! arrayIsEmpty( arguments.except ) ) {
-            for ( var httpVerb in initial ) {
-                var methodName = initial[ httpVerb ];
-                for ( var exceptAction in except ) {
-                    if ( compareNoCase( methodName, exceptAction ) == 0 ) {
-                        structDelete( actionSet, httpVerb );
-                    }
-                }
-            }   
-        }
-
-        return actionSet;
     }
 
 	/**
@@ -1416,5 +1395,41 @@ component extends="coldbox.system.Interceptor" accessors="true"{
 	private function getUtil(){
 		return new coldbox.system.core.util.Util();
 	}
+
+
+    /**
+     * Get the correct route actions based on only and except
+     * @initial The initial set of route actions
+     * @only Limit actions with only
+     * @except Exclude actions with except
+     */
+    private function filterRouteActions( required struct initial, array only = [], array except = [] ) {
+        var actionSet = initial;
+
+        if ( structKeyExists( arguments, "only" ) && ! isNull( arguments.only ) && ! arrayIsEmpty( arguments.only ) ) {
+            actionSet = {};
+            for ( var httpVerb in initial ) {
+                var methodName = initial[ httpVerb ];
+                for ( var onlyAction in only ) {
+                    if ( compareNoCase( methodName, onlyAction ) == 0 ) {
+                        structInsert( actionSet, httpVerb, onlyAction );
+                    }
+                }
+            }
+        }
+
+        if ( structKeyExists( arguments, "except" ) && ! isNull( arguments.except ) && ! arrayIsEmpty( arguments.except ) ) {
+            for ( var httpVerb in initial ) {
+                var methodName = initial[ httpVerb ];
+                for ( var exceptAction in except ) {
+                    if ( compareNoCase( methodName, exceptAction ) == 0 ) {
+                        structDelete( actionSet, httpVerb );
+                    }
+                }
+            }   
+        }
+
+        return actionSet;
+    }
 
 }

--- a/system/interceptors/SES.cfc
+++ b/system/interceptors/SES.cfc
@@ -393,6 +393,75 @@ component extends="coldbox.system.Interceptor" accessors="true"{
 		return this;
 	}
 
+    function addResource(
+        required name,
+        handler=arguments.name,
+        parameterName="id",
+        only=[],
+        except=[]
+    ){
+        if ( ! isArray( only ) ) {
+            only = listToArray(only);
+        }
+
+        if ( ! isArray( except ) ) {
+            except = listToArray(except);
+        }
+
+        var actionSet = {};
+
+        actionSet = filterRouteActions( {GET = "edit"}, only, except );
+        if ( ! structIsEmpty( actionSet ) ) {
+            addRoute(pattern="/#name#/:#parameterName#/edit",handler=handler,action=actionSet);
+        }
+
+        actionSet = filterRouteActions( {GET = "new"}, only, except );
+        if ( ! structIsEmpty( actionSet ) ) {
+            addRoute(pattern="/#name#/new",handler=handler,action=actionSet);
+        }
+
+        actionSet = filterRouteActions( { PUT = "update", PATCH = "update", DELETE = "delete", GET = "show" }, only, except );
+        if ( ! structIsEmpty( actionSet ) ) {
+            addRoute(pattern="/#name#/:#parameterName#",handler=handler,action=actionSet);
+        }
+
+        actionSet = filterRouteActions( {GET = "index", POST = "create"}, only, except );
+        if ( ! structIsEmpty( actionSet ) ) {
+            addRoute(pattern="/#name#",handler=handler,action=actionSet);
+        }
+
+        return this;
+    }
+
+    function filterRouteActions( required struct initial, array only = [], array except = [] ) {
+        var actionSet = initial;
+
+        if ( structKeyExists( arguments, "only" ) && ! isNull( arguments.only ) && ! arrayIsEmpty( arguments.only ) ) {
+            actionSet = {};
+            for ( var httpVerb in initial ) {
+                var methodName = initial[ httpVerb ];
+                for ( var onlyAction in only ) {
+                    if ( compareNoCase( methodName, onlyAction ) == 0 ) {
+                        structInsert( actionSet, httpVerb, onlyAction );
+                    }
+                }
+            }
+        }
+
+        if ( structKeyExists( arguments, "except" ) && ! isNull( arguments.except ) && ! arrayIsEmpty( arguments.except ) ) {
+            for ( var httpVerb in initial ) {
+                var methodName = initial[ httpVerb ];
+                for ( var exceptAction in except ) {
+                    if ( compareNoCase( methodName, exceptAction ) == 0 ) {
+                        structDelete( actionSet, httpVerb );
+                    }
+                }
+            }   
+        }
+
+        return actionSet;
+    }
+
 	/**
 	 * Adds a route to dispatch and returns itself.
 	 * @pattern  The pattern to match against the URL.

--- a/tests/specs/interceptors/SESAddResourceTest.cfc
+++ b/tests/specs/interceptors/SESAddResourceTest.cfc
@@ -1,0 +1,125 @@
+﻿component extends="coldbox.system.testing.BaseInterceptorTest" interceptor="coldbox.system.interceptors.SES"{
+
+    function beforeAll() {
+        super.setup();
+        variables.ses = variables.interceptor;
+    }
+
+    function run() {
+        describe( "SES addResource", function(){
+            beforeEach( function(){
+                ses.$reset();
+                ses.$("addRoute");
+            } );
+            it( "can add all the RESTful routes for a resource", function() {
+                ses.addResource( "photos" );
+
+                var cl = ses.$callLog().addRoute;
+
+                expect( cl ).toHaveLength( 4, "addRoute should have been called 4 times" );
+                expect( cl ).toHaveLength( 4, "addRoute should have been called 4 times" );
+                expect( cl[ 1 ] ).toBe( { pattern = "/photos/:id/edit", handler = "photos", action = { GET = "edit" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                expect( cl[ 2 ] ).toBe( { pattern = "/photos/new", handler = "photos", action = { GET = "new" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                expect( cl[ 3 ] ).toBe( { pattern = "/photos/:id", handler = "photos", action = { GET = "show", PUT = "update", PATCH = "update", DELETE = "delete" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                expect( cl[ 4 ] ).toBe( { pattern = "/photos", handler = "photos", action = { GET = "index", POST = "create" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+            } );
+
+            it( "can override the handler used", function() {
+                ses.addResource( "photos", "PhotosController" );
+
+                var cl = ses.$callLog().addRoute;
+                debug( cl );
+
+                expect( cl ).toHaveLength( 4, "addRoute should have been called 4 times" );
+                expect( cl[ 1 ] ).toBe( { pattern = "/photos/:id/edit", handler = "PhotosController", action = { GET = "edit" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                expect( cl[ 2 ] ).toBe( { pattern = "/photos/new", handler = "PhotosController", action = { GET = "new" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                expect( cl[ 3 ] ).toBe( { pattern = "/photos/:id", handler = "PhotosController", action = { GET = "show", PUT = "update", PATCH = "update", DELETE = "delete" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                expect( cl[ 4 ] ).toBe( { pattern = "/photos", handler = "PhotosController", action = { GET = "index", POST = "create" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+            } );
+
+            describe( "limiting the routes created by action", function() {
+                describe( "using the `only` parameter", function() {
+                    it( "can take a list of actions and only generate those routes", function() {
+                        ses.addResource( name = "photos", only = "index,show" );
+
+                        var cl = ses.$callLog().addRoute;
+                        debug( cl );
+
+                        expect( cl ).toHaveLength( 2, "addRoute should have been called 2 times" );
+                        expect( cl[ 1 ] ).toBe( { pattern = "/photos/:id", handler = "photos", action = { GET = "show" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                        expect( cl[ 2 ] ).toBe( { pattern = "/photos", handler = "photos", action = { GET = "index" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                    } );
+
+                    it( "can take an array of actions and only generate those routes", function() {
+                        ses.addResource( name = "photos", only = [ "index", "show" ] );
+
+                        var cl = ses.$callLog().addRoute;
+                        debug( cl );
+
+                        expect( cl ).toHaveLength( 2, "addRoute should have been called 2 times" );
+                        expect( cl[ 1 ] ).toBe( { pattern = "/photos/:id", handler = "photos", action = { GET = "show" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                        expect( cl[ 2 ] ).toBe( { pattern = "/photos", handler = "photos", action = { GET = "index" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                    } );
+                } );
+
+                describe( "using the `except` parameter", function() {
+                    it( "can take a list of actions and generate all except those routes", function() {
+                        ses.addResource( name = "photos", except = "create,edit,update,delete" );
+
+                        var cl = ses.$callLog().addRoute;
+                        debug( cl );
+
+                        expect( cl ).toHaveLength( 3, "addRoute should have been called 3 times" );
+                        expect( cl[ 1 ] ).toBe( { pattern = "/photos/new", handler = "photos", action = { GET = "new" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                        expect( cl[ 2 ] ).toBe( { pattern = "/photos/:id", handler = "photos", action = { GET = "show" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                        expect( cl[ 3 ] ).toBe( { pattern = "/photos", handler = "photos", action = { GET = "index" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                    } );
+
+                    it( "can take an array of actions and generate all except those routes", function() {
+                        ses.addResource( name = "photos", except = [ "create", "edit", "update", "delete" ] );
+
+                        var cl = ses.$callLog().addRoute;
+                        debug( cl );
+
+                        expect( cl ).toHaveLength( 3, "addRoute should have been called 3 times" );
+                        expect( cl[ 1 ] ).toBe( { pattern = "/photos/new", handler = "photos", action = { GET = "new" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                        expect( cl[ 2 ] ).toBe( { pattern = "/photos/:id", handler = "photos", action = { GET = "show" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                        expect( cl[ 3 ] ).toBe( { pattern = "/photos", handler = "photos", action = { GET = "index" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                    } );
+                } );
+
+                describe( "using both `only` and `except`", function() {
+                    it( "can apply both the `only` and the `except` parameters", function() {
+                        ses.addResource( name = "photos", only = [ "index", "show" ], except = "show" )
+
+                        var cl = ses.$callLog().addRoute;
+                        debug( cl );
+
+                        expect( cl ).toHaveLength( 1, "addRoute should have been called 1 time" );
+                        expect( cl[ 1 ] ).toBe( { pattern = "/photos", handler = "photos", action = { GET = "index" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                    } );
+                } );
+            } );
+
+            it( "can override the parameterName used", function() {
+                ses.addResource( name = "photos", parameterName = "photoId" );
+
+                var cl = ses.$callLog().addRoute;
+                debug( cl );
+
+                expect( cl ).toHaveLength( 4, "addRoute should have been called 4 times" );
+                expect( cl[ 1 ] ).toBe( { pattern = "/photos/:photoId/edit", handler = "photos", action = { GET = "edit" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                expect( cl[ 2 ] ).toBe( { pattern = "/photos/new", handler = "photos", action = { GET = "new" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                expect( cl[ 3 ] ).toBe( { pattern = "/photos/:photoId", handler = "photos", action = { GET = "show", PUT = "update", PATCH = "update", DELETE = "delete" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+                expect( cl[ 4 ] ).toBe( { pattern = "/photos", handler = "photos", action = { GET = "index", POST = "create" } }, "The route did not match.  Remember that order matters.  Add the most specific routes first." );
+            } );
+
+            it( "returns itself to continue chaining", function() {
+                var result = ses.addResource( "photos" );
+
+                expect( result ).toBe( ses );
+            } );
+        } );
+    }
+
+}


### PR DESCRIPTION
Let me know if we're good on this and I'll get a pull request going for the docs as well. Thanks to @elpete for a lot of help on this one.

`addResource` is a method for quickly scaffolding the RESTful routes for a resource

Calling `addResource( "photos" )` would create the following routes: ([taken from the Rails Routing Guide](http://edgeguides.rubyonrails.org/routing.html))

HTTP Verb | Path | Handler.Action | Used For
----------- | -----| ---------------|----------------
GET | /photos | photos.index | Display a list of photos.
GET | /photos/new | photos.new | Return an HTML form for creating a new photo.
POST | /photos | photos.create | Create a new photo.
GET | /photos/:id | photos.show | Display a specific photo.
GET | /photos/:id/edit | photos.edit | Return an HTML form for editing a photo.
PATCH/PUT | /photos/:id | photos.update | Update a specific photo
DELETE | /photos/:id | photos.delete | Delete a specific photo

The `addResource` method has the following attributes:

* The first parameter `name` is required and is the name of the resource. This name will be used for the url path and handler name by default.
* The handler name can be overridden by passing it in as the second argument `handler`. By default, it is the same name as the resource name.
  * i.e. `addResource( name = "photos", handler = "PhotosController", only = "index" )` would generate the route `/photos` that runs the event `PhotosController.index`.
* The `id` placeholder can be overridden by passing in the desired name to the `parameterName` argument.
  * i.e. `addResource( name = "photos", parameterName = "photoId", only = "show" )` would generate the `/photos/:photoId` route.
* It can take an optional list or array of actions as the `only` parameter. If provided, these are the only actions that will be generated.
  * i.e. `addResource( name = "photos", only = "index,show" )` would generate `/photos` and `/photos/:id` routes.
* It can take an optional list or array of actions as the `except` parameter. If provided, these actions will not be generated.
  * i.e. `addResource( name = "photos", except = [ "new", "create", "edit", "update", "destroy" ] )` would generate `/photos` and `/photos/:id` routes.
* If both `only` and `except` are provided, both will be applied.
  * i.e. `addResource( name = "photos", only = "index,show", except="show" )` would generate the `/photos` route.

The tests are implemented in `tests.specs.interceptors.SESAddResourceTest`.