### PR TITLE
Singleton renderer

### DIFF
--- a/.cfconfig.json
+++ b/.cfconfig.json
@@ -26,5 +26,6 @@
     },
     "debuggingEnabled": false,
     "ajaxDebugWindowEnabled": false,
-    "debuggingReportExecutionTimes": false
+    "debuggingReportExecutionTimes": false,
+    "maxCFThreads":100
 }

--- a/system/logging/Logger.cfc
+++ b/system/logging/Logger.cfc
@@ -96,7 +96,7 @@ component accessors="true"{
 		}
 
 		throw(
-			message = "Appender #arguments.name# does not exist.",
+			message = "Appender #arguments.name# does not exist. The appenders registered are [#structKeyList( variables.appenders )#]",
 			detail  = "The appenders registered are #structKeyList( variables.appenders )#",
 			type    = "Logger.AppenderNotFound"
 		);
@@ -334,7 +334,6 @@ component accessors="true"{
 		if( canLog( arguments.severity ) ){
 			// Create Logging Event
 			arguments.category = target.getCategory();
-			var logEvent = new coldbox.system.logging.LogEvent( argumentCollection=arguments );
 
 			// Do we have appenders locally? or go to root Logger
 			if( NOT hasAppenders() ){
@@ -359,12 +358,24 @@ component accessors="true"{
 					// Thread this puppy
 					thread action       = "run"
 						name         = "logMessage_#replace( createUUID(), "-", "", "all" )#"
-						logEvent     = "#logEvent#"
-						thisAppender = "#thisAppender#"
+						appenderName = "#key#"
+						message="#arguments.message#"
+						severity="#arguments.severity#"
+						extraInfo="#arguments.extraInfo#"
 					{
-						attributes.thisAppender.logMessage( attributes.logEvent );
+						var target = this;
+						if( !hasAppenders() ){
+							target = getRootLogger();
+						}
+						var thisAppender = target.getAppender( attributes.appenderName );
+						thread.logEvent = new coldbox.system.logging.LogEvent( message=attributes.message, severity=attributes.severity, extraInfo=attributes.extraInfo );
+						thisAppender.logMessage( thread.logEvent );
 					}
+					  
 				} else {
+					if( isNull( logEvent ) ) {
+						var logEvent = new coldbox.system.logging.LogEvent( argumentCollection=arguments );	
+					}
 					thisAppender.logMessage( logEvent );
 				}
 			}

--- a/system/logging/Logger.cfc
+++ b/system/logging/Logger.cfc
@@ -96,7 +96,7 @@ component accessors="true"{
 		}
 
 		throw(
-			message = "Appender #arguments.name# does not exist. The appenders registered are [#structKeyList( variables.appenders )#]",
+			message = "Appender #arguments.name# does not exist.",
 			detail  = "The appenders registered are #structKeyList( variables.appenders )#",
 			type    = "Logger.AppenderNotFound"
 		);

--- a/system/logging/appenders/FileAppender.cfc
+++ b/system/logging/appenders/FileAppender.cfc
@@ -210,13 +210,13 @@ component accessors="true" extends="coldbox.system.logging.AbstractAppender"{
 			variables.lock( "exclusive", function(){
 				if( !variables.logListener.active ) {
 					out( "FileAppender Listener needs to be started..." );
+					variables.logListener.active = true;
 					// Create the runnable Log Listener, Start it up baby!
 					variables.asyncManager.run(
 						runnable       = this,
 						method         = "runLogListener",
 						loadAppContext = false
 					);
-					variables.logListener.active = true;
 				}
 			} );	
 		}

--- a/system/web/Controller.cfc
+++ b/system/web/Controller.cfc
@@ -58,6 +58,10 @@ component serializable="false" accessors="true"{
 	* The controller logger object
 	*/
 	property name="log";
+	/**
+	* The view/layout renderer
+	*/
+	property name="renderer";
 
 	/**
 	* Constructor
@@ -65,6 +69,9 @@ component serializable="false" accessors="true"{
 	* @appKey The application registered application key
 	*/
 	function init( required appRootPath, appKey="cbController" ){
+		// This will be lazy loaded on first use since the framework isn't ready to create it yet
+		variables.renderer		= "";
+		
 		// Create Utility
 		variables.util 			= new coldbox.system.core.util.Util();
 		// services scope
@@ -122,7 +129,11 @@ component serializable="false" accessors="true"{
 	* Get the system web renderer, you can also retreive it from wirebox via renderer@coldbox
 	*/
 	function getRenderer(){
-		return variables.wireBox.getInstance( "Renderer@coldbox" );
+		// Persist on first creation
+		if( isSimpleValue( variables.renderer ) ) {
+			variables.renderer = variables.wireBox.getInstance( "Renderer@coldbox" );
+		}
+		return variables.renderer;
 	}
 
 	/**

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -407,16 +407,16 @@ component accessors="true" serializable="false" extends="coldbox.system.Framewor
 		var event = getRequestContext();
 
 		savecontent variable="cbox_renderedView"{
-			module
-				template="RendererEncapslator.cfm"
+			cfmodule( 
+				template="RendererEncapslator.cfm",
 				view=arguments.view,
 		    	viewPath=arguments.viewPath,
 		    	viewHelperPath=arguments.viewHelperPath,
-		    	args=arguments.args
+		    	args=arguments.args,
 		    	rendererVariables=variables,
 				event = event,
 				rc 	= event.getCollection(),
-				prc = event.getPrivateCollection();			
+				prc = event.getPrivateCollection() );			
 		}
 
     	return cbox_renderedView;

--- a/system/web/RendererEncapslator.cfm
+++ b/system/web/RendererEncapslator.cfm
@@ -1,0 +1,51 @@
+<!---
+	Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
+	www.ortussolutions.com
+	---
+	I encapsulate variables for rendered templates without the overhaed of a CFC creation
+	
+	@author Brad Wood <brad@ortussolutions.com>
+	@author Luis Majano <lmajano@ortussolutions.com>
+---><cfscript>  
+	// Merge variables from renderer
+	for( _key in attributes.rendererVariables ) {
+		// Skip local, attributes, and arguments scopes which Lucee tucks away inside of variables
+		if( _key != 'local' && _key != 'attributes' && _key != 'arguments' ) {
+			variables[ _key ] = attributes.rendererVariables[ _key ];
+		}
+	}
+	
+	// Views also expect these to be in the variables scope
+	variables.event = attributes.event;
+	variables.rc = attributes.rc;
+	variables.prc = attributes.prc;
+	
+	// Spoof the arguments scope for backwards compat.  i.e. arguments.args
+	variables.arguments = {
+		view=attributes.view,
+    	viewPath=attributes.viewPath,
+    	viewHelperPath=attributes.viewHelperPath,
+    	args=attributes.args
+	};
+ 	// Also add these to variables as well for scope-less lookups
+	structAppend( variables, variables.arguments, true );
+	
+	// global views helper
+	if( len( variables.viewsHelper ) AND ! variables.isViewsHelperIncluded  ){
+		include "#variables.viewsHelper#";
+		variables.isViewsHelperIncluded = true;
+	}
+
+	// view helpers ( directory + view + whatever )
+	if(
+		arguments.viewHelperPath.len() AND
+		NOT variables.renderedHelpers.keyExists( hash( arguments.viewHelperPath.toString() ) )
+	){
+		arguments.viewHelperPath.each( function( item ){
+			include "#arguments.item#";
+		} );
+		variables.renderedHelpers[ hash( arguments.viewHelperPath.toString() ) ] = true;
+	}
+
+	include "#arguments.viewPath#.cfm";
+</cfscript>

--- a/system/web/context/InterceptorState.cfc
+++ b/system/web/context/InterceptorState.cfc
@@ -384,23 +384,22 @@ component accessors="true" extends="coldbox.system.core.events.EventPool"{
 		if( variables.log.canDebug() ){
 			variables.log.debug( "Async interception starting for: '#getState()#', interceptor: #arguments.interceptorKey#, priority: #arguments.asyncPriority#" );
 		}
-
 		thread 	name="#thisThreadName#"
 				action="run"
 				priority="#arguments.asyncPriority#"
-				event="#arguments.event#"
 				interceptData="#arguments.interceptData#"
 				threadName="#thisThreadName#"
 				key="#arguments.interceptorKey#"
 				buffer="#arguments.buffer#"
 		{
+			var event = variables.controller.getRequestService().getContext();
 
 			var args = {
-				"event" 		= attributes.event,
+				"event" 		= event,
 				"interceptData" = attributes.interceptData,
 				"buffer" 		= attributes.buffer,
-				"rc" 			= attributes.event.getCollection(),
-				"prc" 			= attributes.event.getPrivateCollection()
+				"rc" 			= event.getCollection(),
+				"prc" 			= event.getPrivateCollection()
 			};
 
 			invoke( this.getInterceptors().get( attributes.key ), this.getState(), args );

--- a/tests/specs/web/context/interceptorStateTest.cfc
+++ b/tests/specs/web/context/interceptorStateTest.cfc
@@ -132,7 +132,7 @@
 			makepublic( this.state, "invokerAsync" );
 			assertTrue( mockInterceptor.$never( "unittest" ) );
 			this.state.invokerAsync( getMockRequestContext(), {}, this.key, "high", mockBuffer );
-			sleep( 1000 );
+			sleep( 5000 );
 			assertTrue( mockInterceptor.$once( "unittest" ) );
 			// debug( cfthread );
 		</cfscript>


### PR DESCRIPTION
This allows the renderer to be a singleton with NO thread safety issues.  CFModule is used to render views which fully encapsulates their variables scope inside the module call.  Request-specific instance data has been moved from the renderer.  In an example page that calls renderView() 3,000 times, the overall page time dropped from 9 seconds to 700 ms with my changes.   The full test suite is passing on Lucee and Adobe.  This pull also contains fixes necessary for the test suite to even work on Adobe without crashing, including changes to cfthread to avoid messy and costly duplication of CFC instances.