### PR TITLE
Update "Whoops" exception message to allow selecting a subset of text

### DIFF
--- a/system/exceptions/Whoops.cfm
+++ b/system/exceptions/Whoops.cfm
@@ -176,7 +176,6 @@
 							class="exception__message"
 							title="Exception Message - Click to copy"
 							id="exceptionMessage"
-							onclick="copyToClipboard( 'exceptionMessage' )"
 						>
 							<i
 								onclick="copyToClipboard( 'exceptionMessage' )"


### PR DESCRIPTION
Previously if you clicked on the exception message, it would automatically highlight all of the text which makes it difficult to select just a subset. For example, if you just needed to copy a variable name which caused the exception and not the whole message.  This change does not break the "copy to clipboard" button which will still enable users to do so if they need the entire message on their clipboard.  This change gives the feature a little more flexibility with that box.