### PR TITLE
Fix ColdBox-597

### DIFF
--- a/system/modules/HTMLHelper/models/HTMLHelper.cfc
+++ b/system/modules/HTMLHelper/models/HTMLHelper.cfc
@@ -116,7 +116,7 @@ component extends="coldbox.system.FrameworkSupertype" accessors=true singleton{
 			} )
 			.each( function( item ){
 				// Load Asset
-				if( findNoCase( ".js", item ) ){
+				if( listLast( listFirst( listFirst( item, '##' ), '?' ), '.' ) EQ 'js' ){
 					sb.append(
 						'<script src="#jsPath##encodeForHTMLAttribute( item )#" #asyncStr##deferStr#></script>'
 					);


### PR DESCRIPTION
Prevent wrong filetype attribution when an url contains ".js"