### PR TITLE
Add helpers for render data and status code to integration testing

### DIFF
--- a/system/testing/mock/web/context/MockRequestContext.cfc
+++ b/system/testing/mock/web/context/MockRequestContext.cfc
@@ -6,38 +6,40 @@
 */
 component extends="coldbox.system.web.context.RequestContext" serializable=false accessors="true"{
 
-	/**
-	* Set an HTTP Header
-	* @statusCode.hint the status code
-	* @statusText.hint the status text
-	* @name.hint The header name
-	* @value.hint The header value
-	* @charset.hint The charset to use, defaults to UTF-8
-	*
-	* return RequestContext
-	*/
-	function setHTTPHeader(
-		statusCode,
-		statusText="",
-		name,
-		value=""
-	){
-		// status code?
-		if( structKeyExists( arguments, "statusCode" ) ){
+    /**
+    * Set an HTTP Header
+    * @statusCode.hint the status code
+    * @statusText.hint the status text
+    * @name.hint The header name
+    * @value.hint The header value
+    * @charset.hint The charset to use, defaults to UTF-8
+    *
+    * return RequestContext
+    */
+    function setHTTPHeader(
+        statusCode,
+        statusText="",
+        name,
+        value=""
+    ){
+        // status code?
+        if( structKeyExists( arguments, "statusCode" ) ){
             setValue( "cbox_statusCode", arguments.statusCode );
-		}
-		// Name Exists
-		else if( structKeyExists( arguments, "name" ) ){
+        }
+        // Name Exists
+        else if( structKeyExists( arguments, "name" ) ){
             var headers = getValue( "cbox_headers", {} );
             headers[ lcase( arguments.name ) ] = arguments.value;
             setValue( "cbox_headers", headers );
-		} else {
-			throw( message="Invalid header arguments",
-				  detail="Pass in either a statusCode or name argument",
-				  type="RequestContext.InvalidHTTPHeaderParameters" );
-		}
+        } else {
+            throw(
+                message="Invalid header arguments",
+                detail="Pass in either a statusCode or name argument",
+                type="RequestContext.InvalidHTTPHeaderParameters"
+            );
+        }
 
-		return this;
-	}
+        return this;
+    }
 
 }

--- a/system/testing/mock/web/context/MockRequestContext.cfc
+++ b/system/testing/mock/web/context/MockRequestContext.cfc
@@ -1,0 +1,43 @@
+/**
+* Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
+* www.ortussolutions.com
+* ---
+* A mock request context used for integration testing via TestBox
+*/
+component extends="coldbox.system.web.context.RequestContext" serializable=false accessors="true"{
+
+	/**
+	* Set an HTTP Header
+	* @statusCode.hint the status code
+	* @statusText.hint the status text
+	* @name.hint The header name
+	* @value.hint The header value
+	* @charset.hint The charset to use, defaults to UTF-8
+	*
+	* return RequestContext
+	*/
+	function setHTTPHeader(
+		statusCode,
+		statusText="",
+		name,
+		value=""
+	){
+		// status code?
+		if( structKeyExists( arguments, "statusCode" ) ){
+            setValue( "cbox_statusCode", arguments.statusCode );
+		}
+		// Name Exists
+		else if( structKeyExists( arguments, "name" ) ){
+            var headers = getValue( "cbox_headers", {} );
+            headers[ lcase( arguments.name ) ] = arguments.value;
+            setValue( "cbox_headers", headers );
+		} else {
+			throw( message="Invalid header arguments",
+				  detail="Pass in either a statusCode or name argument",
+				  type="RequestContext.InvalidHTTPHeaderParameters" );
+		}
+
+		return this;
+	}
+
+}

--- a/system/web/services/RequestService.cfc
+++ b/system/web/services/RequestService.cfc
@@ -34,7 +34,7 @@ component extends="coldbox.system.web.services.BaseService"{
 		variables.templateCache			= controller.getCache( "template" );
 		variables.flashData 			= controller.getSetting( "flash" );
 		variables.flashDataHash			= hash( variables.flashData.toString() );
-		
+
 		// build out Flash RAM
 		buildFlashScope();
 	}
@@ -98,7 +98,7 @@ component extends="coldbox.system.web.services.BaseService"{
 
 	/**
 	 * Tests if the incoming context is an event cache
-	 * 
+	 *
 	 * @context The request context to test for event caching
 	 * @context.docbox_generic coldbox.system.web.context.RequestContext
 	 * @fwCache Flag to hard purge the cache if needed
@@ -150,18 +150,20 @@ component extends="coldbox.system.web.services.BaseService"{
 
 	/**
 	 * Get the Request context from request scope or create a new one.
-	 * 
+	 *
 	 * @return coldbox.system.web.context.RequestContext
 	 */
-	function getContext(){
-		return ( request.cb_requestContext ?: createContext() );
+	function getContext( string classPath = "coldbox.system.web.context.RequestContext" ){
+        return ( request.keyExists( "cb_requestContext" ) ?
+            request[ "cb_requestContext" ] :
+            createContext( classPath ) );
 	}
 
 	/**
 	 * Set the request context into the request scope
-	 * 
+	 *
 	 * @context Request Context object
-	 * 
+	 *
 	 * @RequestService
 	 */
 	RequestService function setContext( required context ){
@@ -246,11 +248,11 @@ component extends="coldbox.system.web.services.BaseService"{
 	 * Creates a new request context object
 	 * @return coldbox.system.web.context.RequestContext
 	 */
-	function createContext(){
+	function createContext( string classPath = "coldbox.system.web.context.RequestContext" ){
 		var oDecorator = "";
 
-		// Create the original request context
-		var oContext = new coldbox.system.web.context.RequestContext( properties=controller.getConfigSettings(), controller=controller );
+        // Create the original request context
+		var oContext = createObject( "component", classPath ).init( properties=controller.getConfigSettings(), controller=controller );
 
 		// Determine if we have a decorator, if we do, then decorate it.
 		if ( len( controller.getSetting( name="RequestContextDecorator", defaultValue="" ) ) ){


### PR DESCRIPTION
This allows easy access to the status code set during the event execution
as well as other render data properties.