### PR TITLE
Add only method to filter to only desired keys

### DIFF
--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -1215,15 +1215,20 @@ component serializable=false accessors="true"{
     	return ( getHTTPHeader( "X-Requested-With", "" ) eq "XMLHttpRequest" );
 	}
 
-	struct function only( required keys ) {
-		if ( isSimpleValue( keys ) ) {
-			arguments.keys = listToArray( keys );
+	/**
+	* Filters the collection or private collection down to only the provided keys.
+	* @keys A list or array of keys to bring back from the collection or private collection.
+	* @private Private or public, defaults public.
+	*/
+	struct function only( required keys, boolean private = false ){
+		if ( isSimpleValue( arguments.keys ) ){
+			arguments.keys = listToArray( arguments.keys );
 		}
 
 		var returnStruct = {};
-		for ( var key in keys ) {
-			if ( valueExists( key ) ) {
-				returnStruct[ key ] = getValue( key );
+		for ( var key in arguments.keys ){
+			if ( valueExists( key, private ) ){
+				returnStruct[ key ] = getValue( name = key, private = private );
 			}
 		}
 

--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -1215,6 +1215,21 @@ component serializable=false accessors="true"{
     	return ( getHTTPHeader( "X-Requested-With", "" ) eq "XMLHttpRequest" );
 	}
 
+	struct function only( required keys ) {
+		if ( isSimpleValue( keys ) ) {
+			arguments.keys = listToArray( keys );
+		}
+
+		var returnStruct = {};
+		for ( var key in keys ) {
+			if ( valueExists( key ) ) {
+				returnStruct[ key ] = getValue( key );
+			}
+		}
+
+		return returnStruct;
+	}
+
 	/************************************** RESTFUL *********************************************/
 
 	/**

--- a/tests/specs/web/context/requestcontextTest.cfc
+++ b/tests/specs/web/context/requestcontextTest.cfc
@@ -516,4 +516,15 @@
 			.toBe( { "name" = "John", "email" = "john@example.com" } );
 	}
 
+	function testOnlyPrivate() {
+		var event = getRequestContext();
+		event.setValue( "name", "John" );
+		event.setValue( "hackedField", "hacked!" );
+		event.setValue( "name", "Jane", true );
+		event.setValue( "hackedField", "hacked as well!", true );
+
+		expect( event.only( keys = "name,field-that-does-not-exist", private = true ) )
+			.toBe( { "name" = "Jane" } );	
+	}
+
 }

--- a/tests/specs/web/context/requestcontextTest.cfc
+++ b/tests/specs/web/context/requestcontextTest.cfc
@@ -496,4 +496,24 @@
 		debug( link );
 	}
 
+	function testOnlyArray() {
+		var event = getRequestContext();
+		event.setValue( "name", "John" );
+		event.setValue( "email", "john@example.com" );
+		event.setValue( "hackedField", "hacked!" );
+
+		expect( event.only( [ "name", "email", "field-that-does-not-exist" ] ) )
+			.toBe( { "name" = "John", "email" = "john@example.com" } );
+	}
+
+	function testOnlyList() {
+		var event = getRequestContext();
+		event.setValue( "name", "John" );
+		event.setValue( "email", "john@example.com" );
+		event.setValue( "hackedField", "hacked!" );
+
+		expect( event.only( "name,email,field-that-does-not-exist" ) )
+			.toBe( { "name" = "John", "email" = "john@example.com" } );
+	}
+
 }


### PR DESCRIPTION
The `only` method lets you whitelist the keys you want returned from the request context.

Usage:

```
rc = { "email" = "john@example.com", "password" = "pass1234" };
var fields = event.only( [ "email", "username" ] );
// fields = { "email" = "john@example.com" };
```