### PR TITLE
ColdBox-857

### DIFF
--- a/system/modules/HTMLHelper/models/HTMLHelper.cfc
+++ b/system/modules/HTMLHelper/models/HTMLHelper.cfc
@@ -2356,9 +2356,7 @@ component extends="coldbox.system.FrameworkSupertype" accessors=true singleton{
 		var currentModule 		= event.getCurrentModule();
 
 		// Calculate app path depending on module or app
-		var appPath = ( arguments.useModuleRoot && len( currentModule ) ) ?
-						controller.getSetting( "modules" ).find( currentModule ).path & "/":
-						controller.getSetting( "applicationPath" );
+		var appPath = controller.getSetting( "applicationPath" );
 		var mapping = ( arguments.useModuleRoot && len( currentModule ) ) ?
 						event.getModuleRoot() :
 						controller.getSetting( "appMapping" );
@@ -2375,7 +2373,7 @@ component extends="coldbox.system.FrameworkSupertype" accessors=true singleton{
 
 		// Calculat href for asset delivery via Browser
 		if( mapping.len() ){
-			var href = "/#mapping#/#includesLocation#/#arguments.fileName#";
+			var href = "#mapping#/#includesLocation#/#arguments.fileName#";
 		} else {
 			var href = "/#includesLocation#/#arguments.fileName#";
 		}


### PR DESCRIPTION
Fix https://ortussolutions.atlassian.net/projects/COLDBOX/issues/COLDBOX-857?filter=allopenissues&orderby=priority%20DESC

The revManifest is always in the appPath, so no need to switch to module. I'm not sure how this worked in the past.

The slash removed because already included in the path.