### PR TITLE
Update DateFormat Mask to use lowercase "d".

### DIFF
--- a/system/logging/appenders/FileAppender.cfc
+++ b/system/logging/appenders/FileAppender.cfc
@@ -105,7 +105,7 @@ component accessors="true" extends="coldbox.system.logging.AbstractAppender"{
 			message = replace( message, chr(13), '  ', "all" );
 
 			// Entry string
-			entry = '"#severityToString( logEvent.getSeverity() )#","#getname()#","#dateformat( timestamp, "MM/DD/YYYY" )#","#timeformat( timestamp, "HH:MM:SS" )#","#loge.getCategory()#","#message#"';
+			entry = '"#severityToString( logEvent.getSeverity() )#","#getname()#","#dateformat( timestamp, "mm/dd/yyyy" )#","#timeformat( timestamp, "HH:mm:ss" )#","#loge.getCategory()#","#message#"';
 		}
 
 		// Queue it up


### PR DESCRIPTION
Fix DateFormat mask to use lowercase "d" due to ColdFusion 2021 breaking change.  ("D" now outputs "day of year".)

More info here:
https://www.carehart.org/blog/client/index.cfm/2020/11/24/breaking_change_in_cf2021_dateformat_D_vs_d