### PR TITLE
Fix default bug report to show SQL error detail for adobe SQL exceptions

### DIFF
--- a/system/includes/BugReport.cfm
+++ b/system/includes/BugReport.cfm
@@ -169,7 +169,11 @@ A reporting template about exceptions in your ColdBox Apps
 			   <td align="right" class="info"> Remote Address: </td>
 			   <td >#htmlEditFormat(cgi.remote_addr)#</td>
 			 </tr>
-			 <cfif isStruct(oException.getExceptionStruct()) >
+
+			 <cfif 
+			 	isStruct(oException.getExceptionStruct()) 
+			 	OR findNoCase('DatabaseQueryException', getMetadata(oException.getExceptionStruct()).getName())
+			 >
 
 			  <cfif findnocase("database", oException.getType() )>
 				  <tr >


### PR DESCRIPTION
Adobe coldfusion returns false when executing isStruct() against an exception struct. This caused the default coldbox error template to not show the SQL exception details.

Added in another statement to check the underlying class name of the exception struct to determine if it is a database exception.