### PR TITLE
sendFile changed: double quotes instead of single

### DIFF
--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -1241,8 +1241,8 @@ component serializable=false accessors="true"{
 		}
 
 		// detect if extension is already included in name argument, if not add
-		if ( listlast(arguments.name,"." ) != arguments.extension ) {
-			arguments.name = arguments.name & "." & arguments.extension;
+		if ( listlast( arguments.name,"." ) != arguments.extension ) {
+			arguments.name = arguments.name =& ".#arguments.extension#";
 		}
 		//  Set content headers
 		setHTTPHeader( name="content-disposition", value="#arguments.disposition#; filename=""#arguments.name#""" );

--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -1240,8 +1240,12 @@ component serializable=false accessors="true"{
 			);
 		}
 
+		// detect if extension is already included in name argument, if not add
+		if ( listlast(arguments.name,"." ) != arguments.extension ) {
+			arguments.name = arguments.name & "." & arguments.extension;
+		}
 		//  Set content headers
-		setHTTPHeader( name="content-disposition", value="#arguments.disposition#; filename=""#arguments.name#.#extension#""" );
+		setHTTPHeader( name="content-disposition", value="#arguments.disposition#; filename=""#arguments.name#""" );
 		setHTTPHeader( name="content-length", value=fileSize );
 
 		//  Send file

--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -1241,7 +1241,7 @@ component serializable=false accessors="true"{
 		}
 
 		//  Set content headers
-		setHTTPHeader( name="content-disposition", value="#arguments.disposition#; filename='#arguments.name#.#extension#'" );
+		setHTTPHeader( name="content-disposition", value="#arguments.disposition#; filename=""#arguments.name#.#extension#""" );
 		setHTTPHeader( name="content-length", value=fileSize );
 
 		//  Send file


### PR DESCRIPTION
Single quotes will be part of the filename in chrome and firefox, which is not what we want.
So double quotes added as according to RFC
[https://tools.ietf.org/html/rfc6266#page-7](https://tools.ietf.org/html/rfc6266#page-7)
Needed some escaping for double quotes, so now you have double double  quotes and even triple double quotes....