### PR TITLE
Make default baseURL domain and protocol agnostic

### DIFF
--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -144,9 +144,9 @@ component accessors="true" extends="coldbox.system.FrameworkSupertype" threadsaf
 		variables.validExtensions = variables.VALID_EXTENSIONS;
 		// Base Routing URL, defaults to the domain and app mapping defined by the routing services
 		if( len( controller.getSetting( "RoutingAppMapping" ) ) lte 1 ){
-			variables.baseURL = "http://#cgi.HTTP_HOST#";
+			variables.baseURL = "";
 		} else {
-			variables.baseURL = "http://#cgi.HTTP_HOST##controller.getSetting( "RoutingAppMapping" )#";
+			variables.baseURL = "#controller.getSetting( "RoutingAppMapping" )#";
 		}
 		// Are full rewrites enabled
 		variables.fullRewrites = false;


### PR DESCRIPTION
This default causes more problems than it solves, IMHO, and complicates the process of using framework routes for Docker healthchecks.  

I'm opening this PR because I would like to see the hostname and protocol used only if a `pathInfoProvider` explicitly dictates to use it.