### PR TITLE
lowercase cgi.server_name (returns empty when preservecaseforstructke…

### DIFF
--- a/system/cache/report/monitor.cfm
+++ b/system/cache/report/monitor.cfm
@@ -11,7 +11,7 @@ Description :
 	
 ATTRIBUTES:
 - cacheBox : An instance reference to the cacheBox factory to report on
-- baseURL (optional='default') : An optional baseURL that will be used to post to this monitor on. Default is cgi.script_name
+- baseURL (optional='default') : An optional baseURL that will be used to post to this monitor on. Default is CGI.SCRIPT_NAME
 - skin (optional='default') : The skin to render the report in, it uses 'default' skin by default.
 ----------------------------------------------------------------------->
 
@@ -26,7 +26,7 @@ ATTRIBUTES:
 <!--- CacheBox Factory --->
 <cfparam name="attributes.cacheFactory" 	type="any" default="">
 <!--- BaseURL --->	
-<cfparam name="attributes.baseURL" 			type="string" default="#cgi.script_name#">
+<cfparam name="attributes.baseURL" 			type="string" default="#CGI.SCRIPT_NAME#">
 <!--- Skin To Use --->
 <cfparam name="attributes.skin"				type="string" default="default">
 <!--- Enable Monitor --->

--- a/system/cache/util/EventURLFacade.cfc
+++ b/system/cache/util/EventURLFacade.cfc
@@ -36,7 +36,7 @@ component accessors="true"{
 			// Get the original incoming context hash
 			"incomingHash" 	= incomingHash,
 			// Multi-Host support
-			"cgihost" 		= cgi.http_host
+			"cgihost" 		= CGI.HTTP_HOST
 		};
 
 		// Incorporate Routed Structs
@@ -65,7 +65,7 @@ component accessors="true"{
 			// Get the original incoming context hash according to incoming arguments
 			"incomingHash" 	= hash( virtualRC.toString() ),
 			// Multi-Host support
-			"cgihost" 		= cgi.http_host
+			"cgihost" 		= CGI.HTTP_HOST
 		};
 
 		// return hash from cache key struct

--- a/system/includes/BugReport.cfm
+++ b/system/includes/BugReport.cfm
@@ -85,30 +85,29 @@ A reporting template about exceptions in your ColdBox Apps
 		<cfif ArrayLen( oException.getTagContext() )>
 			  <cfset local.arrayTagContext = oException.getTagContext()>
 			  <cfloop from="1" to="#arrayLen( local.arrayTagContext )#" index="local.i">
-				  <!--- Don't clutter the screen with this information unless it's actually useful --->
-			  	  <cfif structKeyExists( local.arrayTagContext[ local.i ], "ID" ) and
+				<!--- Don't clutter the screen with this information unless it's actually useful --->
+			  	<cfif structKeyExists( local.arrayTagContext[ local.i ], "ID" ) and
 			  	  		len( local.arrayTagContext[ local.i ].ID ) and
-			  	  		local.arrayTagContext[ local.i ].ID neq "??"
-			  	  >
-			  <tr >
+			  	  		local.arrayTagContext[ local.i ].ID neq "??">
+			  		<tr>
 						<td align="right" class="info">Tag:</td>
 					    <td>#local.arrayTagContext[ local.i ].ID#</td>
-			  </tr>
-				  </cfif>
-			   <tr >
+			  		</tr>
+				</cfif>
+			   	<tr>
 					<td align="right" class="info">Template:</td>
 				    <td style="color:green;"><strong>#local.arrayTagContext[ local.i ].Template#</strong></td>
-				   </tr>
-			  	  <cfif structKeyExists( local.arrayTagContext[ local.i ], "codePrintHTML" )>
-					  <tr class="tablebreak">
-				<td align="right" class="info">LINE:</td>
+				</tr>
+			  	<cfif structKeyExists( local.arrayTagContext[ local.i ], "codePrintHTML" )>
+					<tr class="tablebreak">
+						<td align="right" class="info">LINE:</td>
 					    <td>#local.arrayTagContext[ local.i ].codePrintHTML#</td>
-			   </tr>
-				  <cfelse>
-			   <tr class="tablebreak">
+			   		</tr>
+				<cfelse>
+			   		<tr class="tablebreak">
 						<td align="right" class="info">Line:</td>
 					    <td ><strong>#local.arrayTagContext[ local.i ].LINE#</strong></td>
-			   </tr>
+			   		</tr>
 				  </cfif>
 			  </cfloop>
 		</cfif>
@@ -157,26 +156,26 @@ A reporting template about exceptions in your ColdBox Apps
 			 </tr>
 			 <tr>
 			   <td align="right" class="info"> Host &amp; Server: </td>
-			   <td >#htmlEditFormat(cgi.http_host)# #local.thisInetHost#</td>
+			   <td >#htmlEditFormat(CGI.HTTP_HOST)# #local.thisInetHost#</td>
 			 </tr>
 			 <tr>
 			   <td align="right" class="info">Query String: </td>
-			   <td >#htmlEditFormat(cgi.QUERY_STRING)#</td>
+			   <td >#htmlEditFormat(CGI.QUERY_STRING)#</td>
 			 </tr>
 
-			<cfif len(cgi.HTTP_REFERER)>
+			<cfif len(CGI.HTTP_REFERER)>
 			 <tr>
 			   <td align="right" class="info">Referrer:</td>
-			   <td >#htmlEditFormat(cgi.HTTP_REFERER)#</td>
+			   <td >#htmlEditFormat(CGI.HTTP_REFERER)#</td>
 			 </tr>
 			</cfif>
 			<tr>
 			   <td align="right" class="info">Browser:</td>
-			   <td >#htmlEditFormat(cgi.HTTP_USER_AGENT)#</td>
+			   <td >#htmlEditFormat(CGI.HTTP_USER_AGENT)#</td>
 			</tr>
 			<tr>
 			   <td align="right" class="info"> Remote Address: </td>
-			   <td >#htmlEditFormat(cgi.remote_addr)#</td>
+			   <td >#htmlEditFormat(CGI.REMOTE_ADDR)#</td>
 			 </tr>
 
 			 <cfif

--- a/system/remote/ColdboxProxy.cfc
+++ b/system/remote/ColdboxProxy.cfc
@@ -25,7 +25,7 @@ Description :
 	<!--- selfAutowire --->
     <cffunction name="selfAutowire" output="false" access="private" hint="Autowire the proxy on creation. This references the super class only, we use cgi information to get the actual proxy component path.">
 		<cfscript>
-			var script_name = cgi.script_name;
+			var script_name = CGI.SCRIPT_NAME;
 			// Only process this logic if hitting a remote proxy CFC directly and if ColdBox exists.
 			if( len( script_name ) < 5 || right( script_name, 4 ) != '.cfc' || !verifyColdBox( throwOnNotExist=false ) ) {
 				return;

--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -371,7 +371,7 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 				prepareMock( getController().getRoutingService() )
 					.$( "getCGIElement" ).$args( "path_info", requestContext ).$results( arguments.route )
 					.$( "getCGIElement" ).$args( "script_name", requestContext ).$results( "" )
-					.$( "getCGIElement" ).$args( "domain", requestContext ).$results( cgi.server_name );
+					.$( "getCGIElement" ).$args( "domain", requestContext ).$results( CGI.SERVER_NAME );
 				arguments.route = "";
         	}
             // if we were passed a route, parse it and prepare the SES interceptor for routing.
@@ -388,7 +388,7 @@ component extends="testbox.system.compat.framework.TestCase"  accessors="true"{
 				prepareMock( getController().getRoutingService() )
 					.$( "getCGIElement" ).$args( "path_info", requestContext ).$results( routeParts.route )
 					.$( "getCGIElement" ).$args( "script_name", requestContext ).$results( "" )
-					.$( "getCGIElement" ).$args( "domain", requestContext ).$results( cgi.server_name );
+					.$( "getCGIElement" ).$args( "domain", requestContext ).$results( CGI.SERVER_NAME );
             }
             else{
                 // If we were passed just an event, remove routing since we don't need it

--- a/system/web/Controller.cfc
+++ b/system/web/Controller.cfc
@@ -296,7 +296,7 @@ component serializable="false" accessors="true"{
 		var relocationType  = "EVENT";
 		var relocationURL   = "";
 		var eventName	    = variables.configSettings[ "EventName" ];
-		var frontController = listlast( cgi.script_name, "/" );
+		var frontController = listlast( CGI.SCRIPT_NAME, "/" );
 		var oRequestContext = services.requestService.getContext();
 		var routeString     = 0;
 

--- a/system/web/config/ApplicationLoader.cfc
+++ b/system/web/config/ApplicationLoader.cfc
@@ -152,7 +152,7 @@ component accessors="true"{
 	 */
 	function calculateAppMapping( required configStruct ){
 		// Get the web path from CGI.
-		var	webPath = replacenocase( cgi.script_name,getFileFromPath( cgi.script_name),"" );
+		var	webPath = replacenocase( CGI.SCRIPT_NAME,getFileFromPath( CGI.SCRIPT_NAME),"" );
 		// Cleanup the template path
 		var localPath = getDirectoryFromPath(replacenocase(getTemplatePath(),"\","/","all" ));
 		// Verify Path Location
@@ -729,7 +729,7 @@ component accessors="true"{
 			for( var key in environments ){
 				// loop over patterns
 				for( var i=1; i lte listLen( environments[ key ] ); i=i+1 ){
-					if( reFindNoCase( listGetAt( environments[ key ], i ), cgi.http_host) ){
+					if( reFindNoCase( listGetAt( environments[ key ], i ), CGI.HTTP_HOST) ){
 						// set new environment
 						configStruct.environment = key;
 					}

--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -670,10 +670,10 @@ component serializable=false accessors="true"{
 	}
 
 	/**
-	* Are we in SSL or not? This method looks at cgi.server_port_secure for indication
+	* Are we in SSL or not? This method looks at CGI.SERVER_PORT_SECURE for indication
 	*/
 	boolean function isSSL(){
-		if( isBoolean( cgi.server_port_secure ) AND cgi.server_port_secure ){
+		if( isBoolean( CGI.SERVER_PORT_SECURE ) AND CGI.SERVER_PORT_SECURE ){
 			return true;
 		}
 		// Add typical proxy headers for SSL
@@ -683,8 +683,8 @@ component serializable=false accessors="true"{
 		if( getHTTPHeader( "x-scheme", "http" ) eq "https" ){
 			return true;
 		}
-		// cgi.https
-		if( cgi.keyExists( "https" ) and cgi.https eq "on" ){
+		// CGI.HTTPS
+		if( CGI.keyExists( "HTTPS" ) and CGI.HTTPS eq "on" ){
 			return true;
 		}
 		return false;
@@ -975,7 +975,7 @@ component serializable=false accessors="true"{
         return arrayToList( [
             isSSL() ? "https://" : "http://",
             CGI.SERVER_NAME,
-			listFind( "80,443", cgi.server_port ) ? "" : ":" & cgi.server_port,
+			listFind( "80,443", CGI.SERVER_PORT ) ? "" : ":" & CGI.SERVER_PORT,
             isSES() ? "" : "/index.cfm",
             CGI.PATH_INFO,
             CGI.QUERY_STRING != "" && CGI.PATH_INFO == "" ? "/" : "",
@@ -1434,7 +1434,7 @@ component serializable=false accessors="true"{
 	* Get the HTTP Request Method Type
 	*/
 	string function getHTTPMethod(){
-		return getValue( "_method", cgi.REQUEST_METHOD );
+		return getValue( "_method", CGI.REQUEST_METHOD );
 	}
 
 	/**

--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -144,9 +144,9 @@ component accessors="true" extends="coldbox.system.FrameworkSupertype" threadsaf
 		variables.validExtensions = variables.VALID_EXTENSIONS;
 		// Base Routing URL, defaults to the domain and app mapping defined by the routing services
 		if( len( controller.getSetting( "RoutingAppMapping" ) ) lte 1 ){
-			variables.baseURL = "http://#cgi.HTTP_HOST#";
+			variables.baseURL = "http://#CGI.HTTP_HOST#";
 		} else {
-			variables.baseURL = "http://#cgi.HTTP_HOST##controller.getSetting( "RoutingAppMapping" )#";
+			variables.baseURL = "http://#CGI.HTTP_HOST##controller.getSetting( "RoutingAppMapping" )#";
 		}
 		// Are full rewrites enabled
 		variables.fullRewrites = false;

--- a/system/web/services/HandlerService.cfc
+++ b/system/web/services/HandlerService.cfc
@@ -443,7 +443,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 		}
 
 		// Invalid Event Detected, log it in the Application log, not a coldbox log but an app log
-		variables.log.error( "Invalid Event detected: #arguments.event#. Path info: #cgi.path_info#, query string: #cgi.query_string#" );
+		variables.log.error( "Invalid Event detected: #arguments.event#. Path info: #CGI.PATH_INFO#, query string: #CGI.QUERY_STRING#" );
 
 		// Throw Exception
 		throw(

--- a/system/web/services/RoutingService.cfc
+++ b/system/web/services/RoutingService.cfc
@@ -180,7 +180,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 				.setSESBaseURL(
 					"http" &
 					( event.isSSL() ? "s" : "" ) &
-					"://#cgi.HTTP_HOST##variables.routingAppMapping#" &
+					"://#CGI.HTTP_HOST##variables.routingAppMapping#" &
 					( variables.router.getFullRewrites() ? "" : "index.cfm" )
 				);
 		}
@@ -268,10 +268,10 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 		// Process SSL Redirects
 		if( routeResults.route.ssl AND NOT event.isSSL() ){
 			controller.relocate(
-				URL         = event.getSESBaseURL() & reReplace( cgi.path_info, "^\/", "" ),
+				URL         = event.getSESBaseURL() & reReplace( CGI.PATH_INFO, "^\/", "" ),
 				ssl         = true,
 				statusCode  = 302,
-				queryString = cgi.query_string
+				queryString = CGI.QUERY_STRING
 			);
 			return;
 		}

--- a/test-harness/config/Coldbox.cfc
+++ b/test-harness/config/Coldbox.cfc
@@ -55,7 +55,7 @@
 
 		// environment settings, create a detectEnvironment() method to detect it yourself.
 		// create a function with the name of the environment so it can be executed if that environment is detected
-		// the value of the environment is a list of regex patterns to match the cgi.http_host.
+		// the value of the environment is a list of regex patterns to match the CGI.HTTP_HOST.
 		environments = {
 			development = "^cf.,^localhost,^127/.0/.0/.1"
 		};

--- a/test-harness/config/Router.cfc
+++ b/test-harness/config/Router.cfc
@@ -36,7 +36,7 @@ component{
 		// Responses + Conditions
 		route( "/ff" )
 			.withCondition( function(){
-				return ( findnocase( "Firefox", cgi.HTTP_USER_AGENT ) ? true : false );
+				return ( findnocase( "Firefox", CGI.HTTP_USER_AGENT ) ? true : false );
 			} )
 			.toResponse( "Hello FireFox" );
 

--- a/test-harness/config/Routes.cfm
+++ b/test-harness/config/Routes.cfm
@@ -16,7 +16,7 @@
 	addRoute( pattern="post/:postID-regex:([a-zA-Z]+?)/:userID-alpha/regex:(xml|json)", handler="ehGeneral", action="dumpRC" );
 
 	function ff(){
-		return ( findnocase( "Firefox", cgi.HTTP_USER_AGENT ) ? true : false );
+		return ( findnocase( "Firefox", CGI.HTTP_USER_AGENT ) ? true : false );
 	};
 
 	function fResponse(rc){

--- a/tests/specs/cache/util/EventsURLFacadeTest.cfc
+++ b/tests/specs/cache/util/EventsURLFacadeTest.cfc
@@ -48,7 +48,7 @@ Description :
 			};
 			var target = {
 				"incomingHash" : hash( testargs.toString() ),
-				"cgihost" : cgi.http_host
+				"cgihost" : CGI.HTTP_HOST
 			};
 
 			expect( testHash ).toBe( hash( target.toString() ) );

--- a/tests/specs/web/context/requestcontextTest.cfc
+++ b/tests/specs/web/context/requestcontextTest.cfc
@@ -664,7 +664,7 @@ component extends="coldbox.system.testing.BaseModelTest"{
         debug( event.getFullUrl() );
         expect( event.getFullUrl() ).toBeTypeOf( "url" );
         var javaUrl = createObject( "java", "java.net.URL" ).init( event.getFullUrl() );
-        expect( javaUrl.getPort() ).toBe( listFind( "80,443", cgi.server_port ) > 0 ? -1 : cgi.server_port );
+        expect( javaUrl.getPort() ).toBe( listFind( "80,443", CGI.SERVER_PORT ) > 0 ? -1 : CGI.SERVER_PORT );
     }
 
 }

--- a/tests/suites/eventCachingCollisions/config/Coldbox.cfc
+++ b/tests/suites/eventCachingCollisions/config/Coldbox.cfc
@@ -78,7 +78,7 @@ Optional Methods
 
 		// environment settings, create a detectEnvironment() method to detect it yourself.
 		// create a function with the name of the environment so it can be executed if that environment is detected
-		// the value of the environment is a list of regex patterns to match the cgi.http_host.
+		// the value of the environment is a list of regex patterns to match the CGI.HTTP_HOST.
 		environments = {
 		};
 

--- a/tests/suites/eventCachingCollisions/config/routes.cfm
+++ b/tests/suites/eventCachingCollisions/config/routes.cfm
@@ -58,9 +58,9 @@ NOTE: The interceptor will create a new setting called: sesBaseURL with this val
 	Else, htmlBaseURL and sesBaseURL should be the same.
 --->
 <cfif len(getSetting("AppMapping")) lte 1>
-	<cfset setBaseURL("http://#cgi.HTTP_HOST#/index.cfm")>
+	<cfset setBaseURL("http://#CGI.HTTP_HOST#/index.cfm")>
 <cfelse>
-	<cfset setBaseURL("http://#cgi.HTTP_HOST#/#getSetting('AppMapping')#/index.cfm")>
+	<cfset setBaseURL("http://#CGI.HTTP_HOST#/#getSetting('AppMapping')#/index.cfm")>
 </cfif>
 
 <!--- -------------------------------------------

--- a/tests/suites/eventCachingCollisions/runTest.cfm
+++ b/tests/suites/eventCachingCollisions/runTest.cfm
@@ -7,7 +7,7 @@
     <!---// find the where the filename starts (should be the last wherever the last period (".") is) //--->
     <cfset var sEndDir = reFind("/[^/]+#arguments.ext#$", sPath) />
 	<cfset sPath = left(sPath, sEndDir) />
-	<cfset returnURL = "http://" & cgi.http_host & sPath />
+	<cfset returnURL = "http://" & CGI.HTTP_HOST & sPath />
     <cfreturn returnURL />
 </cffunction>
 

--- a/tests/suites/loadtests/4load/config/Coldbox.cfc
+++ b/tests/suites/loadtests/4load/config/Coldbox.cfc
@@ -43,7 +43,7 @@
 
 		// environment settings, create a detectEnvironment() method to detect it yourself.
 		// create a function with the name of the environment so it can be executed if that environment is detected
-		// the value of the environment is a list of regex patterns to match the cgi.http_host.
+		// the value of the environment is a list of regex patterns to match the CGI.HTTP_HOST.
 		environments = {
 			//development = "localhost,127\.0\.0\.1"
 		};


### PR DESCRIPTION
Windows version 2019 IIS-10
Coldfusion 2016 with update-11

this.serialization.preservecaseforstructkey = true;

This creates CGI struct with keys in uppercase letters. According to Microsoft that CGI keys are in uppercase. As CF is not case sensitive but somehow this caused problems when accessing CGI with lowercase cgi.server_name (returns empty when preservecaseforstructkey setting is enabled)

Fix: access CGI key with uppercase letters e.g CGI.HTTP_HOST

CGI keys with uppercase letters will be consistent with the rest of code base. some places cgi key are in uppercase.

https://docs.microsoft.com/en-us/iis/web-dev-reference/server-variables