### PR TITLE
Option to call Function to calculate Event Cache Timeout

### DIFF
--- a/system/web/services/HandlerService.cfc
+++ b/system/web/services/HandlerService.cfc
@@ -183,7 +183,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 				// Create caching data structure according to MD, as the cache key can be dynamic by execution.
 				var eventCachingData = {};
 				structAppend( eventCachingData, eventDictionaryEntry, true );
-
+				if( len( eventCachingData.cacheTimeoutUdfInstance ) && len( eventCachingData.cacheTimeoutUdfMethod ) ){
+					eventCachingData.timeout = wirebox.getInstance( eventCachingData.cacheTimeoutUdfInstance )[ eventCachingData.cacheTimeoutUdfMethod ]();
+				}
 				// Create the Cache Key to save
 				eventCachingData.cacheKey = oEventURLFacade.buildEventKey(
 					keySuffix 		= eventDictionaryEntry.suffix,
@@ -583,6 +585,8 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 			"cacheable" 		    = false,
 			"timeout" 		        = "",
 			"lastAccessTimeout" 	= "",
+			"cacheTimeoutUdfInstance" = "",
+			"cacheTimeoutUdfMethod" = "",
 			"cacheKey"  		    = "",
 			"suffix" 			    = "",
 			"provider"				= "template"
@@ -617,6 +621,8 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 						mdEntry.timeout 			= arguments.ehBean.getActionMetadata( "cacheTimeout", "" );
 						mdEntry.lastAccessTimeout 	= arguments.ehBean.getActionMetadata( "cacheLastAccessTimeout", "" );
 						mdEntry.provider 		 	= arguments.ehBean.getActionMetadata( "cacheProvider", "template" );
+						mdEntry.cacheTimeoutUdfInstance = arguments.ehBean.getActionMetadata( "cacheTimeoutUdfInstance", "" );
+						mdEntry.cacheTimeoutUdfMethod = arguments.ehBean.getActionMetadata( "cacheTimeoutUdfMethod", "" );
 
 						// Handler Event Cache Key Suffix, this is global to the event
 						if( isClosure( arguments.oEventHandler.EVENT_CACHE_SUFFIX ) || isCustomFunction( arguments.oEventHandler.EVENT_CACHE_SUFFIX ) ){

--- a/system/web/services/HandlerService.cfc
+++ b/system/web/services/HandlerService.cfc
@@ -184,7 +184,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 				var eventCachingData = {};
 				structAppend( eventCachingData, eventDictionaryEntry, true );
 				if( len( eventCachingData.cacheTimeoutUdfInstance ) && len( eventCachingData.cacheTimeoutUdfMethod ) ){
-					eventCachingData.timeout = wirebox.getInstance( eventCachingData.cacheTimeoutUdfInstance )[ eventCachingData.cacheTimeoutUdfMethod ]();
+					eventCachingData.timeout = invoke( wirebox.getInstance( eventCachingData.cacheTimeoutUdfInstance ), eventCachingData.cacheTimeoutUdfMethod );
 				}
 				// Create the Cache Key to save
 				eventCachingData.cacheKey = oEventURLFacade.buildEventKey(


### PR DESCRIPTION
Clients have requested the ability to set a specific timeout for Event Caching... for example midnight... currently we cannot do that. 
Lucee for one, does not allow us to use a UDF or Closure or even a variable in the function meta data, only a constant value. So we have to manually guess a timeout, 120 or 500 or something, or make it 1440 and then manually clear the caches with a scheduled task or something.
 
I propose we use metadata in the function to name the DSL of the Model, and metadata to name the method to call on the Model to calculate this timeout value.

{code:java}
cacheTimeoutUdfInstance1="apiUtils@api" 
cacheTimeoutUdfMethod1="getMinutesUntilMidnight"
{code}

If both of these metadata values are present, this would call 
`wirebox.getInstance( "apiUtils@api" ).getMinutesUntilMidnight()` 
and override the metadata for the timeout.

Pull request is attached. 
I am not sold on the names, and maybe there is a more stylish way to do it ( a shorthand maybe so we can use one variable ).

https://ortussolutions.atlassian.net/browse/COLDBOX-828