### PR TITLE
COLDBOX-748: use dummy flash scope when sessions disabled

### DIFF
--- a/system/web/services/RequestService.cfc
+++ b/system/web/services/RequestService.cfc
@@ -211,7 +211,13 @@ component extends="coldbox.system.web.services.BaseService"{
 	 * Return the flash scope instance in use by the framework.
 	 */
 	any function getFlashScope(){
-		return variables.flashScope;
+		var appSettings = getApplicationMetadata();
+
+		if ( IsBoolean( appSettings.sessionManagement ?: "" ) && appSettings.sessionManagement ) {
+			return variables.flashScope;
+		}
+
+		return variables.mockFlashScope;
 	}
 
 	/**
@@ -265,6 +271,7 @@ component extends="coldbox.system.web.services.BaseService"{
 
 		// Create Flash RAM object
 		variables.flashScope = createObject( "component", flashPath ).init( controller, variables.flashData );
+		variables.mockFlashScope = createObject( "component", "coldbox.system.web.flash.MockFlash" ).init( controller, variables.flashData );
 
 		return this;
 	}


### PR DESCRIPTION
This is really just a safety backstop. We sometimes disable sessions for things like BOT requests and this logic defends against odd code that might try accessing the flash scope during these requests.