### PR TITLE
Capture request before announcing onRequestCapture

### DIFF
--- a/system/web/services/RequestService.cfc
+++ b/system/web/services/RequestService.cfc
@@ -28,7 +28,8 @@ component extends="coldbox.system.web.services.BaseService"{
 		variables.log 					= controller.getLogBox().getLogger( this );
 		variables.eventName				= controller.getSetting( "eventName" );
 		variables.eventCaching			= controller.getSetting( "eventCaching" );
-		variables.interceptorService 	= controller.getInterceptorService();
+        variables.interceptorService 	= controller.getInterceptorService();
+        variables.routingService        = controller.getRoutingService();
 		variables.handlerService		= controller.getHandlerService();
 		variables.cacheBox				= controller.getCacheBox();
 		variables.cache					= controller.getCache();
@@ -71,6 +72,8 @@ component extends="coldbox.system.web.services.BaseService"{
 			context.configure();
 		}
 
+        // First, process the request through the RoutingService
+        variables.routingService.requestCapture( context );
 		// Execute onRequestCapture interceptionPoint
 		variables.interceptorService.processState( "onRequestCapture" );
 

--- a/system/web/services/RoutingService.cfc
+++ b/system/web/services/RoutingService.cfc
@@ -158,8 +158,10 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 
 	/**
 	 * This is the route dispatcher called upon the request is captured.
+     *
+	 * @event The ColdBox Request context
 	 */
-	public void function requestCapture( event ) {
+	public void function requestCapture( required event ) {
         var rc = event.getCollection();
         var prc = event.getPrivateCollection();
 

--- a/system/web/services/RoutingService.cfc
+++ b/system/web/services/RoutingService.cfc
@@ -156,10 +156,6 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 		return this;
 	}
 
-	/****************************************************************************************************************************/
-	/* 													INTERCEPTION EVENT 														*/
-	/****************************************************************************************************************************/
-
 	/**
 	 * This is the route dispatcher called upon the request is captured.
 	 */

--- a/system/web/services/RoutingService.cfc
+++ b/system/web/services/RoutingService.cfc
@@ -163,7 +163,10 @@ component extends="coldbox.system.web.services.BaseService" accessors="true"{
 	/**
 	 * This is the route dispatcher called upon the request is captured.
 	 */
-	public void function onRequestCapture( event, interceptData, rc, prc, buffer ){
+	public void function requestCapture( event ) {
+        var rc = event.getCollection();
+        var prc = event.getPrivateCollection();
+
         var cleanedPaths = getCleanedPaths( rc, arguments.event );
 
 		// Check if disabled or in proxy mode, if it is, then exit out.

--- a/tests/specs/web/routing/RoutingServiceTest.cfc
+++ b/tests/specs/web/routing/RoutingServiceTest.cfc
@@ -72,7 +72,7 @@
 						scriptName = "",
 						domain     = "localhost"
 					} );
-					routingService.onRequestCapture( mockEvent, mockInterceptData, mockEvent.getCollection(), mockEvent.getPrivateCollection() );
+					routingService.requestCapture( mockEvent );
 					expect( mockEvent.valueExists( "format" ) ).toBeFalse();
 				} );
 
@@ -83,7 +83,7 @@
 						scriptName = "",
 						domain     = "localhost"
 					} );
-					routingService.onRequestCapture( mockEvent, mockInterceptData, mockEvent.getCollection(), mockEvent.getPrivateCollection() );
+					routingService.requestCapture( mockEvent );
 					expect( mockEvent.valueExists( "format" ) ).toBeTrue();
 					expect( mockEvent.getValue( "format" ) ).toBe( "xml" );
 					mockEvent.removeValue( "format" );
@@ -97,7 +97,7 @@
 						scriptName = "",
 						domain     = "localhost"
 					} );
-					routingService.onRequestCapture( mockEvent, mockInterceptData, mockEvent.getCollection(), mockEvent.getPrivateCollection() );
+					routingService.requestCapture( mockEvent );
 					expect( mockEvent.valueExists( "format" ) ).toBeTrue();
 					expect( mockEvent.getValue( "format" ) ).toBe( "json" );
 					mockEvent.removeValue( "format" );
@@ -111,7 +111,7 @@
 						scriptName = "",
 						domain     = "localhost"
 					} );
-					routingService.onRequestCapture( mockEvent, mockInterceptData, mockEvent.getCollection(), mockEvent.getPrivateCollection() );
+					routingService.requestCapture( mockEvent );
 					expect( mockEvent.valueExists( "format" ) ).toBeTrue();
 					expect( mockEvent.getValue( "format" ) ).toBe( "xml" );
 					mockEvent.removeValue( "format" );


### PR DESCRIPTION
Because the `RoutingService` registered itself as an interceptor, you couldn't guarantee that it would be ran before any other `onRequestCapture` points.  This change ensures that the request is processed and the `rc` and `prc` scopes filled before calling interceptors.