### PR TITLE
COLDBOX-952 opt for more efficient method variable merge

### DIFF
--- a/system/web/RendererEncapsulator.cfm
+++ b/system/web/RendererEncapsulator.cfm
@@ -12,12 +12,7 @@
 	variables.renderedHelpers 		= {};
 
 	// Merge variables from renderer
-	variables.append(
-		attributes.rendererVariables.filter( function( key, value ){
-			return !listFindNoCase( "local,attributes,arguments", arguments.key );
-		} ),
-		true
-	);
+	structAppend( variables, attributes.rendererVariables, false );
 
 	// Localize context
 	variables.event = attributes.event;


### PR DESCRIPTION
This change made a ~75% memory usage improvement over the previous logic. I believe that we can just do `StructAppend( ..., false )` here because the variables scope of the module is very limited. Looping over the keys in this way is basically doing the same thing but costing RAM.

Of course, only a consideration when hundreds of `renderView()` calls in a page - but that is entirely posisble with a framework.