### PR TITLE
Remove annotations on beforeAll and afterAll

### DIFF
--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -138,7 +138,6 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 
 	/**
 	* BDD: The main setup method for running ColdBox Integration enabled tests
-	* @beforeAll
 	*/
 	function beforeAll(){
 		if( isNull( variables._ranBeforeAll ) ){
@@ -149,7 +148,6 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 
 	/**
 	* BDD: The main teardown for ColdBox enabled applications after all tests execute
-	* @afterAll
 	*/
 	function afterAll(){
 		if( isNull( variables._ranAfterAll ) ){


### PR DESCRIPTION
Having an annotation of `@beforeAll` on `beforeAll` and `@afterAll` on `afterAll` cause them to be executed twice.