### PR TITLE
Add a whileSwapped test helper to swap out wirebox mappings inside a callback

### DIFF
--- a/tests/specs/integration/IntegrationTestSpec.cfc
+++ b/tests/specs/integration/IntegrationTestSpec.cfc
@@ -1,0 +1,71 @@
+component extends="coldbox.system.testing.BaseTestCase" appMapping="/cbTestHarness" {
+
+    function run() {
+        describe( "coldbox integration test helpers", function() {
+            describe( "whileSwapped WireBox helper", function() {
+                it( "can swap out a WireBox mapping inside a closure", function() {
+                    var mappingName = "test-mapping";
+                    var originalInstance = new tests.resources.Class1();
+                    var newInstance = new tests.resources.Class2();
+                    getWireBox().getBinder().map( mappingName ).toValue( originalInstance );
+
+                    expect( getWireBox().getInstance( mappingName ) ).toBe( originalInstance );
+                    expect( getWireBox().getInstance( mappingName ) ).notToBe( newInstance );
+
+                    whileSwapped( { "#mappingName#" = newInstance }, function() {
+                        expect( getWireBox().getInstance( mappingName ) ).toBe( newInstance );
+                        expect( getWireBox().getInstance( mappingName ) ).notToBe( originalInstance );
+                    } );
+
+                    expect( getWireBox().getInstance( mappingName ) ).toBe( originalInstance );
+                    expect( getWireBox().getInstance( mappingName ) ).notToBe( newInstance );
+                } );
+
+                it( "verifies the mapping exists before swapping it out", function() {
+                    var mappingName = "does-not-exist";
+                    var newInstance = new tests.resources.Class2();
+
+                    expect( function() {
+                        whileSwapped( { "#mappingName#" = newInstance }, function() {
+                            fail( "Test should have failed because the mapping [#mappingName#] does not exist in WireBox." );
+                        } );
+                    } ).toThrow( regex = "No mapping \[#mappingName#\] already configured in WireBox\." );
+                } );
+
+                it( "can skip verifying the mapping exists before swapping it out", function() {
+                    var mappingName = "does-not-exist";
+                    var newInstance = new tests.resources.Class2();
+
+                    expect( function() {
+                        whileSwapped( { "#mappingName#" = newInstance }, function() {
+                            expect( getWireBox().getInstance( mappingName ) ).toBe( newInstance );
+                        }, false );
+                    } ).notToThrow( regex = "No mapping \[#mappingName#\] already configured in WireBox\." );
+                } );
+
+                it( "sets back the mappings even if there is an exception inside the closure", function() {
+                    var mappingName = "test-mapping";
+                    var originalInstance = new tests.resources.Class1();
+                    var newInstance = new tests.resources.Class2();
+                    getWireBox().getBinder().map( mappingName ).toValue( originalInstance );
+
+                    expect( getWireBox().getInstance( mappingName ) ).toBe( originalInstance );
+                    expect( getWireBox().getInstance( mappingName ) ).notToBe( newInstance );
+
+                    try {
+                        whileSwapped( { "#mappingName#" = newInstance }, function() {
+                            throw( "Boom! Some error" );
+                        } );
+                    } catch ( any e ) {
+                        expect( getWireBox().getInstance( mappingName ) ).toBe( originalInstance );
+                        expect( getWireBox().getInstance( mappingName ) ).notToBe( newInstance );
+                        return;
+                    }
+
+                    fail( "Should have gone in to the catch block and finished the test" );
+                } );
+            } );
+        } );
+    }
+
+}


### PR DESCRIPTION
Used like so:

```cfc
component extends="coldbox.system.testing.BaseTestCase" {

    function run() {
        describe( "Currency API", function() {
            it( "can convert an amount from one currency to another", function() {
                var currencyApiStub = createStub()
                    .$( "getExchangeRate" )
                    .$args( "EUR", "USD" )
                    .$results( 1.11 );
                whileSwapped( { "currencyAPI": currencyApiStub }, function() {
                    var event = get( "/currency/convert", {
                        "amount": 10.00,
                        "fromCurrency": "EUR",
                        "toCurrency": "USD"
                    } );
                    expect( event.getStatusCode() ).toBe( 200 );
                    expect( event.getRenderData().data ).toBe( 11.10 );
                } );
            } );
        } );
    }

}
```