### PR TITLE
Fix ColdBox-597 Prevent wrong filetype attribution when an url contains ".js"

### DIFF
--- a/system/core/dynamic/HTMLHelper.cfc
+++ b/system/core/dynamic/HTMLHelper.cfc
@@ -94,7 +94,7 @@ component extends="coldbox.system.FrameworkSupertype" singleton{
 			} )
 			.each( function( item ){
 				// Load Asset
-				if( findNoCase( ".js", item ) ){
+				if( listLast( listFirst( listFirst( item, '##' ), '?' ), '.' ) EQ 'js' ){
 					sb.append(
 						'<script src="#jsPath##item#" #asyncStr##deferStr#></script>'
 					);


### PR DESCRIPTION
An example is https://cdnjs.cloudflare.com/ajax/libs/gridstack.js/0.3.0/gridstack-extra.min.css that contains ".js" in url but is a CSS.