### PR TITLE
Add test and fix for adding a LogBox category after the fact

### DIFF
--- a/system/logging/config/LogBoxConfig.cfc
+++ b/system/logging/config/LogBoxConfig.cfc
@@ -259,36 +259,41 @@ component accessors="true"{
 	struct function getRoot(){
 		return instance.rootLogger;
 	}
-	
+
 	/**
 	 * Add a new category configuration with appender(s).  Appenders MUST be defined first, else this method will throw an exception
-	 * 
+	 *
 	 * @name A unique name for the appender to register. Only unique names can be registered per instance
 	 * @levelMin The default log level for the root logger, by default it is 0 (FATAL). Optional. ex: config.logLevels.WARN
 	 * @levelMax The default log level for the root logger, by default it is 4 (DEBUG). Optional. ex: config.logLevels.WARN
 	 * @appenders A list of appender names to configure this category with. By default it uses all the registered appenders
 	 */
-	LogBoxConfig function category( 
-		required name, 
+	LogBoxConfig function category(
+		required name,
 		levelMin=0,
 		levelMax=4,
 		appenders="*"
 	){
 		// Convert Levels
 		convertLevels( arguments );
-		
+
 		// Check levels
-		levelChecks( arguments.levelMin, arguments.levelMax );
-		
+        levelChecks( arguments.levelMin, arguments.levelMax );
+
+        // Check * all appenders
+        if( appenders eq "*" ){
+            appenders = structKeyList( getAllAppenders() );
+        }
+
 		// Add category registration
 		instance.categories[ arguments.name ] = arguments;
-		
+
 		return this;
 	}
-	
+
 	/**
 	 * Get a specified category definition
-	 * 
+	 *
 	 * @name The category name
 	 */
 	struct function getCategory( required name ){

--- a/tests/specs/logging/LogBoxTest.cfc
+++ b/tests/specs/logging/LogBoxTest.cfc
@@ -2,30 +2,36 @@
 * My BDD Test
 */
 component extends="coldbox.system.testing.BaseModelTest"{
-	
+
 	function run( testResults, testBox ){
-		
+
 		describe( "LogBox Service", function(){
-			
+
 			beforeEach(function( currentSpec ){
 				logbox = createMock( "coldbox.system.logging.LogBox" );
 
 				config = new coldbox.system.logging.config.LogBoxConfig();
-				
+
 				//Appenders
 				config.appender( name="luis", class="coldbox.system.logging.appenders.ConsoleAppender" )
 					.appender( name="luis2", class="coldbox.system.logging.appenders.ConsoleAppender" )
 					.root( appenders="luis,luis2" )
 					// Sample categories
 					.OFF( "coldbox.system" )
-					.debug( "coldbox.system.interceptors" );
+                    .debug( "coldbox.system.interceptors" );
 
 				//init logBox
-				logBox.init( config );
+                logBox.init( config );
+
+                // add this configuration after the fact to test another code path
+                config.category(
+                    name = "coldbox.system.web",
+                    appenders = "*"
+                );
 			});
-			
+
 			describe( "can retrieve loggers with different category names", function(){
-				
+
 				given( "A valid category inheritance trail that is turned off", function(){
 					then( "it will retrieve the inherited category", function(){
 						var logger = logBox.getLogger( "coldbox.system.core" );
@@ -50,12 +56,12 @@ component extends="coldbox.system.testing.BaseModelTest"{
 					});
 				});
 			});
-			
+
 			it( "can get the root logger", function(){
 				var logger = logbox.getRootLogger();
 				logger.info( "test" );
 			});
-			
+
 			it( "can locate category parent loggers", function(){
 				makePublic( logbox, "locateCategoryParentLogger" );
 				// 1: root logger
@@ -67,9 +73,13 @@ component extends="coldbox.system.testing.BaseModelTest"{
 
 				// 3: Expecting an OFF logger
 				var logger = logBox.locateCategoryParentLogger( "coldbox.system.core" );
-				expect( logger.getLevelMin(), logger.logLevels.OFF );
+                expect( logger.getLevelMin(), logger.logLevels.OFF );
+
+                // 4: Expecting all appenders
+                var logger = logBox.locateCategoryParentLogger( "coldbox.system.web.Controller" );
+				expect( logger.getAppenders().count(), 2 );
 			});
-		
+
 		});
 	}
 


### PR DESCRIPTION
Adding a category after LogBox had already been configured errored because the `*` appenders wasn't expanded.  This PR expands the appenders in the `category` method, if needed.