### PR TITLE
COLDBOX-736

### DIFF
--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -104,6 +104,8 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 				// Setup
 				variables.controller.getLoaderService().loadApplication( variables.configMapping, variables.appMapping );
 			}
+			// Load Module CF Mappings so modules can work properly
+			variables.controller.getModuleService().loadMappings();
 			// Auto registration of test as interceptor
 			variables.controller.getInterceptorService().registerInterceptor(interceptorObject=this);
 		}


### PR DESCRIPTION
https://ortussolutions.atlassian.net/browse/COLDBOX-736

When you don't unload the coldbox framework inside your integration tests, coldbox lives in memory across page requests to your tests. This means your CF mappings disappear and the base test case does nothing to ensure the CF mappings for the modules still exist. We need to ensure module mappings are present when loadcoldbox is true.