### PR TITLE
Self-autowire fails for applications with context root configured

### DIFF
--- a/test-harness/views/main/routeTable.cfm
+++ b/test-harness/views/main/routeTable.cfm
@@ -10,7 +10,7 @@
     </thead>
 
     <tbody>
-    <cfloop array="#args.routes#" item="thisRoute">
+    <cfloop array="#args.routes#" index="thisRoute">
         <tr>
             <td>
                 #thisRoute.pattern#


### PR DESCRIPTION
When instantiating components on the application start, autowiring is failing due to the proxy component path being retrieved from the script name in the CGI scope, which was not taking into consideration a defined context root in the webserver.