### PR TITLE
Ensure modules are only activated once, even if it is a child module of one of its dependencies.

### DIFF
--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -424,6 +424,15 @@ component extends="coldbox.system.web.services.BaseService"{
 			activateModule( thisDependency );
 		}
 
+		// Check if activating one of this module's dependencies already activated this module
+		if( modules[ arguments.moduleName ].activated ){
+			// Log it
+			if( variables.logger.canDebug() ){
+				variables.logger.debug( "Module #arguments.moduleName# already activated during dependecy activation, skipping activation." );
+			}
+			return this;
+		}
+
 		// lock and load baby
 		lock 	name="module#getController().getAppHash()#.activation.#arguments.moduleName#"
 				type="exclusive" 

--- a/test-harness/modules/Inception/modules/a-inception/ModuleConfig.cfc
+++ b/test-harness/modules/Inception/modules/a-inception/ModuleConfig.cfc
@@ -1,0 +1,81 @@
+component {
+
+	// Module Properties
+	this.title 				= "a-inception";
+	this.author 			= "Luis Majano";
+	this.webURL 			= "http://www.ortussolutions.com";
+	this.description 		= "Inception child module";
+	this.version			= "1.0.0";
+	// If true, looks for views in the parent first, if not found, then in the module. Else vice-versa
+	this.viewParentLookup 	= true;
+	// If true, looks for layouts in the parent first, if not found, then in module. Else vice-versa
+	this.layoutParentLookup = true;
+	// Module Entry Point
+	this.entryPoint			= "a-inception";
+	// Model Namespace
+	this.modelNamespace		= "";
+	// Auto Map Models Directory
+	this.autoMapModels		= true;
+	// CF Mapping
+	this.cfmapping			= "";
+	this.dependencies       = [ "Inception" ];
+
+	function configure(){
+
+		// parent settings
+		parentSettings = {
+
+		};
+
+		// module settings - stored in modules.name.settings
+		settings = {
+
+		};
+
+		// Layout Settings
+		layoutSettings = {
+			defaultLayout = ""
+		};
+
+		// datasources
+		datasources = {
+
+		};
+
+		// SES Routes
+		routes = [
+			// Module Entry Point
+			{pattern="/", handler="home",action="index"},
+			// Convention Route
+			{pattern="/:handler/:action?"}
+		];
+
+		// Custom Declared Points
+		interceptorSettings = {
+			customInterceptionPoints = ""
+		};
+
+		// Custom Declared Interceptors
+		interceptors = [
+		];
+
+		// Binder Mappings
+		// binder.map("Alias").to("#moduleMapping#.model.MyService");
+		request[ "a-inception" ] = { "loadedCount" = 0 };
+	}
+
+	/**
+	* Fired when the module is registered and activated.
+	*/
+	function onLoad(){
+		request[ "a-inception" ].loadedCount++;
+	}
+
+	/**
+	* Fired when the module is unregistered and unloaded
+	*/
+	function onUnload(){
+
+	}
+
+}

--- a/test-harness/modules/Inception/modules/a-inception/handlers/Home.cfc
+++ b/test-harness/modules/Inception/modules/a-inception/handlers/Home.cfc
@@ -1,0 +1,10 @@
+/**
+* A normal ColdBox Event Handler
+*/
+component{
+
+	function index(event,rc,prc){
+		event.setView("home/index");
+	}
+
+}

--- a/test-harness/modules/Inception/modules/a-inception/views/home/index.cfm
+++ b/test-harness/modules/Inception/modules/a-inception/views/home/index.cfm
@@ -1,0 +1,1 @@
+<h1>Welcome to my inception child module page!</h1>

--- a/tests/specs/integration/ModuleTests.cfc
+++ b/tests/specs/integration/ModuleTests.cfc
@@ -93,7 +93,7 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/cbTestHarne
 				expect( parentSettings[ "test1" ] ).notToBe( config[ "test1" ].settings );
 			} );
 
-			it( "should not load mdoules that have been excluded, even in bundles", function(){
+			it( "should not load modules that have been excluded, even in bundles", function(){
 				var config = getController().getSetting( "modules" );
 				expect(	config ).notToHaveKey( 'excludedmod' );
 			});

--- a/tests/specs/integration/ModuleTests.cfc
+++ b/tests/specs/integration/ModuleTests.cfc
@@ -109,6 +109,15 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/cbTestHarne
 				});
 			});
 
+			given( "A nested module: a-inception", function(){
+				then( "the nested module should only have its onLoad method called once", function(){
+					expect( request ).toHaveKey( "a-inception" );
+					expect( request[ "a-inception" ] ).toBeStruct();
+					expect( request[ "a-inception" ] ).toHaveKey( "loadedCount" );
+					expect( request[ "a-inception" ].loadedCount ).toBe( 1, "Module onLoad should only have been called once." );
+				});
+			});
+
 			given( "A nested module: inception with a 'modules_app' convention", function(){
 				then( "it should load and activate its sub-modules", function(){
 					var config = getController().getSetting( "modules" );


### PR DESCRIPTION
Fixes [COLDBOX-604](https://ortussolutions.atlassian.net/browse/COLDBOX-604)