### PR TITLE
Set default status code for invalid event and exceptions

### DIFF
--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -327,15 +327,25 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 	}
 
 	/**
-	* Executes a framework lifecycle by executing an event.  This method returns a request context object that can be used for assertions
-	* @event The event to execute (e.g. 'main.index')
-    * @route The route to execute (e.g. '/login' which may route to 'sessions.new')
-	* @private Call a private event or not
-	* @prePostExempt If true, pre/post handlers will not be fired.
-	* @eventArguments A collection of arguments to passthrough to the calling event handler method
-	* @renderResults If true, then it will try to do the normal rendering procedures and store the rendered content in the RC as cbox_rendered_content
+    * Executes a framework lifecycle by executing an event.
+    * This method returns a request context object that
+    * is decorated and can be used for assertions.
+    *
+	* @event                 The event to execute (e.g. 'main.index')
+    * @route                 The route to execute
+    *                        (e.g. '/login' which may route to 'sessions.new')
+	* @private               Call a private event or not.
+	* @prePostExempt         If true, pre/post handlers will not be fired.
+    * @eventArguments        A collection of arguments to passthrough to the
+    *                        calling event handler method.
+    * @renderResults         If true, then it will try to do the normal
+    *                        rendering procedures and store the rendered content
+    *                        in the RC as cbox_rendered_content.
+    * @withExceptionHandling If true, then ColdBox will process any errors
+    *                        through the exception handling framework instead
+    *                        of just throwing the error. Default: false.
 	*
-	* @return coldbox.system.context.RequestContext
+	* @return                coldbox.system.context.RequestContext
 	*/
 	function execute(
 		string event = "",
@@ -528,6 +538,11 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
         return getValue( "cbox_statusCode", 200 );
     }
 
+    /**
+    * Get the status code set in the CFML engine.
+    *
+    * @return The CFML status code.
+    */
     function getNativeStatusCode() {
         return getPageContextResponse().getStatus();
     }

--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -123,7 +123,7 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 			}
 			// remove context + reset headers
 			getController().getRequestService().removeContext();
-			getPageContext().getResponse().reset();
+			getPageContextResponse().reset();
 		}
 	}
 
@@ -344,7 +344,8 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 		boolean private=false,
 		boolean prePostExempt=false,
 		struct eventArguments={},
-		boolean renderResults=false
+        boolean renderResults=false,
+        boolean withExceptionHandling = false
 	){
 		var handlerResults  = "";
 		var requestContext  = "";
@@ -441,8 +442,9 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 					else if (
 						!isNull( handlerResults )
 					){
-						// Store raw results
-						requestContext.setValue( "cbox_handler_results", handlerResults );
+                        // Store raw results
+                        requestContext.setValue( "cbox_handler_results", handlerResults );
+                        requestContext.setValue( "cbox_statusCode", getNativeStatusCode() );
 						if( isSimpleValue( handlerResults ) ){
 							renderedContent = handlerResults;
 						} else {
@@ -451,6 +453,7 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 					}
 					// render layout/view pair
 					else{
+                        requestContext.setValue( "cbox_statusCode", getNativeStatusCode() );
 						renderedContent = cbcontroller.getRenderer()
 							.renderLayout(module=requestContext.getCurrentLayoutModule(),
 									     viewModule=requestContext.getCurrentViewModule());
@@ -478,6 +481,9 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 			cbController.getInterceptorService().processState( "postProcess" );
 
 		} catch( Any e ) {
+            if ( withExceptionHandling ) {
+                processException( cbController, e );
+            }
 			// Exclude relocations so they can be asserted.
 			if( NOT listFindNoCase( relocationTypes, e.type ) ){
 				rethrow;
@@ -520,7 +526,11 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
     */
     function getStatusCode(){
         return getValue( "cbox_statusCode", 200 );
-    };
+    }
+
+    function getNativeStatusCode() {
+        return getPageContextResponse().getStatus();
+    }
 
 	/**
 	* Announce an interception to the system. If you use the asynchronous facilities, you will get a thread structure report as a result.
@@ -634,5 +644,88 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 
         return queryParams;
     }
+
+    /**
+	* Process an exception and returns a rendered bug report
+	* @controller The ColdBox Controller
+	* @exception The ColdFusion exception
+	*/
+	private string function processException( required controller, required exception ){
+        // prepare exception facade object + app logger
+		var oException	= new coldbox.system.web.context.ExceptionBean( arguments.exception );
+		var appLogger  	= arguments.controller.getLogBox().getLogger( this );
+		var event		= arguments.controller.getRequestService().getContext();
+		var rc 			= event.getCollection();
+		var prc 		= event.getPrivateCollection();
+
+		// Announce interception
+		arguments.controller.getInterceptorService()
+        .processState( "onException", { exception = arguments.exception } );
+
+		// Store exception in private context
+		event.setPrivateValue( "exception", oException );
+
+		// Set Exception Header
+		getPageContextResponse().setStatus( 500, "Internal Server Error" );
+
+		// Run custom Exception handler if Found, else run default exception routines
+		if ( len( arguments.controller.getSetting( "ExceptionHandler" ) ) ){
+            try{
+                arguments.controller.runEvent( arguments.controller.getSetting( "Exceptionhandler" ) );
+			} catch( Any e ) {
+                // Log Original Error First
+				appLogger.error( "Original Error: #arguments.exception.message# #arguments.exception.detail# ", arguments.exception );
+				// Log Exception Handler Error
+				appLogger.error( "Error running exception handler: #arguments.controller.getSetting( "ExceptionHandler" )# #e.message# #e.detail#", e );
+				// rethrow error
+				rethrow;
+			}
+		} else {
+            // Log Error
+			appLogger.error( "Error: #arguments.exception.message# #arguments.exception.detail# ", arguments.exception );
+		}
+
+		// Render out error via CustomErrorTemplate or Core
+		var customErrorTemplate = arguments.controller.getSetting( "CustomErrorTemplate" );
+		if( len( customErrorTemplate ) ){
+			// Get app location path
+			var appLocation 			= "/";
+			if( len( arguments.controller.getSetting( "AppMapping" ) ) ){
+				appLocation = appLocation & arguments.controller.getSetting( "AppMapping" ) & "/";
+			}
+			var bugReportRelativePath 	= appLocation & reReplace( customErrorTemplate, "^/", "" );
+			var bugReportAbsolutePath 	= customErrorTemplate;
+
+			// Show Bug Report
+			savecontent variable="local.exceptionReport"{
+				// Do we have right path already, test by expanding
+				if( fileExists( expandPath( bugReportRelativePath ) ) ){
+					include "#bugReportRelativePath#";
+				} else {
+					include "#bugReportAbsolutePath#";
+				}
+			}
+
+		} else {
+			// Default ColdBox Error Template
+			savecontent variable="local.exceptionReport"{
+				include "/coldbox/system/includes/BugReport-Public.cfm";
+			}
+		}
+
+		return local.exceptionReport;
+    }
+
+    /**
+	* Helper method to deal with ACF2016's overload of the page context response, come on Adobe, get your act together!
+	**/
+	private function getPageContextResponse(){
+        if ( structKeyExists( server, "lucee" ) ) {
+            return getPageContext().getResponse();
+        }
+        else {
+            return getPageContext().getResponse().getResponse();
+        }
+	}
 
 }

--- a/system/web/Controller.cfc
+++ b/system/web/Controller.cfc
@@ -71,7 +71,7 @@ component serializable="false" accessors="true"{
 		variables.services 		= createObject( "java", "java.util.LinkedHashMap" ).init( 6 );
 		// CFML Engine Utility
 		variables.CFMLEngine 	= new coldbox.system.core.util.CFMLEngine();
-		
+
 		// Set Main Application Properties
 		variables.coldboxInitiated 		= false;
 		variables.appKey				= arguments.appKey;
@@ -94,7 +94,7 @@ component serializable="false" accessors="true"{
 		services.handlerService 	= new coldbox.system.web.services.HandlerService( this );
 		services.moduleService 		= new coldbox.system.web.services.ModuleService( this );
 		services.interceptorService = new coldbox.system.web.services.InterceptorService( this );
-		
+
 		// CacheBox Instance
 		variables.cacheBox 	= createObject("component","coldbox.system.cache.CacheFactory");
 		// WireBox Instance
@@ -134,7 +134,7 @@ component serializable="false" accessors="true"{
 	/**
 	* Get a Cache provider from CacheBox
 	* @cacheName The name of the cache to retrieve, or it defaults to the 'default' cache.
-	* 
+	*
 	* @return coldbox.system.cache.IColdboxApplicationCache
 	*/
 	function getCache( required cacheName='default' ){
@@ -216,7 +216,7 @@ component serializable="false" accessors="true"{
 	* Set a value in the application configuration settings
 	* @name The name of the setting
 	* @value The value to set
-	* 
+	*
 	* @return Controller
 	*/
 	function setSetting( required name, required value ){
@@ -268,20 +268,20 @@ component serializable="false" accessors="true"{
 	* @URL The full URL you would like to relocate to instead of an event: ex: URL='http://www.google.com'
 	* @URI The relative URI you would like to relocate to instead of an event: ex: URI='/mypath/awesome/here'
 	* @statusCode The status code to use in the relocation
-	* 
+	*
 	* @return Controller
 	*/
 	function relocate(
-		event=getSetting( "DefaultEvent" ), 
-		queryString="", 
-		boolean addToken=false, 
+		event=getSetting( "DefaultEvent" ),
+		queryString="",
+		boolean addToken=false,
 		persist="",
 		struct persistStruct=structnew()
-		boolean ssl, 
-		baseURL="", 
-		boolean postProcessExempt=false, 
-		URL, 
-		URI, 
+		boolean ssl,
+		baseURL="",
+		boolean postProcessExempt=false,
+		URL,
+		URI,
 		numeric statusCode=0
 	){
 		// Determine the type of relocation
@@ -293,23 +293,23 @@ component serializable="false" accessors="true"{
 		var routeString     = 0;
 
 		// Determine relocation type
-		if( oRequestContext.isSES() ){ 
-			relocationType = "SES"; 
+		if( oRequestContext.isSES() ){
+			relocationType = "SES";
 		}
-		if( structKeyExists( arguments, "URL" ) ){ 
-			relocationType = "URL"; 
+		if( structKeyExists( arguments, "URL" ) ){
+			relocationType = "URL";
 		}
-		if( structKeyExists( arguments, "URI" ) ){ 
-			relocationType = "URI"; 
+		if( structKeyExists( arguments, "URI" ) ){
+			relocationType = "URI";
 		}
 
 		// Cleanup event string to default if not sent in
-		if( len( trim( arguments.event ) ) eq 0 ){ 
-			arguments.event = getSetting( "DefaultEvent" ); 
+		if( len( trim( arguments.event ) ) eq 0 ){
+			arguments.event = getSetting( "DefaultEvent" );
 		}
 		// Overriding Front Controller via baseURL argument
-		if( len( trim( arguments.baseURL ) ) ){ 
-			frontController = arguments.baseURL; 
+		if( len( trim( arguments.baseURL ) ) ){
+			frontController = arguments.baseURL;
 		}
 
 		// Relocation Types
@@ -445,7 +445,7 @@ component serializable="false" accessors="true"{
 
 			// Test if entry found in cache, and return if found.
 			var data = oCache.get( cacheKey );
-			if( !isNull( data ) ){ 
+			if( !isNull( data ) ){
 				return data;
 			}
 		}
@@ -454,14 +454,14 @@ component serializable="false" accessors="true"{
 		var results = _runEvent( argumentCollection=arguments );
 
 		// Do we have an object coming back?
-		if( 
-			!isNull( results.data ) && 
+		if(
+			!isNull( results.data ) &&
 			isObject( results.data  )
 		){
 			// Ignore, if request context
 			if( isInstanceOf( results.data, "coldbox.system.web.context.RequestContext" )){
 				results.delete( "data" );
-			} 
+			}
 			else if( structKeyExists( results.data, "$renderdata" ) ){
 				results.data = results.data.$renderdata();
 			}
@@ -481,7 +481,7 @@ component serializable="false" accessors="true"{
 
 		// Are we caching
 		if( isCachingOn && !isNull( results.data ) ){
-			oCache.set( 
+			oCache.set(
 				objectKey			= cacheKey,
 				object 				= results.data,
 				timeout 			= arguments.cacheTimeout,
@@ -505,7 +505,7 @@ component serializable="false" accessors="true"{
 	* @eventArguments A collection of arguments to passthrough to the calling event handler method
 	*
 	* @throws InvalidHTTPMethod
-	* 
+	*
 	* @return struct { data:event handler returned data (null), ehBean:event handler bean representation that was fired }
 	*/
 	private function _runEvent(
@@ -549,13 +549,13 @@ component serializable="false" accessors="true"{
 			.setIsPrivate( arguments.private );
 
 		// Validate this is not a view dispatch, else return for rendering
-		if( results.ehBean.getViewDispatch() ){	
-			return results;	
+		if( results.ehBean.getViewDispatch() ){
+			return results;
 		}
 
 		// Now get the correct handler to execute
 		var oHandler = services.handlerService.getHandler( results.ehBean, oRequestContext );
-		
+
 		// Validate again this is not a view dispatch as the handler might exist but not the action
 		if( results.ehBean.getViewDispatch() ){	return results;	}
 
@@ -569,18 +569,22 @@ component serializable="false" accessors="true"{
 			// Determine if it is An allowed HTTP method to execute, else throw error
 			if( NOT structIsEmpty( oHandler.allowedMethods ) AND
 				structKeyExists( oHandler.allowedMethods, results.ehBean.getMethod() ) AND
-				NOT listFindNoCase( oHandler.allowedMethods[ results.ehBean.getMethod() ], oRequestContext.getHTTPMethod() ) 
+				NOT listFindNoCase( oHandler.allowedMethods[ results.ehBean.getMethod() ], oRequestContext.getHTTPMethod() )
 			){
+                oRequestContext.setHTTPHeader(
+					statusCode = 405,
+					statusText = "Invalid HTTP Method: '#oRequestContext.getHTTPMethod()#'"
+				);
 				// set Invalid HTTP method in context
 				oRequestContext.setIsInvalidHTTPMethod();
 				// Do we have a local handler for this exception, if so, call it
 				if( oHandler._actionExists( "onInvalidHTTPMethod" ) ){
-					results.data = oHandler.onInvalidHTTPMethod( 
+					results.data = oHandler.onInvalidHTTPMethod(
 						event			= oRequestContext,
 						rc				= args.rc,
 						prc				= args.prc,
 						faultAction		= results.ehBean.getmethod(),
-						eventArguments	= arguments.eventArguments 
+						eventArguments	= arguments.eventArguments
 					);
 					return results;
 				}
@@ -591,11 +595,7 @@ component serializable="false" accessors="true"{
 				}
 
 				// Throw Exception, no handlers defined
-				oRequestContext.setHTTPHeader( 
-					statusCode = 405,
-					statusText = "Invalid HTTP Method: '#oRequestContext.getHTTPMethod()#'"
-				);
-				throw( 
+				throw(
 					message		= "Invalid HTTP Method: '#oRequestContext.getHTTPMethod()#'",
 					detail		= "The requested event: #arguments.event# cannot be executed using the incoming HTTP request method '#oRequestContext.getHTTPMethod()#'",
 					type		= "InvalidHTTPMethod"
@@ -609,11 +609,11 @@ component serializable="false" accessors="true"{
 					return _runEvent( event = getSetting( "invalidHTTPMethodHandler" ) );
 				}
 				// Throw Exception, no handlers defined
-				oRequestContext.setHTTPHeader( 
+				oRequestContext.setHTTPHeader(
 					statusCode = 405,
 					statusText = "Invalid HTTP Method: '#oRequestContext.getHTTPMethod()#'"
 				);
-				throw( 
+				throw(
 					message		= "Invalid HTTP Method: '#oRequestContext.getHTTPMethod()#'",
 					detail		= "The requested URL: #oRequestContext.getCurrentRoutedURL()# cannot be executed using the incoming HTTP request method '#oRequestContext.getHTTPMethod()#'",
 					type		= "InvalidHTTPMethod"
@@ -635,15 +635,15 @@ component serializable="false" accessors="true"{
 				}
 
 				// Execute Pre Handler if it exists and valid?
-				if( oHandler._actionExists( "preHandler" ) AND 
-					validateAction( results.ehBean.getMethod(), oHandler.PREHANDLER_ONLY, oHandler.PREHANDLER_EXCEPT ) 
+				if( oHandler._actionExists( "preHandler" ) AND
+					validateAction( results.ehBean.getMethod(), oHandler.PREHANDLER_ONLY, oHandler.PREHANDLER_EXCEPT )
 				){
-					oHandler.preHandler( 
+					oHandler.preHandler(
 						event          = oRequestContext,
 						rc             = args.rc,
 						prc            = args.prc,
 						action         = results.ehBean.getMethod(),
-						eventArguments = arguments.eventArguments 
+						eventArguments = arguments.eventArguments
 					);
 				}
 
@@ -678,33 +678,33 @@ component serializable="false" accessors="true"{
 				if( oHandler._actionExists( "around#results.ehBean.getMethod()#" ) ){
 					// Add target Action
 					args.targetAction = oHandler[ results.ehBean.getMethod() ];
-					results.data = invoker( 
-						target        = oHandler, 
-						method        = "around#results.ehBean.getMethod()#", 
-						argCollection = args 
+					results.data = invoker(
+						target        = oHandler,
+						method        = "around#results.ehBean.getMethod()#",
+						argCollection = args
 					);
 					// Cleanup: Remove target action from args for post events
 					structDelete( args, "targetAction" );
 				}
 				// Around Handler Advice Check?
-				else if( 
-					oHandler._actionExists( "aroundHandler" ) AND 
-					validateAction( results.ehBean.getMethod(), oHandler.aroundHandler_only, oHandler.aroundHandler_except ) 
+				else if(
+					oHandler._actionExists( "aroundHandler" ) AND
+					validateAction( results.ehBean.getMethod(), oHandler.aroundHandler_only, oHandler.aroundHandler_except )
 				){
 					results.data = oHandler.aroundHandler(
 						event          = oRequestContext,
 						rc             = args.rc,
 						prc            = args.prc,
 						targetAction   = oHandler[ results.ehBean.getMethod() ],
-						eventArguments = arguments.eventArguments 
+						eventArguments = arguments.eventArguments
 					);
 				} else {
 					// Normal execution
-					results.data = invoker( 
-						target        = oHandler, 
-						method        = results.ehBean.getMethod(), 
-						argCollection = argsMain, 
-						private       = arguments.private 
+					results.data = invoker(
+						target        = oHandler,
+						method        = results.ehBean.getMethod(),
+						argCollection = argsMain,
+						private       = arguments.private
 					);
 				}
 			}
@@ -714,17 +714,17 @@ component serializable="false" accessors="true"{
 
 				// Execute post{Action}?
 				if( oHandler._actionExists( "post#results.ehBean.getMethod()#" ) ){
-					invoker( 
-						target        = oHandler, 
-						method        = "post#results.ehBean.getMethod()#", 
-						argCollection = args 
+					invoker(
+						target        = oHandler,
+						method        = "post#results.ehBean.getMethod()#",
+						argCollection = args
 					);
 				}
 
 				// Execute postHandler()?
-				if( 
-					oHandler._actionExists( "postHandler" ) AND 
-					validateAction( results.ehBean.getMethod(), oHandler.POSTHANDLER_ONLY, oHandler.POSTHANDLER_EXCEPT ) 
+				if(
+					oHandler._actionExists( "postHandler" ) AND
+					validateAction( results.ehBean.getMethod(), oHandler.POSTHANDLER_ONLY, oHandler.POSTHANDLER_EXCEPT )
 				){
 					oHandler.postHandler(
 						event          = oRequestContext,
@@ -758,7 +758,7 @@ component serializable="false" accessors="true"{
 	}
 
 	/****************************************** APPLICATION LOCATORS *************************************************/
-	
+
 	/**
 	* Locate the real path location of a file in a coldbox application. 3 checks: 1) inside of coldbox app, 2) expand the path, 3) Absolute location. If path not found, it returns an empty path
 	* @pathToCheck The relative or absolute file path to verify and locate
@@ -808,7 +808,7 @@ component serializable="false" accessors="true"{
 	}
 
 /****************************************** PRIVATE HELPERS *************************************************/
-	
+
 	/**
 	* Load the internal ColdBox settings
 	*/
@@ -865,8 +865,8 @@ component serializable="false" accessors="true"{
 	/**
 	* Invoke private/public event handler methods
 	*/
-	private function invoker( 
-		required any target, 
+	private function invoker(
+		required any target,
 		required method,
 		struct argCollection={},
 		boolean private=false

--- a/system/web/services/HandlerService.cfc
+++ b/system/web/services/HandlerService.cfc
@@ -28,7 +28,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @controller ColdBox Controller
 	 */
 	function init( required controller ){
@@ -92,9 +92,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 	/**
 	 * Asks wirebox for an instance of a handler.  It verifies that there is a mapping in Wirebox for the handler
 	 * if it does not exist, it maps it first and then retrieves it.
-	 * 
+	 *
 	 * @invocationPath The handler invocation path
-	 * 
+	 *
 	 * @return Handler Instance
 	 */
 	function newHandler( required invocationPath ){
@@ -117,7 +117,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 				.setVirtualInheritance( "coldbox.system.EventHandler" )
 				.addDIConstructorArgument( name="controller", value=controller )
 				.setThreadSafe( true )
-				.setScope( 
+				.setScope(
 					variables.handlerCaching ? wirebox.getBinder().SCOPES.SINGLETON : wirebox.getBinder().SCOPES.NOSCOPE
 				)
 				.setCacheProperties( key="handlers-#arguments.invocationPath#" )
@@ -132,7 +132,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 	 * Get a validated handler instance using an event handler bean and context. This is called
 	 * once event execution is in progress.
 	 * Before returning this method verifies method of execution, event caching, invalid events and stores metadata
-	 * 
+	 *
 	 * @ehBean The event handler bean representation
 	 * @requestContext The request context object
 	 */
@@ -157,8 +157,8 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 			}
 
 			// Test for Implicit View Dispatch
-			if( controller.getSetting( "ImplicitViews" ) AND 
-				isViewDispatch( arguments.ehBean.getFullEvent(), arguments.ehBean ) 
+			if( controller.getSetting( "ImplicitViews" ) AND
+				isViewDispatch( arguments.ehBean.getFullEvent(), arguments.ehBean )
 			){
 				return oEventHandler;
 			}
@@ -168,8 +168,8 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 			// If we get here, then the invalid event kicked in and exists, else an exception is thrown
 			// Go retrieve the handler that will handle the invalid event so it can execute.
-			return getHandler( 
-				getHandlerBean( arguments.ehBean.getFullEvent() ), 
+			return getHandler(
+				getHandlerBean( arguments.ehBean.getFullEvent() ),
 				oRequestContext
 			);
 
@@ -183,8 +183,8 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 		/* ::::::::::::::::::::::::::::::::::::::::: EVENT CACHING :::::::::::::::::::::::::::::::::::::::::::: */
 
 		// Event Caching Routines, if using caching, NOT a private event and we are executing the main event
-		if ( 
-			variables.eventCaching AND 
+		if (
+			variables.eventCaching AND
 			!arguments.ehBean.getIsPrivate() AND
 			arguments.ehBean.getFullEvent() EQ oRequestContext.getCurrentEvent()
 		){
@@ -218,9 +218,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 	/**
 	 * Parse the incoming event string into an event handler bean that is used for the current execution context
-	 * 
+	 *
 	 * @event The full event string
-	 * 
+	 *
 	 * @return coldbox.system.web.context.EventHandlerBean
 	 */
 	function getHandlerBean( required string event ){
@@ -291,7 +291,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 	 * the internal handlers list.  If found, then we append the default action to the event.
 	 *
 	 * @event The request context
-	 * 
+	 *
 	 * @return HandlerService
 	 */
 	function defaultActionCheck( required event ){
@@ -303,9 +303,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 		// Module Check?
 		if( find( ":", currentEvent ) ){
 			var module = listFirst( currentEvent, ":" );
-			if( 
-				structKeyExists( modulesConfig, module ) AND 
-				listFindNoCase( modulesConfig[ module ].registeredHandlers, reReplaceNoCase( currentEvent, "^([^:.]*):", "" ) ) 
+			if(
+				structKeyExists( modulesConfig, module ) AND
+				listFindNoCase( modulesConfig[ module ].registeredHandlers, reReplaceNoCase( currentEvent, "^([^:.]*):", "" ) )
 			){
 				// Append the default event action
 				currentEvent = currentEvent & "." & variables.eventAction;
@@ -316,9 +316,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 		}
 
 		// Do a Default Action Test First, if default action desired.
-		if( 
-			listFindNoCase( handlersList, currentEvent ) OR 
-			listFindNoCase( handlersExternalList, currentEvent ) 
+		if(
+			listFindNoCase( handlersList, currentEvent ) OR
+			listFindNoCase( handlersExternalList, currentEvent )
 		){
 			// Append the default event action
 			currentEvent = currentEvent & "." & variables.eventAction;
@@ -329,9 +329,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 		return this;
 	}
 	/**
-	 * Check if the incoming event has a matching implicit view to dispatch. This is usually called 
+	 * Check if the incoming event has a matching implicit view to dispatch. This is usually called
 	 * when there is no existing handler found.
-	 * 
+	 *
 	 * @event The event string
 	 * @ehBean The event handler bean
 	 */
@@ -363,21 +363,26 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 	/**
 	 * Invalid Event procedures
-	 * 
+	 *
 	 * @event The event that was found to be invalid
 	 * @ehBean The event handler bean
-	 * 
+	 *
 	 * @throws EventHandlerNotRegisteredException,InvalidEventHandlerException
-	 * 
+	 *
 	 * @return HandlerService
 	 */
 	function invalidEvent( required string event, required ehBean ){
+        controller.getRequestService().getContext().setHTTPHeader(
+            statusCode = 404,
+            statusText = "Not Found"
+        );
+
 		var iData = {
 			"invalidEvent" 	= arguments.event,
 			"ehBean"		= arguments.ehBean,
 			"override"		= false
 		};
-		variables.interceptorService.processState( "onInvalidEvent", iData );
+        variables.interceptorService.processState( "onInvalidEvent", iData );
 
 		// If the override was changed by the interceptors then they updated the ehBean of execution
 		if( iData.override ){
@@ -389,7 +394,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 			// Test for invalid Event Error as well so we don't go in an endless error loop
 			if ( compareNoCase( variables.invalidEventHandler, arguments.event ) eq 0 ){
-				throw( 
+				throw(
 					message = "The invalidEventHandler event is also invalid",
 					detail  = "The invalidEventHandler setting is also invalid: #variables.invalidEventHandler#. Please check your settings",
 					type    = "HandlerService.InvalidEventHandlerException"
@@ -404,9 +409,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 				.setMethod( listLast( variables.invalidEventHandler, ".") )
 				.setModule( '' );
 			// If module found in invalid event, set it for discovery
-			if( find( ":", variables.invalidEventHandler ) ){ 
-				arguments.ehBean.setModule( getToken( variables.invalidEventHandler, 1 ) ); 
-			}
+			if( find( ":", variables.invalidEventHandler ) ){
+				arguments.ehBean.setModule( getToken( variables.invalidEventHandler, 1 ) );
+            }
 
 			return this;
 		}
@@ -415,17 +420,17 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 		variables.log.error( "Invalid Event detected: #arguments.event#. Path info: #cgi.path_info#, query string: #cgi.query_string#" );
 
 		// Throw Exception
-		throw( 
-			message = "The event: #arguments.event# is not a valid registered event.", 
-			type    = "EventHandlerNotRegisteredException" 
+		throw(
+			message = "The event: #arguments.event# is not a valid registered event.",
+			type    = "EventHandlerNotRegisteredException"
 		);
 	}
 
 	/**
 	 * Register's application event handlers according to convention and external paths
-	 * 
+	 *
 	 * @throws HandlersDirectoryNotFoundException
-	 * 
+	 *
 	 * @return HandlerService
 	 */
 	function registerHandlers(){
@@ -465,7 +470,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 	/**
 	 * Clear the internal cache dictionaries
-	 * 
+	 *
 	 * @return HandlerService
 	 */
 	function clearDictionaries(){
@@ -475,7 +480,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 	/**
 	 * Get an event string's metdata entry. If not found, then you will get a new metadata entry using the `getNewMDEntry()` method.
-	 * 
+	 *
 	 * @targetEvent The event to match for metadata.
 	 */
 	struct function getEventMetadataEntry( required targetEvent ){
@@ -488,7 +493,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 	/**
 	 * Retrieve handler listings from disk
-	 * 
+	 *
 	 * @directory The path to retrieve
 	 */
 	array function getHandlerListing( required directory ){
@@ -516,12 +521,12 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 		return fileArray;
 	}
-	
+
 	/************************************ PRIVATE ************************************/
 
 	/**
 	 * Verifies setup of base handler class in WireBox
-	 * 
+	 *
 	 * @return HandlerService
 	 */
 	private function wireboxSetup(){
@@ -538,7 +543,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 	/**
 	 * Return a new metadata struct object
-	 * 
+	 *
 	 * @return { cacheable:boolean, timeout, lastAccessTimeout, cacheKey, suffix }
 	 */
 	 private struct function getNewMDEntry(){
@@ -554,10 +559,10 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 	/**
 	 * Return the event caching metadata for an action execution context.
-	 * 
+	 *
 	 * @ehBean The event handler bean
 	 * @oEventHandler The event handler to execute
-	 * 
+	 *
 	 * @return strc
 	 */
 	private struct function getEventCachingMetadata( required ehBean, required oEventHandler ){
@@ -565,9 +570,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 		// Double lock for race conditions
 		if( !structKeyExists( variables.eventCacheDictionary, cacheKey ) ){
-			lock 	name="handlerservice.#controller.getAppHash()#.eventcachingmd.#cacheKey#" 
+			lock 	name="handlerservice.#controller.getAppHash()#.eventcachingmd.#cacheKey#"
 					type="exclusive"
-					throwontimeout="true" 
+					throwontimeout="true"
 					timeout="10"
 			{
 				if ( !structKeyExists( variables.eventCacheDictionary, cacheKey) ){
@@ -580,7 +585,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 						mdEntry.timeout 			= arguments.ehBean.getActionMetadata( "cacheTimeout", "" );
 						mdEntry.lastAccessTimeout 	= arguments.ehBean.getActionMetadata( "cacheLastAccessTimeout", "" );
 						mdEntry.provider 		 	= arguments.ehBean.getActionMetadata( "cacheProvider", "template" );
-						
+
 						// Handler Event Cache Key Suffix, this is global to the event
 						if( isClosure( arguments.oEventHandler.EVENT_CACHE_SUFFIX ) ){
 							mdEntry.suffix = oEventHandler.EVENT_CACHE_SUFFIX( arguments.ehBean );
@@ -589,7 +594,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 						}
 
 					} //end cache metadata is true
-					
+
 					// Save md Entry in dictionary
 					variables.eventCacheDictionary[ cacheKey ] = mdEntry;
 				}//end of md cache dictionary.

--- a/test-harness/handlers/main.cfc
+++ b/test-harness/handlers/main.cfc
@@ -1,4 +1,4 @@
-﻿component{
+component{
 
 	this.allowedMethods = {
 		"index" = "GET"
@@ -22,7 +22,11 @@
 	function testUnload( event, rc, prc ){
 		controller.getModuleService().unload( "conventionsTest" );
 		return "unloaded conventions";
-	}
+    }
+
+    function throwException( event, rc, prc ) {
+        throw( "Whoops!" );
+    }
 
 	/**
 	 * Global invalid http method handler
@@ -60,7 +64,7 @@
 	}
 
 	function onInvalidEvent( event, rc, prc ){
-		event.renderData( data="<h1>Invalid Page</h1>" );
+		event.renderData( data="<h1>Invalid Page</h1>", statusCode = 404 );
 	}
 
 	function onRequestStart( event, rc, prc ){

--- a/test-harness/handlers/main.cfc
+++ b/test-harness/handlers/main.cfc
@@ -15,7 +15,7 @@
 		prc.aRoutes          = getInterceptor( "SES", true ).getRoutes();
 		prc.aModuleRoutes    = getInterceptor( "SES", true ).getModuleRoutingTable();
 		prc.aNamespaceRoutes = getInterceptor( "SES", true ).getNamespaceRoutingTable();
-		
+
 		event.setView( "main/routes" );
 	}
 
@@ -28,7 +28,6 @@
 	 * Global invalid http method handler
 	 */
 	function invalidHTTPMethod( event, rc, prc ){
-		event.setHTTPHeader( statusCode=405, statusText="invalid http method" );
 		return "invalid http: #event.getCurrentEvent()#";
 	}
 
@@ -61,8 +60,7 @@
 	}
 
 	function onInvalidEvent( event, rc, prc ){
-		event.setHTTPHeader( statusCode="404", statusText="InvalidPage")
-			.renderData( data="<h1>Invalid Page</h1>" );
+		event.renderData( data="<h1>Invalid Page</h1>" );
 	}
 
 	function onRequestStart( event, rc, prc ){

--- a/tests/specs/integration/EventExecutions.cfc
+++ b/tests/specs/integration/EventExecutions.cfc
@@ -1,10 +1,10 @@
 /*******************************************************************************
-*	Integration Test as BDD  
+*	Integration Test as BDD
 *
 *	Extends the integration class: coldbox.system.testing.BaseTestCase
 *
-*	so you can test your ColdBox application headlessly. The 'appMapping' points by default to 
-*	the '/root' mapping created in the test folder Application.cfc.  Please note that this 
+*	so you can test your ColdBox application headlessly. The 'appMapping' points by default to
+*	the '/root' mapping created in the test folder Application.cfc.  Please note that this
 *	Application.cfc must mimic the real one in your root, including ORM settings if needed.
 *
 *	The 'execute()' method is used to execute a ColdBox event, with the following arguments
@@ -15,7 +15,7 @@
 *	* renderResults : Render back the results of the event
 *******************************************************************************/
 component extends="coldbox.system.testing.BaseTestCase" appMapping="/cbTestHarness"{
-	
+
 	/*********************************** LIFE CYCLE Methods ***********************************/
 
 	function beforeAll(){
@@ -29,7 +29,7 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/cbTestHarne
 	}
 
 /*********************************** BDD SUITES ***********************************/
-	
+
 	function run(){
 
 		describe( "Event Execution System", function(){
@@ -67,13 +67,43 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/cbTestHarne
 						prepareMock( getRequestContext() ).$( "getHTTPMethod", "DELETE" );
 						// Execute
 						var e = execute( event="main.index", renderResults=true );
-						expect(	e.getRenderedContent() ).toInclude( "invalid http: main.index" );
+                        expect(	e.getRenderedContent() ).toInclude( "invalid http: main.index" );
+                        expect( e.getStatusCode() ).toBe( 405 );
+					});
+				});
+            });
+
+            story( "I want to execute a global invalid event handler", function(){
+				given( "an invalid event", function(){
+					then( "it should fire the global invalid event handler", function(){
+                        var e = execute( event="does.not.exist", renderResults=true );
+                        expect( e.getStatusCode() ).toBe( 404 );
+					});
+				});
+            });
+
+            story( "I want the onException to have a default status code of 500", function(){
+				given( "an event that fires an exception", function(){
+					then( "it should default the status code to 500", function(){
+                        expect( function() {
+                            var e = execute( event="main.throwException", renderResults=true, withExceptionHandling = true );
+                        } ).toThrow();
+                        expect( getNativeStatusCode() ).toBe( 500 );
 					});
 				});
 			});
-		
+
 		});
 
-	}
-	
+    }
+
+    private function getNativeStatusCode() {
+        if ( structKeyExists( server, "lucee" ) ) {
+            return getPageContext().getResponse().getStatus();
+        }
+        else {
+            return getPageContext().getResponse().getResponse().getStatus();
+        }
+    }
+
 }


### PR DESCRIPTION
Right now, both of these have a default status code of 200.  This is especially troublesome with ajax requests since a 200 _thinks_ it passed even though it failed.  You could always set an `invalidEvent` or `onException` handler, but this sets those status codes by default.

As a side benefit, the integration testing `getStatusCode` helper now works in more situations (like view rendering) and there is a new `withExceptionHandling` to use exception handling (like the global `onException` handler) with integration tests.