### PR TITLE
Add a module id injection DSL.

### DIFF
--- a/system/ioc/Builder.cfc
+++ b/system/ioc/Builder.cfc
@@ -377,7 +377,7 @@ component serializable="false" accessors="true"{
 		// Check if Custom DSL exists, if it does, execute it
 		if( structKeyExists( variables.customDSL, DSLNamespace ) ){
 			return variables.customDSL[ DSLNamespace ].process( argumentCollection=arguments );
-		}
+        }
 
 		// Determine Type of Injection according to type
 		// Some namespaces requires the ColdBox context, if not found, an exception is thrown.
@@ -441,6 +441,9 @@ component serializable="false" accessors="true"{
 
 			// If no DSL's found, let's try to use the name as the empty namespace
 			default : {
+                if( len( DSLNamespace ) && left( DSLNamespace, 1 ) == "@" ){
+                    arguments.definition.dsl = arguments.definition.name & arguments.definition.dsl;
+                }
 				refLocal.dependency = getModelDSL( argumentCollection=arguments );
 			}
 		}

--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -529,12 +529,6 @@ component extends="coldbox.system.web.services.BaseService"{
 					binder.mapDirectory( packagePath=packagePath );
 				}
 
-				// Register Default Module Export if it exists as @moduleName, so you can do getInstance( "@moduleName" )
-				if( fileExists( mconfig.modelsPhysicalPath & "/#arguments.moduleName#.cfc" ) ){
-					binder.map( [ "@#arguments.moduleName#", "@#mConfig.modelNamespace#" ] )
-						.to( packagePath & ".#arguments.moduleName#" );
-				}
-
 				// Process mapped data
 				binder.processMappings();
 			}

--- a/tests/specs/integration/ModuleTests.cfc
+++ b/tests/specs/integration/ModuleTests.cfc
@@ -1,5 +1,5 @@
 /*******************************************************************************
-*	Integration Test as BDD  
+*	Integration Test as BDD
 *
 *	Extends the integration class: coldbox.system.testing.BaseTestCase
 *
@@ -86,7 +86,7 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/cbTestHarne
 
 				expect(	config ).toHaveKey( 'test1' );
 				expect( config[ "test1" ] ).toHaveKey( "settings" );
-				
+
 				expect( config[ "test1" ].settings ).toBe( parentSettings.moduleSettings[ "test1" ] );
 
 				expect( parentSettings ).toHaveKey( "test1" );
@@ -127,21 +127,6 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/cbTestHarne
 			});
 		});
 
-		story( "Modules can support default model export", function(){
-			given( "A module with a model of the same name", function(){
-				then( "You will be able to get the model via @moduleName", function(){
-					var oModel = getInstance( "@conventionsTest" );
-					oModel.echo();
-				});
-			});
-			given( "A model namespace", function(){
-				then( "You will be able to get the model via @modelNamespace", function(){
-					var oModel = getInstance( "@MyConventionsTest" );
-					oModel.echo();
-				});
-			});
-		});
-
 		story( "Modules can register custom routing", function(){
 			given( "A routing array", function(){
 				then( "module routes should be registered", function(){
@@ -157,7 +142,7 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/cbTestHarne
 			given( "application helpers directive", function(){
 				then( "the module service will load them by convention", function(){
 					var event = execute( event="conventionsTest:test.index", renderResults=true );
-					expect( event.getRenderedContent() ).toInclude( "hello from module app helper" );			
+					expect( event.getRenderedContent() ).toInclude( "hello from module app helper" );
 				});
 			});
 		});
@@ -182,7 +167,7 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/cbTestHarne
 
 					expect( photosFound ).toBeTrue();
 					expect( usersFound ).toBeTrue();
-					
+
 				} );
 			} );
 		} );


### PR DESCRIPTION
This PR adds the ability to use an `id` injection with a module.
Just as the `id` DSL uses the name of the model as the mapping,
this adds a similar DSL for modules using `@#moduleNamespace#`.

```
property name="MyService" inject="id";
// should inject the dependency mapped to `MyService`

property name="MyService" inject="@myModule";
// should inject the dependency mapped to `MyService@myModule`
```

This also removes the old (beta) behavior of registering a default export in the ModuleService.
The good news is this will still work as long as the name being injected is the name of the module.

```
property name="bcrypt" inject="@Bcrypt";
// This works because the model name in Bcrypt is `Bcrypt`

property name="encrypt" inject="@Bcrypt";
// This will not work anymore because `encrypt@Bcrypt` isn't a valid mapping
```