### PR TITLE
LOGBOX-35 always allow spawning of log processor thread when engine supports it

### DIFF
--- a/system/core/util/Util.cfc
+++ b/system/core/util/Util.cfc
@@ -10,6 +10,13 @@ Description :
 ----------------------------------------------------------------------->
 <cfcomponent output="false" hint="The main ColdBox utility library filled with lots of nice goodies.">
 
+	<!--- constructor --->
+	<cffunction name="init" access="public" returntype="any" output="false">
+		<cfscript>
+			checkThreadWithinThreadSupport();
+		</cfscript>
+	</cffunction>
+
 	<!--- getMixerUtil --->
     <cffunction name="getMixerUtil" output="false" access="public" returntype="any" hint="Get the mixer utility" doc_generic="coldbox.system.core.dynamic.MixerUtil">
     	<cfscript>
@@ -92,6 +99,29 @@ Description :
 
 			return false;
 		</cfscript>
+	</cffunction>
+
+	<!--- threadWithinThreadSupported --->
+	<cffunction name="threadWithinThreadSupported" access="public" returntype="boolean" hint="I return whether or not the current engine allows spawning threads from child threads" output="false">
+		<cfreturn variables.threadWithinThreadSupported />
+	</cffunction>
+
+	<!--- checkThreadWithinThreadSupport --->
+	<cffunction name="checkThreadWithinThreadSupport" access="private" returntype="any" output="false" hint="A little test logic to check for thread within thread support">
+		<cfset variables.threadWithinThreadSupported = false/>
+		<cftry>
+			<cfthread name="#CreateUUId()#">
+				<cftry>
+					<cfthread name="#CreateUUId()#">
+						<cfset variables.threadWithinThreadSupported = true />
+					</cfthread>
+					<cfcatch>
+					</cfcatch>
+				</cftry>
+			</cfthread>
+			<cfcatch>
+			</cfcatch>
+		</cftry>
 	</cffunction>
 
 	<!--- placeHolderReplacer --->

--- a/system/logging/appenders/FileAppender.cfc
+++ b/system/logging/appenders/FileAppender.cfc
@@ -306,8 +306,10 @@ component accessors="true" extends="coldbox.system.logging.AbstractAppender"{
 	 * @message The target message
 	 */
 	private FileAppender function append( required message ){
-		// If we are not in a thread, then start the log listener, else queue it
-		if( !getUtil().inThread() ){
+		var util = getUtil();
+
+		// if thread within thread not supported, check we're not already in child thread
+		if( util.threadWithinThreadSupported() || !util.inThread() ){
 			// Ensure log listener
 			startLogListener();
 		}


### PR DESCRIPTION
This prevents issues where the log processing thread never spawns, or does not spawn in a timely manner, when logging in background threads. This problem can lead to memory usage issues because the log queue is held in heap and cannot be collected.