### PR TITLE
CACHEBOX-46 Cachebox concurrency

### DIFF
--- a/home/dom/code/coldbox-platform/tests/logs/commandbox.log
+++ b/home/dom/code/coldbox-platform/tests/logs/commandbox.log
@@ -1,2 +1,0 @@
-"Severity","Appender","Date","Time","Category","Message"
-"Severity","Appender","Date","Time","Category","Message"

--- a/home/dom/code/coldbox-platform/tests/logs/commandbox.log
+++ b/home/dom/code/coldbox-platform/tests/logs/commandbox.log
@@ -1,0 +1,2 @@
+"Severity","Appender","Date","Time","Category","Message"
+"Severity","Appender","Date","Time","Category","Message"

--- a/system/aop/Mixer.cfc
+++ b/system/aop/Mixer.cfc
@@ -105,17 +105,17 @@ component accessors="true"{
 		var idCode		= variables.system.identityHashCode( target );
 
 		// Check if incoming mapping name is already class matched?
-		if( NOT structKeyExists( variables.classMatchDictionary, mappingName ) ){
+		if( NOT variables.classMatchDictionary.containsKey( mappingName ) ){
 			// Register this incoming mapping for class aspect matching
 			buildClassMatchDictionary( target, mapping, idCode );
 		}
 
 		// Now, we check if we have any aspects to apply to this class according to class matchers
-		if( arrayLen( variables.classMatchDictionary[ mappingName ] ) ){
+		if( arrayLen( variables.classMatchDictionary.get(mappingName) ) ){
 			AOPBuilder(
 				target 		= target,
 				mapping 	= mapping,
-				dictionary 	= variables.classMatchDictionary[ mappingName ],
+				dictionary 	= variables.classMatchDictionary.get(mappingName),
 				idCode 		= idCode
 			);
 		}
@@ -136,7 +136,7 @@ component accessors="true"{
 
     	lock name="aop.#variables.classID#.cmd.for.#arguments.idCode#" type="exclusive" timeout="30" throwontimeout="true"{
 			// check again, double lock
-			if( NOT structKeyExists( variables.classMatchDictionary, mappingName ) ){
+			if( NOT variables.classMatchDictionary.containsKey(mappingName) ){
 
 				// Discover matching for the class via all aspect bindings
 				for( var x=1; x LTE bindingsLen; x++ ){
@@ -154,7 +154,7 @@ component accessors="true"{
 				}
 
 				// Store matched dictionary
-				variables.classMatchDictionary[ mappingName ] = matchedAspects;
+				variables.classMatchDictionary.put(mappingName, matchedAspects);
 
 			} // end if in dictionary
 		} // end lock
@@ -280,9 +280,9 @@ component accessors="true"{
 		var udfOut 			= createObject( "java","java.lang.StringBuilder" ).init( '' );
 		var lb				= "#chr( 13 )##chr( 10 )#";
 		var fncMD			= {
-			name       = "", 
-			access     = "public", 
-			output     ="false", 
+			name       = "",
+			access     = "public",
+			output     ="false",
 			returnType = "any"
 		};
 		var mappingName 	= arguments.mapping.getName();
@@ -290,14 +290,14 @@ component accessors="true"{
 
 		// MD proxy Defaults
 		fncMD.name = arguments.jointPointMD.name;
-		if( structKeyExists( arguments.jointPointMD, "access" ) ){ 
-			fncMD.access = arguments.jointPointMD.access; 
+		if( structKeyExists( arguments.jointPointMD, "access" ) ){
+			fncMD.access = arguments.jointPointMD.access;
 		}
-		if( structKeyExists( arguments.jointPointMD, "output" ) ){ 
-			fncMD.output = arguments.jointPointMD.output; 
+		if( structKeyExists( arguments.jointPointMD, "output" ) ){
+			fncMD.output = arguments.jointPointMD.output;
 		}
-		if( structKeyExists( arguments.jointPointMD, "returntype" ) ){ 
-			fncMD.returntype = arguments.jointPointMD.returnType; 
+		if( structKeyExists( arguments.jointPointMD, "returntype" ) ){
+			fncMD.returntype = arguments.jointPointMD.returnType;
 		}
 		// Create Original Method Proxy Signature
 		if( fncMD.access eq "public" ){
@@ -305,10 +305,10 @@ component accessors="true"{
 		}
 
 		var thisFNC = '
-		<:cffunction name="aop_#hash( arguments.jointpoint )#" 
-					access="#fncMD.access#" 
-					output="#fncMD.output#" 
-					returntype="#fncMD.returntype#" 
+		<:cffunction name="aop_#hash( arguments.jointpoint )#"
+					access="#fncMD.access#"
+					output="#fncMD.output#"
+					returntype="#fncMD.returntype#"
 					hint="WireBox AOP just rulez!"
 		>
 			<cfscript>
@@ -334,7 +334,7 @@ component accessors="true"{
 		// Do : replacement, due to inline compilation avoidances
 		thisFNC = replace( thisFNC, "<:", "<", "all" );
 		udfOut.append( thisFNC );
-		
+
 		// MD5 Content Checks
 		var codeSignature 	= hash( udfOUt.toString() );
 		var tmpFile 		= variables.properties.generationPath & "/" & codeSignature & ".cfm";
@@ -352,10 +352,10 @@ component accessors="true"{
 			arguments.target.$wbAOPRemove( arguments.jointpoint );
 			// Mix In generated aspect
 			arguments.target.$wbAOPInclude( tmpFile );
-			
+
 			// Remove Temp Aspect from disk
 			//variables.mixerUtil.removeAspect( expandedFile );
-			
+
 			// debug info
 			if( variables.log.canDebug() ){
 				variables.log.debug( "Target (#mappingName#) weaved with new (#arguments.jointpoint#) method and with the following aspects: #arguments.aspects.toString()#" );

--- a/system/cache/store/ConcurrentSoftReferenceStore.cfc
+++ b/system/cache/store/ConcurrentSoftReferenceStore.cfc
@@ -19,20 +19,20 @@ Description :
 		<cfscript>
 			// Super size me
 			super.init( arguments.cacheProvider );
-			
+
 			// Override Fields
 			instance.indexer.setFields( instance.indexer.getFields() & ",isSoftReference");
-			
+
 			// Prepare soft reference lookup maps
 			instance.softRefKeyMap	 = CreateObject("java","java.util.concurrent.ConcurrentHashMap").init();
 			instance.referenceQueue  = CreateObject("java","java.lang.ref.ReferenceQueue").init();
-			
+
 			return this;
 		</cfscript>
 	</cffunction>
 
 <!------------------------------------------- INTERFACE PUBLIC METHODS ------------------------------------------->
-	
+
 	<!--- clearAll --->
     <cffunction name="clearAll" output="false" access="public" returntype="void" hint="Clear all elements of the store">
     	<cfscript>
@@ -40,101 +40,99 @@ Description :
 			instance.softRefKeyMap.clear();
 		</cfscript>
     </cffunction>
-	
+
 	<!--- reap --->
     <cffunction name="reap" output="false" access="public" returntype="void" hint="Reap the storage, clean it from old stuff">
-    	
+
     	<cfset var refLocal = {}>
-    	
+
     	<cflock name="ConcurrentSoftReferenceStore.reap.#instance.storeID#" type="exclusive" timeout="20">
     	<cfscript>
-    		
+
     		// Init Ref Key Vars
 			refLocal.collected = instance.referenceQueue.poll();
-			
+
 			// Let's reap the garbage collected soft references
 			while( structKeyExists(reflocal, "collected") ){
-				
+
 				// Clean if it still exists
 				if( softRefLookup( reflocal.collected ) ){
-					
+
 					// expire it
 					expireObject( getSoftRefKey(refLocal.collected) );
-					
+
 					// GC Collection Hit
 					instance.cacheProvider.getStats().gcHit();
 				}
-				
+
 				// Poll Again
 				reflocal.collected = instance.referenceQueue.poll();
 			}
 		</cfscript>
 		</cflock>
-		
+
     </cffunction>
-	
+
 	<!--- lookup --->
 	<cffunction name="lookup" access="public" output="false" returntype="any" hint="Check if an object is in cache.">
 		<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
-		
-		<cfset var refLocal = {}>
-			
-		<cflock name="ConcurrentSoftReferenceStore.#instance.storeID#.#arguments.objectKey#" type="readonly" timeout="10" throwonTimeout="true">
+
+
 		<cfscript>
+			var refLocal = {};
 			// check existence via super, if not found, check as it might be a soft reference
 			if( NOT super.lookup( arguments.objectKey ) ){ return false; }
 			// get quiet to test it as it might be a soft reference
 			refLocal.target = getQuiet( arguments.objectKey );
 			// is it found?
 			if( NOT structKeyExists(refLocal,"target") ){ return false; }
-			
+
 			// if we get here, it is found
-			return true;					
+			return true;
 		</cfscript>
-		</cflock>
 	</cffunction>
-	
+
 	<!--- Get an object from the pool --->
 	<cffunction name="get" access="public" output="false" returntype="any" hint="Get an object from cache. If its a soft reference object it might return a null value.">
 		<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
 		<cfscript>
 			var refLocal = {};
-			
+
 			// Get via concurrent store
 			refLocal.target = super.get( arguments.objectKey );
 			if( !isNull( refLocal.target ) ){
-				
+
 				// Validate if SR or normal object
 				if( isInstanceOf(refLocal.target, "java.lang.ref.SoftReference") ){
 					return refLocal.target.get();
 				}
-				
+
 				return refLocal.target;
-			}	
+			}
 		</cfscript>
 	</cffunction>
-	
+
 	<!--- getQuiet --->
 	<cffunction name="getQuiet" access="public" output="false" returntype="any" hint="Get an object from cache. If its a soft reference object it might return a null value.">
 		<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
 		<cfscript>
 			var refLocal = {};
-			
+
 			// Get via concurrent store
 			refLocal.target = super.getQuiet( arguments.objectKey );
-			
+
 			if( !isNull( refLocal.target ) ){
-				
+
 				// Validate if SR or normal object
 				if( isInstanceOf(refLocal.target, "java.lang.ref.SoftReference") ){
 					return refLocal.target.get();
 				}
-				
+
 				return refLocal.target;
-			}		
-		</cfscript>		
+			}
+		</cfscript>
 	</cffunction>
-	
+
 	<!--- Set an Object in the pool --->
 	<cffunction name="set" access="public" output="false" returntype="void" hint="sets an object in the storage.">
 		<!--- ************************************************************* --->
@@ -144,14 +142,13 @@ Description :
 		<cfargument name="lastAccessTimeout"	type="any"  required="false" default="0" hint="Idle Timeout in minutes">
 		<cfargument name="extras" 				type="any" default="#structnew()#" hint="A map of extra name-value pairs"/>
 		<!--- ************************************************************* --->
-		
-		<cfset var target 	= 0>
-		<cfset var isSR	= (arguments.timeout GT 0)>
-		
+
+
 		<!--- Extra lock due to extra md --->
-		<cflock name="ConcurrentSoftReferenceStore.#instance.storeID#.#arguments.objectKey#" type="exclusive" timeout="10" throwonTimeout="true">
 		<cfscript>
-			
+			var target = 0;
+			var isSR   = (arguments.timeout GT 0);
+
 			// Check for eternal object
 			if( isSR ){
 				// Cache as soft reference not an eternal object
@@ -160,73 +157,61 @@ Description :
 			else{
 				target = arguments.object;
 			}
-			
+
 			// Store it
 			super.set(objectKey=arguments.objectKey,
 					  object=target,
 					  timeout=arguments.timeout,
 					  lastAccessTimeout=arguments.lastAccessTimeout,
 					  extras=arguments.extras);
-			
+
 			// Set extra md in indexer
 			instance.indexer.setObjectMetadataProperty(arguments.objectKey,"isSoftReference", isSR );
 		</cfscript>
-		</cflock>
 	</cffunction>
 
 	<!--- Clear an object from the pool --->
 	<cffunction name="clear" access="public" output="false" returntype="any" hint="Clears an object from the storage pool">
 		<cfargument name="objectKey" 			type="any"  required="true" hint="The object key">
-		
-		<cfset var softRef = "">
-		
-		<cflock name="ConcurrentSoftReferenceStore.#instance.storeID#.#arguments.objectKey#" type="exclusive" timeout="10" throwonTimeout="true">
+
 		<cfscript>
-			
 			// Check if it exists
-			if( NOT structKeyExists(instance.pool, arguments.objectKey) ){
+			if( NOT instance.pool.containsKey(arguments.objectKey) ){
 				return false;
 			}
-			
+
 			// Is this a soft reference?
-			softRef = instance.pool[arguments.objectKey];
-			
+			var softRef = instance.pool.get(arguments.objectKey);
+
 			// Removal of Soft Ref Lookup
 			if( instance.indexer.getObjectMetadataProperty(arguments.objectKey,"isSoftReference") ){
-				structDelete(getSoftRefKeyMap(),softRef);
+				getSoftRefKeyMap().remove(softRef);
 			}
-			
+
 			return super.clear( arguments.objectKey );
 		</cfscript>
-		</cflock>
 	</cffunction>
 
 	<!--- getReferenceQueue --->
 	<cffunction name="getReferenceQueue" access="public" output="false" returntype="any" hint="Get soft reference queue object">
 		<cfreturn instance.referenceQueue/>
-	</cffunction>	
-	
+	</cffunction>
+
 	<!--- Get Soft Reference KeyMap --->
 	<cffunction name="getSoftRefKeyMap" access="public" output="false" returntype="any" hint="Get the soft reference key map">
 		<cfreturn instance.softRefKeyMap/>
-	</cffunction>	
-		
+	</cffunction>
+
 	<!--- softRefLookup --->
 	<cffunction name="softRefLookup" access="public" returntype="any" hint="See if the soft reference is in the reference key map" output="false" >
 		<cfargument name="softRef" required="true" type="any" hint="The soft reference to check">
-		<cfreturn structKeyExists(instance.softRefKeyMap,arguments.softRef)>
+		<cfreturn instance.softRefKeyMap.containsKey(arguments.softRef)>
 	</cffunction>
-	
+
 	<!--- getSoftRefKey --->
 	<cffunction name="getSoftRefKey" access="public" returntype="any" hint="Get the soft reference's key from the soft reference lookback map" output="false" >
 		<cfargument name="softRef" required="true" type="any" hint="The soft reference to check">
-		<cfscript>
-			var keyMap = getSoftRefKeyMap();
-			
-			if( structKeyExists(keyMap,arguments.softRef) ){
-				return keyMap[arguments.softRef];
-			}
-		</cfscript>
+		<cfreturn getSoftRefKeyMap().get( arguments.softRef )>
 	</cffunction>
 
 <!------------------------------------------- PRIVATE ------------------------------------------->
@@ -236,14 +221,14 @@ Description :
 		<cfargument name="objectKey" type="any"  	required="true" hint="The value of the key pair">
 		<cfargument name="target"	 type="any" 	required="true" hint="The object to wrap">
 		<cfscript>
-		
+
 			// Create Soft Reference Wrapper and register with Queue
 			var softRef = CreateObject("java","java.lang.ref.SoftReference").init(arguments.target,getReferenceQueue());
 			var refKeyMap = getSoftRefKeyMap();
-			
+
 			// Create Reverse Mapping
-			refKeyMap[ softRef ] = arguments.objectKey;
-			
+			refKeyMap.put(softRef, arguments.objectKey);
+
 			return softRef;
 		</cfscript>
 	</cffunction>

--- a/system/cache/store/ConcurrentStore.cfc
+++ b/system/cache/store/ConcurrentStore.cfc
@@ -18,34 +18,35 @@ Description :
 		<cfscript>
 			// Indexing Fields
 			var fields = "hits,timeout,lastAccessTimeout,created,LastAccessed,isExpired";
-			
+
 			// Prepare instance
 			instance = {
-				cacheProvider   = arguments.cacheProvider,
-				storeID 		= createObject('java','java.lang.System').identityHashCode(this),
-				pool			= createObject("java","java.util.concurrent.ConcurrentHashMap").init(),
-				indexer    		= createObject("component","coldbox.system.cache.store.indexers.MetadataIndexer").init(fields)
+				cacheProvider = arguments.cacheProvider,
+				storeID       = createObject('java','java.lang.System').identityHashCode(this),
+				pool          = createObject("java","java.util.concurrent.ConcurrentHashMap").init(),
+				indexer       = createObject("component","coldbox.system.cache.store.indexers.MetadataIndexer").init(fields),
+				collections   = createObject("java","java.util.Collections")
 			};
-			
+
 			return this;
 		</cfscript>
 	</cffunction>
 
 <!------------------------------------------- INTERFACE PUBLIC METHODS ------------------------------------------->
-	
+
 	<!--- flush --->
     <cffunction name="flush" output="false" access="public" returntype="void" hint="Flush the store to a permanent storage">
     </cffunction>
-	
+
 	<!--- reap --->
     <cffunction name="reap" output="false" access="public" returntype="void" hint="Reap the storage, clean it from old stuff">
     </cffunction>
-	
+
 	<!--- getStoreID --->
     <cffunction name="getStoreID" output="false" access="public" returntype="any" hint="Get this storage's ID">
     	<cfreturn instance.storeID>
     </cffunction>
-	
+
 	<!--- clearAll --->
     <cffunction name="clearAll" output="false" access="public" returntype="void" hint="Clear all elements of the store">
 		<cfscript>
@@ -53,7 +54,7 @@ Description :
 			instance.indexer.clearAll();
 		</cfscript>
     </cffunction>
-	
+
 	<!--- getPool --->
 	<cffunction name="getPool" access="public" returntype="any" output="false" hint="Get a reference to the store's pool of objects">
 		<cfreturn instance.pool>
@@ -63,87 +64,67 @@ Description :
 	<cffunction name="getIndexer" access="public" returntype="any" output="false" hint="Get the store's pool metadata indexer structure">
 		<cfreturn instance.indexer>
 	</cffunction>
-	
+
 	<!--- getKeys --->
 	<cffunction name="getKeys" output="false" access="public" returntype="any" hint="Get all the store's object keys">
-		<cfreturn structKeyArray( getPool() )>
+		<cfreturn instance.collections.list( instance.pool.keys() )>
 	</cffunction>
-	
+
 	<!--- lookup --->
 	<cffunction name="lookup" access="public" output="false" returntype="any" hint="Check if an object is in cache.">
 		<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
-		
-		<cflock name="ConcurrentStore.#instance.storeID#.#arguments.objectKey#" type="readonly" timeout="10" throwonTimeout="true">
-		<cfscript>
-			// Check if object in pool and object not dead
-			if( structKeyExists( instance.pool , arguments.objectKey)  
-			    AND instance.indexer.objectExists( arguments.objectKey ) 
-				AND NOT instance.indexer.getObjectMetadataProperty(arguments.objectKey,"isExpired") ){
-				return true;
-			}
-			
-			return false;
-		</cfscript>
-		</cflock>
+
+		<cfreturn instance.pool.containsKey(arguments.objectKey)
+		      AND instance.indexer.objectExists(arguments.objectKey)
+		      AND NOT instance.indexer.getObjectMetadataProperty(arguments.objectKey,"isExpired")>
 	</cffunction>
-	
+
 	<!--- get --->
 	<cffunction name="get" access="public" output="false" returntype="any" hint="Get an object from the object store, returns java null if not found">
 		<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
-		
-		<cfset var refLocal = structnew()>
-		
-		<cflock name="ConcurrentStore.#instance.storeID#.#arguments.objectKey#" type="exclusive" timeout="10" throwonTimeout="true">
+
 		<cfscript>
+			var refLocal = structnew()
 			// retrieve from map
 			refLocal.results = instance.pool.get( arguments.objectKey );
 			if( !isNull( refLocal.results ) ){
-			
+
 				// Record Metadata Access
 				instance.indexer.setObjectMetadataProperty(arguments.objectKey,"hits", instance.indexer.getObjectMetadataProperty(arguments.objectKey,"hits")+1);
 				instance.indexer.setObjectMetadataProperty(arguments.objectKey,"LastAccessed", now());
-				
+
 				// return object
 				return refLocal.results;
 			}
 		</cfscript>
-		</cflock>
 	</cffunction>
-	
+
 	<!--- getQuiet --->
 	<cffunction name="getQuiet" access="public" output="false" returntype="any" hint="Get an object from cache with no stats, null if not found">
 		<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
-		<cfset var refLocal = structnew()>
-		
-		<cflock name="ConcurrentStore.#instance.storeID#.#arguments.objectKey#" type="readonly" timeout="10" throwonTimeout="true">
-			<cfscript>
-				// retrieve from map
-				refLocal.results = instance.pool.get( arguments.objectKey );
-				if( structKeyExists(refLocal,"results") ){
-					return refLocal.results;
-				}
-			</cfscript>
-		</cflock>
+
+		<cfscript>
+			var refLocal = structnew();
+			// retrieve from map
+			refLocal.results = instance.pool.get( arguments.objectKey );
+			if( structKeyExists(refLocal,"results") ){
+				return refLocal.results;
+			}
+		</cfscript>
 	</cffunction>
-	
+
 	<!--- expireObject --->
 	<cffunction name="expireObject" output="false" access="public" returntype="void" hint="Mark an object for expiration">
 		<cfargument name="objectKey" type="any"  required="true" hint="The object key">
-		
-		<cflock name="ConcurrentStore.#instance.storeID#.#arguments.objectKey#" type="exclusive" timeout="10" throwonTimeout="true">
-			<cfset instance.indexer.setObjectMetadataProperty(arguments.objectKey,"isExpired", true)>
-		</cflock>
-		
+
+		<cfset instance.indexer.setObjectMetadataProperty(arguments.objectKey,"isExpired", true)>
 	</cffunction>
-	
+
 	<!--- isExpired --->
     <cffunction name="isExpired" output="false" access="public" returntype="any" hint="Test if an object in the store has expired or not">
     	<cfargument name="objectKey" type="any"  required="true" hint="The object key">
-		
-		<cflock name="ConcurrentStore.#instance.storeID#.#arguments.objectKey#" type="readonly" timeout="10" throwonTimeout="true">
-			<cfreturn instance.indexer.getObjectMetadataProperty(arguments.objectKey,"isExpired")>
-		</cflock>
-		
+
+		<cfreturn instance.indexer.getObjectMetadataProperty(arguments.objectKey,"isExpired")>
     </cffunction>
 
 	<!--- Set an Object in the pool --->
@@ -155,57 +136,50 @@ Description :
 		<cfargument name="lastAccessTimeout"	type="any"  required="false" default="" hint="Timeout in minutes">
 		<cfargument name="extras" 				type="any" default="#structnew()#" hint="A map of extra name-value pairs"/>
 		<!--- ************************************************************* --->
-		
-		<cfset var metadata = {}>
-		
-		<cflock name="ConcurrentStore.#instance.storeID#.#arguments.objectKey#" type="exclusive" timeout="10" throwonTimeout="true">
+
 		<cfscript>
 			// Set new Object into cache pool
-			instance.pool[arguments.objectKey] = arguments.object;
-			
+			instance.pool.put( arguments.objectKey, arguments.object );
+
 			// Create object's metdata
-			metaData = {
+			var metaData = {
 				hits = 1,
 				timeout = arguments.timeout,
 				lastAccessTimeout = arguments.LastAccessTimeout,
 				created = now(),
-				LastAccessed = now(),		
+				LastAccessed = now(),
 				isExpired = false
 			};
-			
+
 			// Save the object's metadata
 			instance.indexer.setObjectMetadata(arguments.objectKey, metaData);
 		</cfscript>
-		</cflock>
 	</cffunction>
 
 	<!--- Clear an object from the pool --->
 	<cffunction name="clear" access="public" output="false" returntype="any" hint="Clears an object from the storage pool">
 		<cfargument name="objectKey" 			type="any"  required="true" hint="The object key">
-		
-		<cfset var target = "">
-		
-		<cflock name="ConcurrentStore.#instance.storeID#.#arguments.objectKey#" type="exclusive" timeout="10" throwonTimeout="true">
+
 		<cfscript>
-			
+			var target = "";
+
 			// Check if it exists
-			if( NOT structKeyExists(instance.pool, arguments.objectKey) ){
+			if( !instance.pool.containsKey(arguments.objectKey)) {
 				return false;
 			}
-			
+
 			// Remove it
-			structDelete(instance.pool, arguments.objectKey);
-			instance.indexer.clear( arguments.objectKey );
-							
+			instance.pool.remove(arguments.objectKey);
+			instance.indexer.clear(arguments.objectKey);
+
 			// Removed
 			return true;
 		</cfscript>
-		</cflock>
 	</cffunction>
 
 	<!--- Get the size of the pool --->
 	<cffunction name="getSize" access="public" output="false" returntype="any" hint="Get the cache's size in items">
-		<cfreturn structCount( instance.pool )>
+		<cfreturn instance.pool.size()>
 	</cffunction>
 
 <!------------------------------------------- PRIVATE ------------------------------------------->

--- a/system/cache/store/indexers/MetadataIndexer.cfc
+++ b/system/cache/store/indexers/MetadataIndexer.cfc
@@ -69,7 +69,7 @@ Description :
 	<!--- clear --->
     <cffunction name="clear" output="false" access="public" returntype="void" hint="Clear a metadata key">
     	<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
-		<cfset structDelete( instance.poolMetadata, arguments.objectKey )>
+		<cfset instance.poolMetadata.remove( arguments.objectKey )>
     </cffunction>
 
 	<!--- getKeys --->

--- a/system/cache/store/indexers/MetadataIndexer.cfc
+++ b/system/cache/store/indexers/MetadataIndexer.cfc
@@ -125,7 +125,7 @@ Description :
 
 	<!--- getSize --->
     <cffunction name="getSize" output="false" access="public" returntype="any" hint="Get the size of the indexer">
-    	<cfreturn structCount( instance.poolMetadata )>
+    	<cfreturn instance.poolMetadata.size()>
     </cffunction>
 
 	<!--- getSortedKeys --->

--- a/system/cache/store/indexers/MetadataIndexer.cfc
+++ b/system/cache/store/indexers/MetadataIndexer.cfc
@@ -80,14 +80,14 @@ Description :
 	<!--- getObjectMetadata --->
 	<cffunction name="getObjectMetadata" access="public" returntype="any" output="false" hint="Get a metadata entry for a specific entry. Exception if key not found">
 		<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
-		<cfreturn instance.poolMetadata[ arguments.objectKey ]>
+		<cfreturn instance.poolMetadata.get( arguments.objectKey )>
 	</cffunction>
 
 	<!--- setObjectMetadata --->
 	<cffunction name="setObjectMetadata" access="public" returntype="void" output="false" hint="Set the metadata entry for a specific entry">
 		<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
 		<cfargument name="metadata"  type="any" required="true" hint="The metadata structure to store for the cache entry">
-		<cfset instance.poolMetadata[ arguments.objectKey ] = arguments.metadata>
+		<cfset instance.poolMetadata.put( arguments.objectKey, arguments.metadata )>
 	</cffunction>
 
 	<!--- objectExists --->

--- a/system/cache/store/indexers/MetadataIndexer.cfc
+++ b/system/cache/store/indexers/MetadataIndexer.cfc
@@ -101,8 +101,12 @@ Description :
 		<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
 		<cfargument name="property"  type="any" required="true" hint="The property of the metadata to retrieve, must exist in the binded fields or exception is thrown">
 
-		<cfset validateField( arguments.property )>
-		<cfreturn instance.poolMetadata[ arguments.objectKey ][ arguments.property ] >
+		<cfscript>
+			validateField( arguments.property );
+			var metadata = getObjectMetadata( arguments.objectKey );
+
+			return metadata[ arguments.property ];
+		</cfscript>
 	</cffunction>
 
 	<!--- setObjectMetadataProperty --->
@@ -111,9 +115,12 @@ Description :
 		<cfargument name="property"  type="any" required="true" hint="The property of the metadata to retrieve">
 		<cfargument name="value"  	 type="any" required="true" hint="The value of the property">
 
-		<cfset validateField( arguments.property )>
-		<cfset instance.poolMetadata[ arguments.objectKey ][ arguments.property ] = arguments.value >
+		<cfscript>
+			validateField( arguments.property );
+			var metadata = getObjectMetadata( arguments.objectKey );
 
+			metadata[ arguments.property ] = arguments.value;
+		</cfscript>
 	</cffunction>
 
 	<!--- getSize --->

--- a/system/cache/store/indexers/MetadataIndexer.cfc
+++ b/system/cache/store/indexers/MetadataIndexer.cfc
@@ -93,7 +93,7 @@ Description :
 	<!--- objectExists --->
     <cffunction name="objectExists" output="false" access="public" returntype="any" hint="Check if the metadata entry exists for an object">
     	<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
-		<cfreturn structKeyExists( instance.poolMetadata, arguments.objectKey )>
+		<cfreturn instance.poolMetadata.containsKey( arguments.objectKey )>
     </cffunction>
 
 	<!--- getObjectMetadataProperty --->

--- a/system/cache/store/indexers/MetadataIndexer.cfc
+++ b/system/cache/store/indexers/MetadataIndexer.cfc
@@ -9,12 +9,12 @@ Date        :	11/14/2007
 Description :
 	This is a utility object that helps object stores keep their elements indexed
 	and stored nicely.  It is also a nice way to give back metadata results.
-	
+
 ----------------------------------------------------------------------->
 <cfcomponent output="false" hint="This is a utility object that helps object stores keep their items indexed and pretty">
 
 <!------------------------------------------- CONSTRUCTOR ------------------------------------------->
-	
+
 	<cffunction name="init" access="public" output="false" returntype="MetadataIndexer" hint="Constructor">
 		<cfargument name="fields" required="true" hint="The list or array of fields to bind this index on"/>
 		<cfscript>
@@ -22,23 +22,25 @@ Description :
 				// Create metadata pool
 				poolMetadata = CreateObject("java","java.util.concurrent.ConcurrentHashMap").init(),
 				// Index ID
-				indexID = createObject('java','java.lang.System').identityHashCode(this)
+				indexID = createObject('java','java.lang.System').identityHashCode(this),
+				// Collections (for static .list() method)
+				collections = createObject('java','java.util.Collections')
 			};
-			
+
 			// Store Fields
 			setFields( arguments.fields );
-			
+
 			return this;
 		</cfscript>
 	</cffunction>
-	
+
 <!------------------------------------------- PUBLIC ------------------------------------------->
-	
+
 	<!--- getFields --->
 	<cffunction name="getFields" access="public" returntype="any" output="false" hint="Get the bounded fields list">
     	<cfreturn instance.fields>
     </cffunction>
-	
+
 	<!--- setFields --->
     <cffunction name="setFields" output="false" access="public" returntype="void" hint="Override the constructed metadata fields this index is binded to">
     	<cfargument name="fields" type="any" required="true" hint="The list or array of fields to bind this index on"/>
@@ -47,32 +49,32 @@ Description :
 			if( isArray(arguments.fields) ){
 				arguments.fields = arrayToList( arguments.fields );
 			}
-			
+
 			// Store fields
 			instance.fields = arguments.fields;
 		</cfscript>
     </cffunction>
 
-	
+
 	<!--- getPoolMetadata --->
     <cffunction name="getPoolMetadata" output="false" access="public" returntype="any" hint="Get the entire pool reference">
     	<cfreturn instance.poolMetadata>
     </cffunction>
-	
+
 	<!--- clearAll --->
     <cffunction name="clearAll" output="false" access="public" returntype="void" hint="Clear the entire metadata map">
     	<cfset instance.poolMetadata.clear()>
     </cffunction>
-	
+
 	<!--- clear --->
     <cffunction name="clear" output="false" access="public" returntype="void" hint="Clear a metadata key">
     	<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
 		<cfset structDelete( instance.poolMetadata, arguments.objectKey )>
     </cffunction>
-	
+
 	<!--- getKeys --->
     <cffunction name="getKeys" output="false" access="public" returntype="any" hint="Returns an array of the keys stored in the index" doc_generic="array">
-    	<cfreturn structKeyArray( getPoolMetadata() )>
+    	<cfreturn instance.collections.list( instance.poolMetadata.keys() )>
     </cffunction>
 
 	<!--- getObjectMetadata --->
@@ -80,45 +82,45 @@ Description :
 		<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
 		<cfreturn instance.poolMetadata[ arguments.objectKey ]>
 	</cffunction>
-	
+
 	<!--- setObjectMetadata --->
 	<cffunction name="setObjectMetadata" access="public" returntype="void" output="false" hint="Set the metadata entry for a specific entry">
 		<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
 		<cfargument name="metadata"  type="any" required="true" hint="The metadata structure to store for the cache entry">
 		<cfset instance.poolMetadata[ arguments.objectKey ] = arguments.metadata>
 	</cffunction>
-	
+
 	<!--- objectExists --->
     <cffunction name="objectExists" output="false" access="public" returntype="any" hint="Check if the metadata entry exists for an object">
     	<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
 		<cfreturn structKeyExists( instance.poolMetadata, arguments.objectKey )>
     </cffunction>
-	
+
 	<!--- getObjectMetadataProperty --->
 	<cffunction name="getObjectMetadataProperty" access="public" returntype="any" output="false" hint="Get a specific metadata property for a specific entry">
 		<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
 		<cfargument name="property"  type="any" required="true" hint="The property of the metadata to retrieve, must exist in the binded fields or exception is thrown">
-		
+
 		<cfset validateField( arguments.property )>
 		<cfreturn instance.poolMetadata[ arguments.objectKey ][ arguments.property ] >
 	</cffunction>
-	
+
 	<!--- setObjectMetadataProperty --->
 	<cffunction name="setObjectMetadataProperty" access="public" returntype="void" output="false" hint="Set a metadata property for a specific entry">
 		<cfargument name="objectKey" type="any" required="true" hint="The key of the object">
 		<cfargument name="property"  type="any" required="true" hint="The property of the metadata to retrieve">
 		<cfargument name="value"  	 type="any" required="true" hint="The value of the property">
-		
+
 		<cfset validateField( arguments.property )>
 		<cfset instance.poolMetadata[ arguments.objectKey ][ arguments.property ] = arguments.value >
-		
+
 	</cffunction>
-	
+
 	<!--- getSize --->
     <cffunction name="getSize" output="false" access="public" returntype="any" hint="Get the size of the indexer">
     	<cfreturn structCount( instance.poolMetadata )>
     </cffunction>
-	
+
 	<!--- getSortedKeys --->
     <cffunction name="getSortedKeys" output="false" access="public" returntype="any" hint="Get an array of sorted keys for this indexer according to parameters">
     	<cfargument name="property"  type="any" required="true" hint="The property field to sort the index on. It must exist in the binded fields or exception"/>
@@ -126,7 +128,7 @@ Description :
 		<cfargument name="sortOrder" type="any" required="false" default="asc" hint="The sort order: asc or desc"/>
 		<cfscript>
 			validateField( arguments.property );
-			
+
 			return structSort( instance.poolMetadata, arguments.sortType, arguments.sortOrder, arguments.property );
 		</cfscript>
     </cffunction>

--- a/system/ioc/scopes/Singleton.cfc
+++ b/system/ioc/scopes/Singleton.cfc
@@ -23,11 +23,11 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true"{
 
 	/**
 	 * Configure the scope for operation and returns itself
-	 * 
-	 * 
+	 *
+	 *
 	 * @injector The linked WireBox injector
 	 * @injector.doc_generic coldbox.system.ioc.Injector
-	 * 
+	 *
 	 * @return coldbox.system.ioc.scopes.IScope
 	 */
 	function init( required injector ){
@@ -39,8 +39,8 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true"{
 
 	/**
 	 * Retrieve an object from scope or create it if not found in scope
-	 * 
-	 * 
+	 *
+	 *
 	 * @mapping The linked WireBox injector
 	 * @mapping.doc_generic coldbox.system.ioc.config.Mapping
 	 * @initArguments The constructor struct of arguments to passthrough to initialization
@@ -50,16 +50,16 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true"{
 		var cacheKey = lcase( arguments.mapping.getName() );
 
 		// Verify in Singleton Cache
-		if( NOT structKeyExists( variables.singletons, cacheKey ) ){
-			
+		if( NOT variables.singletons.containsKey(cacheKey) ){
+
 			// Lock it
-			lock 	name="WireBox.#variables.injector.getInjectorID()#.Singleton.#cacheKey#" 
-					type="exclusive" 
-					timeout="30" 
+			lock 	name="WireBox.#variables.injector.getInjectorID()#.Singleton.#cacheKey#"
+					type="exclusive"
+					timeout="30"
 					throwontimeout="true"{
-			
+
 						// double lock it
-				if( NOT structKeyExists( variables.singletons, cacheKey) ){
+				if( NOT variables.singletons.containsKey(cacheKey) ){
 
 					// some nice debug info.
 					if( variables.log.canDebug() ){
@@ -71,7 +71,7 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true"{
 
 					// If not in wiring thread safety, store in singleton cache to satisfy circular dependencies
 					if( NOT arguments.mapping.getThreadSafe() ){
-						variables.singletons[ cacheKey ] = tmpSingleton;
+						variables.singletons.put(cacheKey, tmpSingleton);
 					}
 
 					// wire up dependencies on the singleton object
@@ -79,7 +79,7 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true"{
 
 					// If thread safe, then now store it in the singleton cache, as all dependencies are now safely wired
 					if( arguments.mapping.getThreadSafe() ){
-						variables.singletons[ cacheKey ] = tmpSingleton;
+						variables.singletons.put(cacheKey, tmpSingleton);
 					}
 
 					// log it
@@ -88,26 +88,26 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true"{
 					}
 
 					// return it
-					return variables.singletons[ cacheKey ];
+					return variables.singletons.get(cacheKey);
 				}
-			
+
 			} // end lock
 		}
 
 		// return singleton
-		return variables.singletons[ cacheKey ];
+		return variables.singletons.get(cacheKey);
 	}
 
 	/**
 	 * Indicates whether an object exists in scope
-	 * 
+	 *
 	 * @mapping The linked WireBox injector
 	 * @mapping.doc_generic coldbox.system.ioc.config.Mapping
-	 * 
+	 *
 	 * @return coldbox.system.ioc.scopes.IScope
 	 */
 	boolean function exists( required mapping ){
-		return structKeyExists( variables.singletons, lcase( arguments.mapping.getName() ) );
+		return variables.singletons.containsKey(lcase( arguments.mapping.getName() ));
 	}
 
 	/**


### PR DESCRIPTION
The following changes are focused on Cachebox but also touch on a couple of other uses of `java.util.concurrent.ConcurrentHashMap` in Coldbox.

The crux is that, in Lucee at least, using CFML Struct functions on instances of `java.util.concurrent.ConcurrentHashMap` are *not thread safe*, negating the purpose of using it. For instance, our application error logs show sporadic instances of `ArrayIndexOutOfBounds` and other `variable does not exist` errors in Cachebox:

```cfc
component {
// ...
    instance.pool = createObject( "java", "java.util.concurrent.ConcurrentHashMap" ).init();
// ...
    function getKeys() {
        return StructKeyArray( instance.pool ); // <<< throws ArrayIndexOutOfBounds error while pool is having keys cleared
    }
}
```

This change, then, makes use of the java methods directly defined on `java.util.concurrent.ConcurrentHashMap` to achieve what is asked of it. i.e. getting the number of keys, getting an array of keys, getting and setting values, checking key existence. It also removes the exclusive locks, defined in the cache stores, that should be redundant due to the thread safety of the `ConcurrentHashMap`. As an extra bonus, the methods to get an array of keys performed around 3x faster in my tests that `StructKeyArray()`.

We have already made these changes in Preside applications (thanks to the modular architecture of Cachebox, we could just use a separate provider that looks for our own Store) - and can see the easily reproducable thread safety errors disappear.