### PR TITLE
Add a forceMap method as a shortcut to map( alias, force )

### DIFF
--- a/system/ioc/config/Binder.cfc
+++ b/system/ioc/config/Binder.cfc
@@ -574,6 +574,16 @@ component accessors="true" {
 	}
 
 	/**
+	 * Create a mapping to an object overwriting any existing registration.
+	 *
+	 * @alias A single alias or a list or an array of aliases for this mapping. Remember an object can be refered by many names
+	 */
+	Binder function forceMap( required alias ) {
+		arguments.force = true;
+		return map( argumentCollection = arguments );
+	}
+
+	/**
 	 * Map to a destination CFC class path.
 	 *
 	 * @path The class path to the object to map


### PR DESCRIPTION
`map( "Mapping", true )` is difficult to understand the intent of the `true` argument (`force`).
`forceMap( "Mapping" )` makes this boolean flag unnecessary and coveys the intent of the method.