### PR TITLE
Initial pass at merging HTTP verbs for the same route

### DIFF
--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -631,7 +631,7 @@ component accessors="true" extends="coldbox.system.FrameworkSupertype" threadsaf
 
 	        // update, delete and show routes
 	        actionSet = filterRouteActions(
-	        	{ PUT = "update", PATCH = "update", POST = "create", DELETE = "delete", GET = "show" },
+	        	{ PUT = "update", PATCH = "update", DELETE = "delete", GET = "show" },
 	        	arguments.only,
 	        	arguments.except
 	        );
@@ -757,7 +757,30 @@ component accessors="true" extends="coldbox.system.FrameworkSupertype" threadsaf
 			if( thisRoute.pattern neq "/" ){
 				thisRoute.pattern = right( thisRoute.pattern, len( thisRoute.pattern ) - 1 );
 			}
-		}
+        }
+
+        // Check for existing route matches
+        var matchingRoutes = variables.routes.filter( function( route ) {
+            return route.pattern == thisRoute.pattern;
+        } );
+        if ( ! matchingRoutes.isEmpty() ) {
+            var matchingRoute = matchingRoutes[ 1 ];
+            // collect action:
+            var actions = {};
+            var matchingActions = isStruct( matchingRoute.action ) ? matchingRoute.action : {};
+            structAppend( actions, matchingActions, true );
+            for ( var verb in matchingRoute.verbs ) {
+                structInsert( actions, verb, matchingRoute.event );
+            }
+            var thisRouteActions = isStruct( thisRoute.action ) ? thisRoute.action : {};
+            structAppend( actions, thisRouteActions, true );
+            for ( var verb in thisRoute.verbs ) {
+                structInsert( actions, verb, thisRoute.event );
+            }
+            matchingRoute.action = actions;
+            matchingRoute.verbs = "";
+            return;
+        }
 
 		// Check if we have optional args by looking for a ?
 		if( findnocase( "?", thisRoute.pattern ) AND NOT findNoCase( "regex:", thisRoute.pattern ) ){

--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -761,7 +761,8 @@ component accessors="true" extends="coldbox.system.FrameworkSupertype" threadsaf
 
         // Check for existing route matches
         var matchingRoutes = variables.routes.filter( function( route ) {
-            return route.pattern == thisRoute.pattern;
+            return route.pattern == thisRoute.pattern &&
+                route.domain == thisRoute.domain;
         } );
         if ( ! matchingRoutes.isEmpty() ) {
             var matchingRoute = matchingRoutes[ 1 ];
@@ -779,7 +780,7 @@ component accessors="true" extends="coldbox.system.FrameworkSupertype" threadsaf
             }
             matchingRoute.action = actions;
             matchingRoute.verbs = "";
-            return;
+            return this;
         }
 
 		// Check if we have optional args by looking for a ?

--- a/tests/specs/web/routing/ResourcesTest.cfc
+++ b/tests/specs/web/routing/ResourcesTest.cfc
@@ -62,7 +62,7 @@
                     {
                         pattern = "/photos/:id",
                         handler = "photos",
-                        action = { GET = "show", PUT = "update", PATCH = "update", POST = "create", DELETE = "delete" },
+                        action = { GET = "show", PUT = "update", PATCH = "update", DELETE = "delete" },
                         module  = "",
                         namespace = ""
                     },
@@ -111,7 +111,7 @@
                     {
                         pattern = "/photos/:id",
                         handler = "PhotosController",
-                        action = { GET = "show", PUT = "update", PATCH = "update", POST = "create", DELETE = "delete" },
+                        action = { GET = "show", PUT = "update", PATCH = "update", DELETE = "delete" },
                         module  = "",
                         namespace = ""
                     },
@@ -160,7 +160,7 @@
                     {
                         pattern = "/photos/:photoId",
                         handler = "photos",
-                        action  = { GET = "show", PUT = "update", PATCH = "update", POST = "create", DELETE = "delete" },
+                        action  = { GET = "show", PUT = "update", PATCH = "update", DELETE = "delete" },
                         module  = "",
                         namespace = ""
                     },

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -43,8 +43,6 @@ component extends="coldbox.system.testing.BaseModelTest"{
 			});
 
 			story( "I want to group routes with common options", function(){
-
-
 				given( "a grouped route with handler and pattern only", function(){
 					then( "it should store the route with common options", function(){
 						router.group( { pattern="/api", handler="api" }, function( options ){
@@ -156,7 +154,25 @@ component extends="coldbox.system.testing.BaseModelTest"{
 							);
 						} );
 					} );
-				});
+                });
+
+                given( "different HTTP verbs for the same route", function(){
+                    then( "both verbs should be registered", function(){
+                        router.post( "photos/", "photos.create" );
+                        router.get( "photos/", "photos.index" );
+
+                        var routes = router.getRoutes();
+                        expect( routes ).toBeArray();
+                        expect( routes ).toHaveLength( 1, "One route should be registered" );
+                        expect( routes[ 1 ].pattern ).toBe( "photos/" );
+                        expect( routes[ 1 ].action ).toBeStruct();
+                        expect( routes[ 1 ].action ).toHaveLength( 2, "The registered route should have two actions" );
+                        expect( routes[ 1 ].action ).toBe( {
+                            "GET" = "photos.index",
+                            "POST" = "photos.create"
+                        } );
+                    });
+                });
 			} );
 
 			story( "I can register module routes", function(){
@@ -428,7 +444,32 @@ component extends="coldbox.system.testing.BaseModelTest"{
 				});
 			});
 
-
+            story( "I can register a suite of routes with resources", function() {
+                given( "I register a resource", function() {
+                    then( "I should have a suite of routes for that resource", function() {
+                        router.resources( "photos" );
+                        var routes = router.getRoutes();
+                        expect( routes ).toBeArray();
+                        expect( routes ).toHaveLength( 4 );
+                        expect( routes[ 1 ].pattern ).toBe( "photos/:id/edit/" );
+                        expect( routes[ 1 ].action ).toBe( { "GET" = "edit" } );
+                        expect( routes[ 2 ].pattern ).toBe( "photos/new/" );
+                        expect( routes[ 2 ].action ).toBe( { "GET" = "new" } );
+                        expect( routes[ 3 ].pattern ).toBe( "photos/:id/" );
+                        expect( routes[ 3 ].action ).toBe( {
+                            "GET" = "show",
+                            "PATCH" = "update",
+                            "PUT" = "update",
+                            "DELETE" = "delete"
+                        } );
+                        expect( routes[ 4 ].pattern ).toBe( "photos/" );
+                        expect( routes[ 4 ].action ).toBe( {
+                            "GET" = "index",
+                            "POST" = "create"
+                        } );
+                    } );
+                } );
+            } );
 		});
 	}
 


### PR DESCRIPTION
Currently, the following doesn't work as expected:

```
router.post( "photos/", "photos.create" );
router.get( "photos/", "photos.index" );
```

You would expect then you could either `GET` or `POST` to `photos/`.  This is not the case.  Instead this creates two routes.  If you tried to `GET /photos` you would match the route that only has a `POST` verb and it would give you an error of an invalid HTTP verb.

This PR attempts to merge routes when a route with a matching pattern already exists in the routing table.