### PR TITLE
Add new request context dsl injection.

### DIFF
--- a/system/ioc/dsl/ColdBoxDSL.cfc
+++ b/system/ioc/dsl/ColdBoxDSL.cfc
@@ -102,17 +102,6 @@ Description :
 							// just get setting
 							return instance.coldbox.getSetting( thisLocationKey );
 						}
-						case "requestContext"       : {
-							if ( thisLocationKey == "rc" ) {
-								return instance.coldbox.getRequestService().getContext().getCollection();
-							}
-							else if ( thisLocationKey == "prc" ) {
-								return instance.coldbox.getRequestService().getContext().getPrivateCollection();
-							}
-							else {
-								instance.log.debug( "The collection type requested: #thisLocationKey# does not exist in the request context. Valid collection types are [rc, prc]." );
-							}
-					    }
 						case "modulesettings"		: {
 							moduleSettings = instance.coldbox.getSetting("modules");
 							if( structKeyExists(moduleSettings, thisLocationKey ) ){

--- a/system/ioc/dsl/ColdBoxDSL.cfc
+++ b/system/ioc/dsl/ColdBoxDSL.cfc
@@ -83,7 +83,7 @@ Description :
 
 					break;
 				}
-				//coldobx:{key}:{target} Usually for named factories
+				//coldbox:{key}:{target} Usually for named factories
 				case 3: {
 					thisLocationType = getToken(thisType,2,":");
 					thisLocationKey  = getToken(thisType,3,":");
@@ -102,6 +102,17 @@ Description :
 							// just get setting
 							return instance.coldbox.getSetting( thisLocationKey );
 						}
+						case "requestContext"       : {
+							if ( thisLocationKey == "rc" ) {
+								return instance.coldbox.getRequestService().getContext().getCollection();
+							}
+							else if ( thisLocationKey == "prc" ) {
+								return instance.coldbox.getRequestService().getContext().getPrivateCollection();
+							}
+							else {
+								instance.log.debug( "The collection type requested: #thisLocationKey# does not exist in the request context. Valid collection types are [rc, prc]." );
+							}
+					    }
 						case "modulesettings"		: {
 							moduleSettings = instance.coldbox.getSetting("modules");
 							if( structKeyExists(moduleSettings, thisLocationKey ) ){

--- a/system/ioc/dsl/ColdBoxDSL.cfc
+++ b/system/ioc/dsl/ColdBoxDSL.cfc
@@ -70,9 +70,10 @@ Description :
 					switch( thisLocationKey ){
 						case "flash"		 		: { return instance.coldbox.getRequestService().getFlashScope(); }
 						case "loaderService"		: { return instance.coldbox.getLoaderService(); }
-						case "requestService"		: { return instance.coldbox.getrequestService(); }
-						case "handlerService"		: { return instance.coldbox.gethandlerService(); }
-						case "interceptorService"	: { return instance.coldbox.getinterceptorService(); }
+						case "requestService"		: { return instance.coldbox.getRequestService(); }
+						case "requestContext"		: { return instance.coldbox.getRequestService().getContext(); }
+						case "handlerService"		: { return instance.coldbox.getHandlerService(); }
+						case "interceptorService"	: { return instance.coldbox.getInterceptorService(); }
 						case "moduleService"		: { return instance.coldbox.getModuleService(); }
 						case "renderer"				: { return instance.coldbox.getRenderer(); }
 						case "dataMarshaller"		: { return instance.coldbox.getDataMarshaller(); }

--- a/tests/specs/ioc/dsl/ColdBoxDSLTest.cfc
+++ b/tests/specs/ioc/dsl/ColdBoxDSLTest.cfc
@@ -57,16 +57,22 @@
 		c = builder.getColdBoxDSL(def);
 		assertEquals( this, c);
 
-		mockColdbox.$("getrequestService",this);
+		mockColdbox.$("getRequestService",this);
 		def = {name="configBean", dsl="coldbox:requestService"};
 		c = builder.getColdBoxDSL(def);
 		assertEquals( this, c);
 
 		mockFlash = getMockBox().createEmptyMock("coldbox.system.web.flash.SessionFlash");
-		mockColdbox.$("getrequestService", getMockBox().createStub().$("getFlashScope", mockFlash) );
+		mockColdbox.$("getRequestService", getMockBox().createStub().$("getFlashScope", mockFlash) );
 		def = {name="flash", dsl="coldbox:flash"};
 		c = builder.getColdBoxDSL(def);
 		assertEquals( mockFlash, c);
+
+		mockEvent = getMockBox().createEmptyMock("coldbox.system.web.context.RequestContext");
+		mockColdbox.$("getRequestService", getMockBox().createStub().$("getContext", mockEvent) );
+		def = {name="event", dsl="coldbox:requestContext"};
+		c = builder.getColdBoxDSL(def);
+		assertEquals( mockEvent, c);
 
 		mockColdbox.$("getHandlerService",this);
 		def = {name="configBean", dsl="coldbox:handlerService"};
@@ -94,6 +100,8 @@
 		def = {name="marshaller", dsl="coldbox:dataMarshaller"};
 		c = builder.getColdBoxDSL(def);
 		assertEquals( mockMarshaller, c);
+
+
 	}
 
 	function testgetColdboxDSLStage3(){

--- a/tests/specs/ioc/dsl/ColdBoxDSLTest.cfc
+++ b/tests/specs/ioc/dsl/ColdBoxDSLTest.cfc
@@ -147,6 +147,24 @@
 		c = builder.getColdBoxDSL(def);
 		assertEquals( modSettings.myModule , c);
 
+		// rc
+		var rc = { event = "main.index", format = "html" };
+		var mockEvent = getMockBox().createEmptyMock("coldbox.system.web.context.RequestContext");
+		mockEvent.$( "getCollection", rc );
+		mockColdbox.$( "getRequestService", getMockBox().createStub().$( "getContext", mockEvent ) );
+		def = {name="rc", dsl="coldbox:requestContext:rc"};
+		c = builder.getColdBoxDSL(def);
+		assertEquals( rc , c);
+
+		// prc
+		var prc = { cbox_incomingContextHash = "E421429442BAC5178C6BE0CB3C9796E1" };
+		var mockEvent = getMockBox().createEmptyMock("coldbox.system.web.context.RequestContext");
+		mockEvent.$( "getPrivateCollection", prc );
+		mockColdbox.$( "getRequestService", getMockBox().createStub().$( "getContext", mockEvent ) );
+		def = { name = "prc", dsl = "coldbox:requestContext:prc" };
+		c = builder.getColdBoxDSL( def );
+		assertEquals( prc , c );
+
 		// fwsetting
 		def = {name="mySetting", dsl="coldbox:fwSetting"};
 		mockColdBox.$("getSetting").$args("mySetting",true).$results("UnitTest");

--- a/tests/specs/ioc/dsl/ColdBoxDSLTest.cfc
+++ b/tests/specs/ioc/dsl/ColdBoxDSLTest.cfc
@@ -147,24 +147,6 @@
 		c = builder.getColdBoxDSL(def);
 		assertEquals( modSettings.myModule , c);
 
-		// rc
-		var rc = { event = "main.index", format = "html" };
-		var mockEvent = getMockBox().createEmptyMock("coldbox.system.web.context.RequestContext");
-		mockEvent.$( "getCollection", rc );
-		mockColdbox.$( "getRequestService", getMockBox().createStub().$( "getContext", mockEvent ) );
-		def = {name="rc", dsl="coldbox:requestContext:rc"};
-		c = builder.getColdBoxDSL(def);
-		assertEquals( rc , c);
-
-		// prc
-		var prc = { cbox_incomingContextHash = "E421429442BAC5178C6BE0CB3C9796E1" };
-		var mockEvent = getMockBox().createEmptyMock("coldbox.system.web.context.RequestContext");
-		mockEvent.$( "getPrivateCollection", prc );
-		mockColdbox.$( "getRequestService", getMockBox().createStub().$( "getContext", mockEvent ) );
-		def = { name = "prc", dsl = "coldbox:requestContext:prc" };
-		c = builder.getColdBoxDSL( def );
-		assertEquals( prc , c );
-
 		// fwsetting
 		def = {name="mySetting", dsl="coldbox:fwSetting"};
 		mockColdBox.$("getSetting").$args("mySetting",true).$results("UnitTest");


### PR DESCRIPTION
To get the request-scoped instance, simply use the provider: `coldbox:requestContext`.

If you are using this in anything other than request-scoped or other transient-scoped, use a provider: `provider:coldbox:requestContext`.  A reminder that methods will be forwarded on to the provided instance.  That means:

```cfc
component {
    property name="event" inject="provider:coldbox:requestContext";

    function doStuff() {
        var rc = event.getCollection();
        // same as
        var rc = event.get().getCollection();
    }
}
```

works just fine, with or without calling `get` first.