### PR TITLE
Reset the response when calling setup

### DIFF
--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -123,6 +123,7 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 			}
 			// remove context
 			getController().getRequestService().removeContext();
+			getPageContext().getResponse().reset();
 		}
 	}
 


### PR DESCRIPTION
In order to prevent things like duplicate headers, reset the response when calling setup in between tests.