### PR TITLE
Update DateFormat Mask to use lowercase "d".

### DIFF
--- a/system/exceptions/BugReport.cfm
+++ b/system/exceptions/BugReport.cfm
@@ -68,7 +68,7 @@ A reporting template about exceptions in your ColdBox Apps
 			 </cfif>
 			<tr>
 				<td align="right" class="info"><strong>Timestamp: </strong></td>
-				<td>#dateformat(now(), "MM/DD/YYYY")# #timeformat(now(),"hh:MM:SS TT")#</td>
+				<td>#dateformat(now(), "mm/dd/yyyy")# #timeformat(now(),"hh:mm:ss tt")#</td>
 			</tr>
 			 <tr >
 				<th colspan="2" >Event Details:</th>
@@ -155,7 +155,7 @@ A reporting template about exceptions in your ColdBox Apps
 		<table class="table" align="center">
 			<tr>
 			   <td align="right" class="info">Bug Date:</td>
-			   <td >#dateformat(now(), "MM/DD/YYYY")# #timeformat(now(),"hh:MM:SS TT")#</td>
+			   <td >#dateformat(now(), "mm/dd/yyyy")# #timeformat(now(),"hh:mm:ss tt")#</td>
 			 </tr>
 
 			 <tr>


### PR DESCRIPTION
Fix DateFormat mask to use lowercase "d" due to ColdFusion 2021 breaking change.  ("D" now outputs "day of year".)

More info here:
https://www.carehart.org/blog/client/index.cfm/2020/11/24/breaking_change_in_cf2021_dateformat_D_vs_d