### PR TITLE
Update RequestContext.cfc getFullUrl() to include port number

### DIFF
--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -968,6 +968,7 @@ component serializable=false accessors="true"{
         return arrayToList( [
             isSSL() ? "https://" : "http://",
             CGI.SERVER_NAME,
+			listLen( variables.SESBaseURL, ':' ) == 3 ? ":" & CGI.SERVER_PORT : "",
             isSES() ? "" : "/index.cfm",
             CGI.PATH_INFO,
             CGI.QUERY_STRING != "" && CGI.PATH_INFO == "" ? "/" : "",

--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -968,7 +968,7 @@ component serializable=false accessors="true"{
         return arrayToList( [
             isSSL() ? "https://" : "http://",
             CGI.SERVER_NAME,
-			listLen( variables.SESBaseURL, ':' ) == 3 ? ":" & CGI.SERVER_PORT : "",
+			listFind( "80,443", cgi.server_port ) ? "" : cgi.server_port,
             isSES() ? "" : "/index.cfm",
             CGI.PATH_INFO,
             CGI.QUERY_STRING != "" && CGI.PATH_INFO == "" ? "/" : "",


### PR DESCRIPTION
Currently `getHTMLBaseURL()` returns the port number if it is displayed in the address bar. It seems like `getFullURL()` should also include the port number if displayed as well.  Having the port displayed is especially important if you have a `<base>` tag in your layout and use anchor links (e.g. `<a href="#event.getFullURL()###anchor"...`.  

current:
`event.getHTMLBaseURL()` = `http://127.0.0.1:52606/`
`event.getFullURL()` = `http://127.0.0.1/handler/action/`

proposed:
`event.getHTMLBaseURL()` = `http://127.0.0.1:52606/`
`event.getFullURL()` = `http://127.0.0.1:52606/handler/action/`