### PR TITLE
COLDBOX-763 scope target var

### DIFF
--- a/system/ioc/Builder.cfc
+++ b/system/ioc/Builder.cfc
@@ -727,6 +727,8 @@
 			arguments.target.injectMixin( 'init', baseObject.init );
 		}
 
+		// local reference to arguments to use in closures below
+		var args = arguments;
 		baseObject.getVariablesMixin()
 			// filter out overrides
 			.filter( function( key, value ) {
@@ -735,17 +737,17 @@
 			.each( function( propertyName, propertyValue ){
 				// inject the property/method now
 				if( !isNull( propertyValue ) ) {
-					target.injectPropertyMixin( propertyName, propertyValue );
+					args.target.injectPropertyMixin( propertyName, propertyValue );
 				}
 				// Do we need to do automatic generic getter/setters
 				if( generateAccessors and baseProperties.keyExists( propertyName ) ){
 
-					if( ! structKeyExists( target, "get#propertyName#" ) ){
-						target.injectMixin( "get" & propertyName, variables.genericGetter );
+					if( ! structKeyExists( args.target, "get#propertyName#" ) ){
+						args.target.injectMixin( "get" & propertyName, variables.genericGetter );
 					}
 
-					if( ! structKeyExists( target, "set#propertyName#" ) ){
-						target.injectMixin( "set" & propertyName, variables.genericSetter );
+					if( ! structKeyExists( args.target, "set#propertyName#" ) ){
+						args.target.injectMixin( "set" & propertyName, variables.genericSetter );
 					}
 
 				}


### PR DESCRIPTION
This addresses an issue with an unscoped argument reference. See: https://ortussolutions.atlassian.net/browse/COLDBOX-763 for detail.

Wasn't sure what preference you had re naming copy of arguments scope here for reference in closures, but have gone with `args` for now.

Had a quick look to see where I could add tests but train pulling into station and running out of time, so no time to provide a test case for this particular scenario, apologies.