### PR TITLE
Resolves COLDBOX-708

### DIFF
--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -1032,7 +1032,9 @@ component accessors="true" extends="coldbox.system.FrameworkSupertype" threadsaf
 			verbs 					= "",
 			headers 				= {},
 			rc 						= {},
-			prc 					= {}
+			prc 					= {},
+			overwriteRC             = {},
+			overwritePRC            = {}
 		};
 	}
 
@@ -1266,6 +1268,9 @@ component accessors="true" extends="coldbox.system.FrameworkSupertype" threadsaf
 			arguments.value,
 			arguments.overwrite
 		);
+
+		variables.thisRoute.rcOverwrite[ name ] = overwrite;
+
 		return this;
 	}
 
@@ -1284,6 +1289,12 @@ component accessors="true" extends="coldbox.system.FrameworkSupertype" threadsaf
 			processWith( arguments );
 		}
 		variables.thisRoute.rc.append( arguments.map, arguments.overwrite );
+
+		//set our overwrite flags for the route params
+		for( var keyName in arguments.map ){
+			variables.thisRoute.rcOverwrite[ keyName ] = overwrite;
+		}
+
 		return this;
 	}
 
@@ -1307,6 +1318,9 @@ component accessors="true" extends="coldbox.system.FrameworkSupertype" threadsaf
 			arguments.value,
 			arguments.overwrite
 		);
+
+		variables.thisRoute.prcOverwrite[ name ] = overwrite;		
+
 		return this;
 	}
 
@@ -1325,6 +1339,12 @@ component accessors="true" extends="coldbox.system.FrameworkSupertype" threadsaf
 			processWith( arguments );
 		}
 		variables.thisRoute.prc.append( arguments.map, arguments.overwrite );
+
+		//set our overwrite flags for the route params
+		for( var keyName in arguments.map ){
+			variables.thisRoute.prcOverwrite[ keyName ] = overwrite;
+		}
+
 		return this;
 	}
 

--- a/system/web/services/RoutingService.cfc
+++ b/system/web/services/RoutingService.cfc
@@ -234,12 +234,14 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 		// Now route should have all the key/pairs from the URL we need to pass to our event object for processing
 		rc.append( routeResults.params, true );
+
 		// Incorporate RC variables using overwrite settings
 		for( var rcKey in routeResults.route.rc ){
 			if( !structKeyExists( rc, rcKey ) || ( routeResults.route.rcOverwrite[ rcKey ] ?: false ) ){
 				rc[ rcKey ] = routeResults.route.rc[ rcKey ]
 			}
 		}
+		
 		// Incorporate PRC variables using overwrite settings
 		for( var prcKey in routeResults.route.prc ){
 			if( !structKeyExists( prc, prcKey ) || ( routeResults.route.prcOverwrite[ prcKey ] ?: false ) ){

--- a/system/web/services/RoutingService.cfc
+++ b/system/web/services/RoutingService.cfc
@@ -234,10 +234,18 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 		// Now route should have all the key/pairs from the URL we need to pass to our event object for processing
 		rc.append( routeResults.params, true );
-		// Incorporate RC variables without overrides
-		rc.append( routeResults.route.rc, routeResults.route.rcOverwrite ?: false );
-		// Incorporate PRC variables without overrides
-		prc.append( routeResults.route.prc, routeResults.route.prcOverwrite ?: false  );
+		// Incorporate RC variables using overwrite settings
+		for( var rcKey in routeResults.route.rc ){
+			if( !structKeyExists( rc, rcKey ) || ( routeResults.route.rcOverwrite[ rcKey ] ?: false ) ){
+				rc[ rcKey ] = routeResults.route.rc[ rcKey ]
+			}
+		}
+		// Incorporate PRC variables using overwrite settings
+		for( var prcKey in routeResults.route.prc ){
+			if( !structKeyExists( prc, prcKey ) || ( routeResults.route.prcOverwrite[ prcKey ] ?: false ) ){
+				prc[ prcKey ] = routeResults.route.prc[ prcKey ]
+			}
+		}
 
 		/****************** Start Processing Route ******************/
 

--- a/system/web/services/RoutingService.cfc
+++ b/system/web/services/RoutingService.cfc
@@ -235,9 +235,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 		// Now route should have all the key/pairs from the URL we need to pass to our event object for processing
 		rc.append( routeResults.params, true );
 		// Incorporate RC variables without overrides
-		rc.append( routeResults.route.rc );
+		rc.append( routeResults.route.rc, routeResults.route.rcOverwrite ?: false );
 		// Incorporate PRC variables without overrides
-		prc.append( routeResults.route.prc );
+		prc.append( routeResults.route.prc, routeResults.route.prcOverwrite ?: false  );
 
 		/****************** Start Processing Route ******************/
 

--- a/tests/specs/web/routing/RoutingServiceTest.cfc
+++ b/tests/specs/web/routing/RoutingServiceTest.cfc
@@ -118,6 +118,102 @@
 				} );
 
 			} );
+
+			describe( "Can accurately process a request capture with routing params", function(){
+
+
+				beforeEach( function(){
+					// Mocks
+					mockEvent = createMock( "coldbox.system.web.context.RequestContext" )
+						.init(
+							controller = getController(),
+							properties = {
+								defaultLayout 	= "Main.cfm",
+								defaultView 	= "",
+								eventName 		= "event",
+								modules 		= {}
+							}
+						);
+					mockInterceptData = {};
+				} );
+				
+				it( "Tests that route rc/prc params will be applied on request capture", function(){
+					
+					//test regular SES route
+					path_info = "/somefolder/test";
+
+					// We need a clean mock so we can mock one of the routing methods
+					var routingService = prepareMock( getController().getRoutingService() );
+					routingService.$( "getCGIElement" ).$results( path_info, '', 'localhost' );
+
+					routingService.$( "findRoute" ).$callback( function(){
+						return {
+							"params" : {},
+							"route" : {
+								"rc" : {
+									"name" : "jon"
+								},
+								"prc" : {
+									"foo" : "bar"
+								},
+								"redirect" : "",
+								"ssl" : false,
+								"event" : "",
+								"handler" : "",
+								"action" : "",
+								"view" : "",
+								"headers" : [],
+								"response" : ""
+							}
+						}
+					} );
+
+					routingService.onRequestCapture( mockEvent, mockInterceptData, mockEvent.getCollection(), mockEvent.getPrivateCollection() );
+					expect( mockEvent.getValue( "name" ) ).toBe( "jon" );
+					expect( mockEvent.getPrivateValue( "foo" ) ).toBe( "bar" );
+
+				} );
+				
+				it( "Tests that route params will not overwrite pre-existing rc values", function(){
+					
+					//test regular SES route
+					path_info = "/somefolder/test";
+
+					mockEvent.setValue( "name", "luis" );
+					mockEvent.setPrivateValue( "foo", "bar" );
+
+					// We need a clean mock so we can mock one of the routing methods
+					var routingService = prepareMock( getController().getRoutingService() );
+					routingService.$( "getCGIElement" ).$results( path_info, '', 'localhost' );
+
+					routingService.$( "findRoute" ).$callback( function(){
+						return {
+							"params" : {},
+							"route" : {
+								"rc" : {
+									"name" : "jon"
+								},
+								"prc" : {
+									"foo" : "baz"
+								},
+								"redirect" : "",
+								"ssl" : false,
+								"event" : "",
+								"handler" : "",
+								"action" : "",
+								"view" : "",
+								"headers" : [],
+								"response" : ""
+							}
+						}
+					} );
+
+					routingService.onRequestCapture( mockEvent, mockInterceptData, mockEvent.getCollection(), mockEvent.getPrivateCollection() );
+					expect( mockEvent.getValue( "name" ) ).toBe( "luis" );
+					expect( mockEvent.getPrivateValue( "foo" ) ).toBe( "bar" );
+
+				} );
+			} );
 		} );
 	}
 }


### PR DESCRIPTION
prevents rc/prc explicit values from being overwritten by paramed route rc/prc values. Also adds keys for persisting the `overwrite` argument to the Router `rc()` and `prc()` methods.