### PR TITLE
Map : to / in URL

### DIFF
--- a/system/web/Controller.cfc
+++ b/system/web/Controller.cfc
@@ -345,7 +345,7 @@ component serializable="false" accessors="true"{
 			// Default event relocations
 			case "SES" : {
 				// Route String start by converting event syntax to / syntax
-				routeString = replace( arguments.event, ".", "/", "all" );
+				routeString = replaceList( arguments.event, ".,:", "/,/" );
 				// Convert Query String to convention name value-pairs
 				if( len( trim( arguments.queryString ) ) ){
 					// If the routestring ends with '/' we do not want to

--- a/system/web/Controller.cfc
+++ b/system/web/Controller.cfc
@@ -344,8 +344,16 @@ component serializable="false" accessors="true"{
 
 			// Default event relocations
 			case "SES" : {
+				// Convert module into proper entry point
+				if( listLen( arguments.event, ":" ) > 1 ) {
+					var mConfig = getSetting( "modules" );
+					var module = listFirst( arguments.event, ":" );
+					if( structKeyExists( mConfig, module ) ){
+						arguments.event = mConfig[ module ].inheritedEntryPoint & "/" & listRest( arguments.event, ":" );
+					}
+				}
 				// Route String start by converting event syntax to / syntax
-				routeString = replaceList( arguments.event, ".,:", "/,/" );
+				routeString = replace( arguments.event, ".", "/", "all" );
 				// Convert Query String to convention name value-pairs
 				if( len( trim( arguments.queryString ) ) ){
 					// If the routestring ends with '/' we do not want to
@@ -716,10 +724,7 @@ component serializable="false" accessors="true"{
 				}
 				// Around Handler Advice Check?
 				else if(
-					!arguments.prePostExempt
-					&&
-					oHandler._actionExists( "aroundHandler" )
-					&&
+					oHandler._actionExists( "aroundHandler" ) AND
 					validateAction( results.ehBean.getMethod(), oHandler.aroundHandler_only, oHandler.aroundHandler_except )
 				){
 					results.data = oHandler.aroundHandler(

--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -1078,7 +1078,15 @@ component serializable=false accessors="true"{
 
 			// Translate link or plain
 			if( arguments.translate ){
-				arguments.to = replaceList( arguments.to, ".,:", "/,/" );
+				// Convert module into proper entry point
+				if( listLen( arguments.to, ":" ) > 1 ) {
+					var mConfig = controller.getSetting( "modules" );
+					var module = listFirst( arguments.to, ":" );
+					if( structKeyExists( mConfig, module ) ){
+						arguments.to = mConfig[ module ].inheritedEntryPoint & "/" & listRest( arguments.to, ":" );
+					}
+				}
+				arguments.to = replace( arguments.to, ".", "/", "all" );
 				// QuqeryString Conversions
 				if( len( arguments.queryString ) ){
 					if( right( arguments.to, 1 ) neq  "/" ){

--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -1078,7 +1078,7 @@ component serializable=false accessors="true"{
 
 			// Translate link or plain
 			if( arguments.translate ){
-				arguments.to = replace( arguments.to, ".", "/", "all" );
+				arguments.to = replaceList( arguments.to, ".,:", "/,/" );
 				// QuqeryString Conversions
 				if( len( arguments.queryString ) ){
 					if( right( arguments.to, 1 ) neq  "/" ){


### PR DESCRIPTION
When an event includes a module the separator is ":" and should be mapped to "/" in the translated URL. There could be other places in the codebase where this change should also be applied but I don't have enough knowledge to make that decision :-)