### PR TITLE
Updated invoke() to correctly call method by name

### DIFF
--- a/system/core/conversion/XMLConverter.cfc
+++ b/system/core/conversion/XMLConverter.cfc
@@ -256,7 +256,7 @@ Modifications
 					OR md.properties[x]["marshal"] EQ true
 				){
 					thisName  = md.properties[x].name;
-					thisValue = invoke( target, "get#thisName()#" );
+					thisValue = invoke( target, "get#thisName#" );
 
 					// Value Defined?
 					if( not isDefined("thisValue") ){

--- a/tests/specs/core/conversion/XMLConverterTest.cfc
+++ b/tests/specs/core/conversion/XMLConverterTest.cfc
@@ -6,6 +6,14 @@
 		xml = createMock( className = "coldbox.system.core.conversion.XMLConverter" ).init();
 	}
 
+	function testObjectToXML(){
+		test = new tests.resources.Test();
+
+		results = xml.objectToXML( data=test );
+
+		assertTrue( isXML( results ) );
+	}
+
 	function testArrayToXML(){
 		// 1: No nesting
 		test    = [ 1, 2, 3, 4 ];


### PR DESCRIPTION
The invoke incorrectly included "()" in with the method name which is not required