### PR TITLE
COLDBOX-749 singleton renderer

### DIFF
--- a/system/includes/LuceeDuplicate.cfm
+++ b/system/includes/LuceeDuplicate.cfm
@@ -1,0 +1,10 @@
+<!---
+	To be included in CFC's that require Lucee's shallow duplicate()
+	so as not to break the Adobe ColdFusion cfml compiler.
+--->
+<cffunction name="luceeDuplicate" access="public" returntype="any" output="false">
+	<cfargument name="objectToDuplicate" type="any"     required="true"  />
+	<cfargument name="full"              type="boolean" required="false" default="true" />
+
+	<cfreturn Duplicate( arguments.objectToDuplicate, arguments.full ) />
+</cffunction>

--- a/system/web/Controller.cfc
+++ b/system/web/Controller.cfc
@@ -122,7 +122,7 @@ component serializable="false" accessors="true"{
 	* Get the system web renderer, you can also retreive it from wirebox via renderer@coldbox
 	*/
 	function getRenderer(){
-		return variables.wireBox.getInstance( "Renderer@coldbox" );
+		return variables.wireBox.getInstance( "RendererFactory@coldbox" ).getRenderer();
 	}
 
 	/**

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -890,6 +890,6 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 
 
 	private any function getThreadSafeInstanceOfThisService() {
-		return StructCopy( this );
+		return structCopy( this );
 	}
 }

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -890,6 +890,6 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 
 
 	private any function getThreadSafeInstanceOfThisService() {
-		return Duplicate( this, false );
+		return StructCopy( this );
 	}
 }

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -890,6 +890,6 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 
 
 	private any function getThreadSafeInstanceOfThisService() {
-		return structCopy( this );
+		return StructCopy( this );
 	}
 }

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -394,7 +394,7 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
      * @viewHelperPath The helpers for the view to load before it
      * @args The view arguments
      */
-    public function renderViewComposite(
+    private function renderViewComposite(
     	view,
     	viewPath,
     	viewHelperPath,

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -160,15 +160,6 @@ component accessors="true" serializable="false" extends="coldbox.system.Framewor
 		// Template Cache & Caching Maps
 		variables.renderedHelpers	= {};
 
-		// Discovery caching
-
-		// Set event scope, we are not caching, so it is threadsafe.
-		variables.event = getRequestContext();
-
-		// Create View Scopes
-		variables.rc 	= event.getCollection();
-		variables.prc 	= event.getCollection( private=true );
-
 		// Load global UDF Libraries into target
 		loadApplicationHelpers();
 

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -888,13 +888,13 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 	private any function getThreadSafeInstanceOfThisService() {
 		var isLucee = structKeyExists( server, "lucee" );
 
-  		if ( isLucee ) {
+		if ( isLucee ) {
 			return StructCopy( this );
-  		}
+		}
 
   		var threadSafeInstance = new Renderer( variables.controller, variables.html );
 
-  		threadSafeInstance.setTemplateCache( getTemplateCache() );
+  		threadSafeInstance.setTemplateCache( this.getTemplateCache() );
 
   		return threadSafeInstance;
 

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -114,6 +114,67 @@ component accessors="true" serializable="false" extends="coldbox.system.Framewor
 		return this;
 	}
 
+	/**
+	 * Special "faster" Constructor
+	 * for renderer factory
+	 */
+	function fasterInit(
+		required controller,
+		required logBox,
+		required log,
+		required flash,
+		required cacheBox,
+		required wireBox,
+		required layoutsConvention,
+		required viewsConvention,
+		required appMapping,
+		required viewsExternalLocation,
+		required layoutsExternalLocation,
+		required modulesConfig,
+		required viewsHelper,
+		required viewCaching,
+		required htmlHelper,
+		required templateCache
+	){
+		variables.controller              = arguments.controller;
+		variables.logBox                  = arguments.logBox;
+		variables.log                     = arguments.log;
+		variables.flash                   = arguments.flash;
+		variables.cacheBox                = arguments.cacheBox;
+		variables.wireBox                 = arguments.wireBox;
+		variables.layoutsConvention       = arguments.layoutsConvention;
+		variables.viewsConvention         = arguments.viewsConvention;
+		variables.appMapping              = arguments.appMapping;
+		variables.viewsExternalLocation   = arguments.viewsExternalLocation;
+		variables.layoutsExternalLocation = arguments.layoutsExternalLocation;
+		variables.modulesConfig           = arguments.modulesConfig;
+		variables.viewsHelper             = arguments.viewsHelper;
+		variables.viewCaching             = arguments.viewCaching;
+		variables.isDiscoveryCaching      = arguments.viewCaching;
+		variables.html                    = arguments.htmlHelper;
+		variables.templateCache           = arguments.templateCache;
+		variables.lockName                = arguments.lockName;
+		variables.isViewsHelperIncluded   = false;
+		variables.explicitView            = {};
+
+		// Template Cache & Caching Maps
+		variables.renderedHelpers	= {};
+
+		// Discovery caching
+
+		// Set event scope, we are not caching, so it is threadsafe.
+		variables.event = getRequestContext();
+
+		// Create View Scopes
+		variables.rc 	= event.getCollection();
+		variables.prc 	= event.getCollection( private=true );
+
+		// Load global UDF Libraries into target
+		loadApplicationHelpers();
+
+		return this;
+	}
+
 	/************************************** VIEW METHODS *********************************************/
 
 	/**
@@ -872,6 +933,10 @@ component accessors="true" serializable="false" extends="coldbox.system.Framewor
 		}
 
 		return layout;
+	}
+
+	function announceAfterRendererInit() {
+		announceInterception( "afterRendererInit", { variables = variables, this = this } );
 	}
 
 }

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -890,6 +890,6 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 
 
 	private any function getThreadSafeInstanceOfThisService() {
-		return StructCopy( this );
+		return Duplicate( this, false );
 	}
 }

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -888,13 +888,13 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 	private any function getThreadSafeInstanceOfThisService() {
 		var isLucee = structKeyExists( server, "lucee" );
 
-		if ( isLucee ) {
+  		if ( isLucee ) {
 			return StructCopy( this );
-		}
+  		}
 
   		var threadSafeInstance = new Renderer( variables.controller, variables.html );
 
-  		threadSafeInstance.setTemplateCache( this.getTemplateCache() );
+  		threadSafeInstance.setTemplateCache( getTemplateCache() );
 
   		return threadSafeInstance;
 

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -14,7 +14,6 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 	*/
 	property name="templateCache" 	inject="cachebox:template";
 
-
 	/************************************** PROPERTIES *********************************************/
 
 	// Location of layouts
@@ -40,15 +39,20 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 	// Discovery caching is tied to handlers for discovery.
 	property name="isDiscoveryCaching";
 
+	// View/Layout Properties
+	property name="event";
+	property name="rc";
+	property name="prc";
+	property name="html";
+
 	/************************************** CONSTRUCTOR *********************************************/
 
 	/**
 	* Constructor
 	* @controller The ColdBox main controller
 	* @controller.inject coldbox
-	* @htmlHelper.inject @htmlHelper
 	*/
-	function init( required controller, required htmlHelper ){
+	function init( required controller ){
 		// setup controller
 		variables.controller = arguments.controller;
 		// Register LogBox
@@ -89,7 +93,7 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 		variables.isDiscoveryCaching = controller.getSetting( "viewCaching" );
 
 		// HTML Helper
-		variables.html  = arguments.htmlHelper;
+		variables.html  = variables.wirebox.getInstance( dsl="@HTMLHelper" );
 
 		// Load global UDF Libraries into target
 		loadApplicationHelpers();
@@ -886,17 +890,6 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 
 
 	private any function getThreadSafeInstanceOfThisService() {
-		var isLucee = structKeyExists( server, "lucee" );
-
-  		if ( isLucee ) {
-			return StructCopy( this );
-  		}
-
-  		var threadSafeInstance = new Renderer( variables.controller, variables.html );
-
-  		threadSafeInstance.setTemplateCache( getTemplateCache() );
-
-  		return threadSafeInstance;
-
+		return StructCopy( this );
 	}
 }

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -394,7 +394,7 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
      * @viewHelperPath The helpers for the view to load before it
      * @args The view arguments
      */
-    private function renderViewComposite(
+    public function renderViewComposite(
     	view,
     	viewPath,
     	viewHelperPath,

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -14,6 +14,7 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 	*/
 	property name="templateCache" 	inject="cachebox:template";
 
+
 	/************************************** PROPERTIES *********************************************/
 
 	// Location of layouts
@@ -39,20 +40,15 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 	// Discovery caching is tied to handlers for discovery.
 	property name="isDiscoveryCaching";
 
-	// View/Layout Properties
-	property name="event";
-	property name="rc";
-	property name="prc";
-	property name="html";
-
 	/************************************** CONSTRUCTOR *********************************************/
 
 	/**
 	* Constructor
 	* @controller The ColdBox main controller
 	* @controller.inject coldbox
+	* @htmlHelper.inject @htmlHelper
 	*/
-	function init( required controller ){
+	function init( required controller, required htmlHelper ){
 		// setup controller
 		variables.controller = arguments.controller;
 		// Register LogBox
@@ -93,7 +89,7 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 		variables.isDiscoveryCaching = controller.getSetting( "viewCaching" );
 
 		// HTML Helper
-		variables.html  = variables.wirebox.getInstance( dsl="@HTMLHelper" );
+		variables.html  = arguments.htmlHelper;
 
 		// Load global UDF Libraries into target
 		loadApplicationHelpers();
@@ -890,6 +886,17 @@ component accessors="true" singleton="true" serializable="false" extends="coldbo
 
 
 	private any function getThreadSafeInstanceOfThisService() {
-		return StructCopy( this );
+		var isLucee = structKeyExists( server, "lucee" );
+
+  		if ( isLucee ) {
+			return StructCopy( this );
+  		}
+
+  		var threadSafeInstance = new Renderer( variables.controller, variables.html );
+
+  		threadSafeInstance.setTemplateCache( getTemplateCache() );
+
+  		return threadSafeInstance;
+
 	}
 }

--- a/system/web/RendererFactory.cfc
+++ b/system/web/RendererFactory.cfc
@@ -59,7 +59,7 @@ component singleton=true serializable=false extends="coldbox.system.FrameworkSup
 		if ( isLucee()  ) {
 			return cloneRenderer();
 		} else {
-			return newRenderer();
+			return newRenderer( true );
 		}
 	}
 
@@ -67,7 +67,7 @@ component singleton=true serializable=false extends="coldbox.system.FrameworkSup
 		return StructKeyExists( server, "lucee" );
 	}
 
-	private any function newRenderer() {
+	private any function newRenderer( boolean completeInit=false ) {
 		var renderer = createObject( "Renderer" ).fasterInit(
 			controller              = variables.controller,
 			logBox                  = variables.logBox,
@@ -88,17 +88,27 @@ component singleton=true serializable=false extends="coldbox.system.FrameworkSup
 			lockName                = variables.lockName
 		);
 
-		renderer.announceAfterRendererInit();
+		if ( arguments.completeInit ) {
+			var event = getRequestContext();
+
+			renderer.setEvent( event );
+			renderer.setRc( event.getCollection() );
+			renderer.setPrc( event.getCollection( private=true ) );
+
+			renderer.announceAfterRendererInit();
+		}
 
 		return renderer;
 	}
 
 	private any function cloneRenderer() {
 		var cloned = LuceeDuplicate( objectToDuplicate=variables.cloneableRenderer, full=false );
+		var event  = getRequestContext();
 
-		cloned.setEvent( getRequestContext() );
-		cloned.setRc( getRequestContext().getCollection() );
-		cloned.setPrc( getRequestContext().getCollection( private=true ) );
+		cloned.setEvent( event );
+		cloned.setRc( event.getCollection() );
+		cloned.setPrc( event.getCollection( private=true ) );
+
 		cloned.announceAfterRendererInit();
 
 		return cloned;

--- a/system/web/RendererFactory.cfc
+++ b/system/web/RendererFactory.cfc
@@ -1,0 +1,107 @@
+/**
+* Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
+* www.ortussolutions.com
+* ---
+* The system web renderer
+* @author Luis Majano <lmajano@ortussolutions.com>
+*/
+component singleton=true serializable=false extends="coldbox.system.FrameworkSupertype"{
+
+	/************************************** CONSTRUCTOR *********************************************/
+
+	/**
+	 * @controller           The ColdBox main controller
+	 * @controller.inject    coldbox
+	 * @htmlHelper.inject    @htmlHelper
+	 * @templateCache.inject cachebox:template
+	 */
+	function init( required controller, required htmlHelper, required templateCache ){
+		variables.controller = arguments.controller;
+		variables.logBox     = arguments.controller.getLogBox();
+		variables.log        = variables.logBox.getLogger( this );
+		variables.flash      = arguments.controller.getRequestService().getFlashScope();
+		variables.cacheBox   = arguments.controller.getCacheBox();
+		variables.wireBox    = arguments.controller.getWireBox();
+
+		// Set Conventions, Settings and Properties
+		variables.layoutsConvention       = variables.controller.getSetting( "layoutsConvention", true );
+		variables.viewsConvention         = variables.controller.getSetting( "viewsConvention", true );
+		variables.appMapping              = variables.controller.getSetting( "AppMapping" );
+		variables.viewsExternalLocation   = variables.controller.getSetting( "ViewsExternalLocation" );
+		variables.layoutsExternalLocation = variables.controller.getSetting( "LayoutsExternalLocation" );
+		variables.modulesConfig           = variables.controller.getSetting( "modules" );
+		variables.viewsHelper             = variables.controller.getSetting( "viewsHelper" );
+		variables.viewCaching             = variables.controller.getSetting( "viewCaching" );
+		variables.isDiscoveryCaching      = variables.viewCaching;
+		variables.isViewsHelperIncluded   = false;
+		variables.renderedHelpers         = {};
+		variables.lockName                = "rendering.#variables.controller.getAppHash()#";
+		variables.htmlHelper              = arguments.htmlHelper;
+		variables.templateCache           = arguments.templateCache;
+
+		// Verify View Helper Template extension + location
+		if( len( variables.viewsHelper ) ){
+			// extension detection
+			variables.viewsHelper = ( listLast( variables.viewsHelper, "." ) eq "cfm" ? variables.viewsHelper : variables.viewsHelper & ".cfm" );
+			// Append mapping to it.
+			variables.viewsHelper = "/#variables.appMapping#/#variables.viewsHelper#";
+		}
+
+		if ( isLucee() ) {
+			variables.cloneableRenderer = newRenderer();
+			cfinclude( template="../includes/LuceeDuplicate.cfm" );
+		}
+
+		return this;
+	}
+
+	function getRenderer() {
+		if ( isLucee()  ) {
+			return cloneRenderer();
+		} else {
+			return newRenderer();
+		}
+	}
+
+	private boolean function isLucee() {
+		return StructKeyExists( server, "lucee" );
+	}
+
+	private any function newRenderer() {
+		var renderer = createObject( "Renderer" ).fasterInit(
+			controller              = variables.controller,
+			logBox                  = variables.logBox,
+			log                     = variables.log,
+			flash                   = variables.flash,
+			cacheBox                = variables.cacheBox,
+			wireBox                 = variables.wireBox,
+			layoutsConvention       = variables.layoutsConvention,
+			viewsConvention         = variables.viewsConvention,
+			appMapping              = variables.appMapping,
+			viewsExternalLocation   = variables.viewsExternalLocation,
+			layoutsExternalLocation = variables.layoutsExternalLocation,
+			modulesConfig           = variables.modulesConfig,
+			viewsHelper             = variables.viewsHelper,
+			viewCaching             = variables.viewCaching,
+			htmlHelper              = variables.htmlHelper,
+			templateCache           = variables.templateCache,
+			lockName                = variables.lockName
+		);
+
+		renderer.announceAfterRendererInit();
+
+		return renderer;
+	}
+
+	private any function cloneRenderer() {
+		var cloned = LuceeDuplicate( objectToDuplicate=variables.cloneableRenderer, full=false );
+
+		cloned.setEvent( getRequestContext() );
+		cloned.setRc( getRequestContext().getCollection() );
+		cloned.setPrc( getRequestContext().getCollection( private=true ) );
+		cloned.announceAfterRendererInit();
+
+		return cloned;
+	}
+
+}

--- a/system/web/services/LoaderService.cfc
+++ b/system/web/services/LoaderService.cfc
@@ -112,9 +112,13 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 		// Map ColdBox Utility Objects
 		var binder = controller.getWireBox().getBinder();
 
-		// Map Renderer
+		// Map Renderer (for backward compatibility)
 		binder.map( "Renderer@coldbox" )
 			.to( "coldbox.system.web.Renderer" );
+		// Map Renderer Factory
+		binder.map( "RendererFactory@coldbox" )
+			.asSingleton()
+			.to( "coldbox.system.web.RendererFactory" );
 		// Map Data Marshaller
 		binder.map( "DataMarshaller@coldbox" )
 			.to( "coldbox.system.core.conversion.DataMarshaller" );


### PR DESCRIPTION
The renderer service is current a transient service. This makes it threadsafe but also make it slow (if you have a request with lots of small renderView() calls, the request time adds up).

The following changes allow the renderer service to be a singleton while still being threadsafe for variables set within included views.

It does this by creating a shallow clone of itself just for the method that includes the cfm view template. This performs well and does not modify the scope of the singleton instance. Shallow cloning is fast.