### PR TITLE
Fix a requirement for columnName if column is defined - new

### DIFF
--- a/system/modules/HTMLHelper/models/HTMLHelper.cfc
+++ b/system/modules/HTMLHelper/models/HTMLHelper.cfc
@@ -1656,8 +1656,7 @@ component extends="coldbox.system.FrameworkSupertype" accessors=true singleton{
 
 			// struct normalizing
 			if( isStruct( val[ x ] ) ){
-				// Default
-				thisName = thisValue;
+				thisName = "";
 
 				// check for value?
 				if( structKeyExists(val[ x ], "value") ){ thisValue = val[ x ].value; }
@@ -1670,8 +1669,10 @@ component extends="coldbox.system.FrameworkSupertype" accessors=true singleton{
 				if( len( arguments.nameColumn ) ){
 					if( structKeyExists( val[ x ], arguments.nameColumn ) ){ thisName = val[ x ][nameColumn]; }
 				}
-				else{
-					if( structKeyExists( val[ x ], arguments.column ) ){ thisName = val[ x ][column]; }
+				
+				// If thisName is still the default, use the content of thisValue as the name
+				if( thisName == "" ){
+					thisName = thisValue;
 				}
 
 			}


### PR DESCRIPTION
Without this, if you set a column, but not columnName, it will not use the default 'name' field, it will overwrite it with the column field ( value ) because of the else.
Tested locally, this works.

Update of pull request after new file location and conversion of tag to script.
https://github.com/ColdBox/coldbox-platform/pull/357