### PR TITLE
feat(RequestContext): Add urlMatches to match current urls

### DIFF
--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -637,6 +637,42 @@ component serializable="false" accessors="true" {
 	}
 
 	/**
+	 * Tests that a given path exists in the currently routed URL.
+	 * If the exact flag is passed, the path must match exactly.
+	 * Using the `urlMatchesExact` is preferred.
+	 *
+	 * @path    The path to match in the currently routed URL.
+	 * @exact   Flag to do an exact match instead of a partial match
+	 *
+	 * @return  Boolean
+	 */
+	boolean function urlMatches( required string path, boolean exact = false ){
+		var currentRoutedURL = getCurrentRoutedURL();
+		if ( arguments.exact ) {
+			return arguments.path == currentRoutedURL;
+		}
+		var replaced = replace( currentRoutedURL, arguments.path, "" );
+		var sliced = mid(
+			currentRoutedURL,
+			len( arguments.path ) + 1,
+			len( currentRoutedURL ) - len( arguments.path )
+		);
+		return replaced == sliced;
+	}
+
+	/**
+	 * Tests that a given path matches exactly to the currently routed URL.
+	 *
+	 * @path    The path to match exactly to the currently routed URL.
+	 *
+	 * @return  Boolean
+	 */
+	boolean function urlMatchesExact( required string path ){
+		arguments.exact = true;
+		return urlMatches( argumentCollection = arguments );
+	}
+
+	/**
 	 * Get the current routed namespace that matched the SES route, if any
 	 */
 	string function getCurrentRoutedNamespace(){
@@ -1375,7 +1411,7 @@ component serializable="false" accessors="true" {
 
 		//  Send file
 		if ( isBinary( arguments.file ) ) {
-			cfcontent( variable=arguments.file, type=arguments.mimetype );
+			cfcontent(variable=arguments.file, type=arguments.mimetype);
 		} else {
 			cfcontent(
 				deletefile=arguments.deleteFile,

--- a/tests/specs/web/context/RequestContextTest.cfc
+++ b/tests/specs/web/context/RequestContextTest.cfc
@@ -599,7 +599,7 @@ component extends="coldbox.system.testing.BaseModelTest" {
 		event.setHTTPHeader( name = "expires", value = "#now()#" );
 	}
 
-	function testGetHTTPConetnt(){
+	function testGetHTTPContent(){
 		var event = getRequestContext();
 
 		test = event.getHTTPContent();
@@ -753,6 +753,20 @@ component extends="coldbox.system.testing.BaseModelTest" {
 		expect( event.getFullUrl() ).toBeTypeOf( "url" );
 		var javaUrl = createObject( "java", "java.net.URL" ).init( event.getFullUrl() );
 		expect( javaUrl.getPort() ).toBe( listFind( "80,443", CGI.SERVER_PORT ) > 0 ? -1 : CGI.SERVER_PORT );
+	}
+
+	function testUrlMatches(){
+		var event = getRequestContext();
+		event.setPrivateValue( "currentRoutedURL", "/foo/bar/baz" );
+		expect( event.getCurrentRoutedURL() ).toBe( "/foo/bar/baz" );
+		expect( event.urlMatches( "/foo/bar/baz" ) ).toBeTrue();
+		expect( event.urlMatches( "/foo/baz/bar" ) ).toBeFalse();
+		expect( event.urlMatches( "/bar/baz" ) ).toBeFalse();
+		expect( event.urlMatches( "/foo/bar" ) ).toBeTrue();
+		expect( event.urlMatches( "/foo" ) ).toBeTrue();
+		expect( event.urlMatches( "/" ) ).toBeTrue();
+		expect( event.urlMatches( path = "/foo/bar", exact = true ) ).toBeFalse();
+		expect( event.urlMatchesExact( "/foo/bar" ) ).toBeFalse();
 	}
 
 }


### PR DESCRIPTION
This is used mainly to apply active classes to a link or section.
It matches partial paths by default.  An `exact` flag or the
`urlMatchesExact` method can be used to only do exact path matches.