### PR TITLE
Added Local InvalidHTTPMethod call for SES Routes

### DIFF
--- a/system/web/Controller.cfc
+++ b/system/web/Controller.cfc
@@ -604,6 +604,17 @@ component serializable="false" accessors="true"{
 
 			// SES Invalid HTTP Routing
 			if( arguments.defaultEvent && oRequestContext.isInvalidHTTPMethod() ){
+				
+				if( oHandler._actionExists( "onInvalidHTTPMethod" ) ){
+					return oHandler.onInvalidHTTPMethod( 
+						event			= oRequestContext,
+						rc				= args.rc,
+						prc				= args.prc,
+						faultAction		= oRequestContext.getCurrentRoutedURL(),
+						eventArguments	= arguments.eventArguments 
+					);
+				}
+				
 				// Do we have the invalidHTTPMethodHandler setting? If so, call it.
 				if( len( getSetting( "invalidHTTPMethodHandler" ) ) ){
 					return _runEvent( event = getSetting( "invalidHTTPMethodHandler" ) );


### PR DESCRIPTION
Allowed methods in the handler was supported and was throwing the handlers onInvalidHTTPMethod call, but if the allowed method was not supported by the routes, this handlers onInvalidHTTPMethod was not being called.

CC @elpete 