### PR TITLE
getComponentMetaData parsing error info

### DIFF
--- a/system/core/util/Util.cfc
+++ b/system/core/util/Util.cfc
@@ -219,7 +219,12 @@ Description :
 			<cfif isObject(component)>
 				<cfset md = getMetaData(component)>
 			<cfelse>
-				<cfset md = getComponentMetaData(component)>
+				<cftry>
+					<cfset md = getComponentMetadata( component )>
+					<cfcatch type="any">
+						<cfthrow message="Error parsing metaData for component #component#, please check for errors" >
+					</cfcatch>
+				</cftry>
 			</cfif>
 		</cfif>
 


### PR DESCRIPTION
Add more info on getComponentMetaData errors. In lucee there's no sign of filenames or Linenumbers. I filed a bug with Lucee, but in the mean time it would be very helpful to at least have some info on which file is failing on injections.

I could make a better pull request where we rewrite most of this function to script, and add better error handling so we can pass all extended info from the original errors, so it doesn't get lost if there are filenames and numbers. ACF does this right, current versions of lucee fail to reveal the filename in getComponentMetadata parsing errors.