### PR TITLE
Don't exclude path in parent mapping destinations

### DIFF
--- a/system/ioc/config/Binder.cfc
+++ b/system/ioc/config/Binder.cfc
@@ -390,7 +390,7 @@ Description :
 		<cfscript>
 			// copy parent class's memento instance, exclude alias, name and path
 			for( var mapping in getCurrentMapping() ) {
-				mapping.processMemento( getMapping( arguments.alias ).getMemento(), "alias,name,path" );
+				mapping.processMemento( getMapping( arguments.alias ).getMemento(), "alias,name" );
 			}
 			return this;
 		</cfscript>


### PR DESCRIPTION
Excluding the path gives the new mapping no where to point to.