### PR TITLE
Add check for eCacheEntry.provider key

### DIFF
--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -199,6 +199,9 @@ component serializable="false" accessors="true"{
 
 			// Verify if event caching item is in selected cache
 			if( structKeyExists( eCacheEntry, "cachekey" ) ){
+				if( !structKeyExists( eCacheEntry, "provider" ) ){
+					eCacheEntry[ "provider" ] = "template";
+				}
 				refResults.eventCaching = cacheBox
 					.getCache( eCacheEntry.provider )
 					.get( eCacheEntry.cacheKey );


### PR DESCRIPTION
Ensures support for backward compatibility until `HandlerService.cfc:209` and `RequestService.cfc:139` are updated to set the provider.