### PR TITLE
Update DateFormat Mask to use lowercase "d".

### DIFF
--- a/system/cache/report/skins/default/CacheReport.cfm
+++ b/system/cache/report/skins/default/CacheReport.cfm
@@ -40,7 +40,7 @@
 	  Last Reap
 	</div>
 	<div class="cachebox_debugContentCell">
-	 #DateFormat(cacheStats.getlastReapDatetime(),"MMM-DD-YYYY")#
+	 #DateFormat(cacheStats.getlastReapDatetime(),"mmm-dd-yyyy")#
 	 #TimeFormat(cacheStats.getlastReapDatetime(),"hh:mm:ss tt")#
 	</div>
 </cfif>


### PR DESCRIPTION
 DateFormat mask to use lowercase "d" due to ColdFusion 2021 breaking change.  ("D" now outputs "day of year".)

More info here:
https://www.carehart.org/blog/client/index.cfm/2020/11/24/breaking_change_in_cf2021_dateformat_D_vs_d