### PR TITLE
Fix declaring multiple resources at once

### DIFF
--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -677,7 +677,7 @@ component
 			if ( !structIsEmpty( actionSet ) ) {
 				addRoute(
 					pattern  : "#thisPattern#/new",
-					handler  : arguments.handler,
+					handler  : isNull( arguments.handler ) ? thisResource : arguments.handler,
 					action   : actionSet,
 					module   : arguments.module,
 					namespace: arguments.namespace,
@@ -699,7 +699,7 @@ component
 			if ( !structIsEmpty( actionSet ) ) {
 				addRoute(
 					pattern  : "#thisPattern#/:#arguments.parameterName#",
-					handler  : arguments.handler,
+					handler  : isNull( arguments.handler ) ? thisResource : arguments.handler,
 					action   : actionSet,
 					module   : arguments.module,
 					namespace: arguments.namespace,
@@ -716,7 +716,7 @@ component
 			if ( !structIsEmpty( actionSet ) ) {
 				addRoute(
 					pattern  : "#thisPattern#",
-					handler  : arguments.handler,
+					handler  : isNull( arguments.handler ) ? thisResource : arguments.handler,
 					action   : actionSet,
 					module   : arguments.module,
 					namespace: arguments.namespace,

--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -624,7 +624,7 @@ component
 	 */
 	function resources(
 		required resource,
-		handler          = arguments.resource,
+		handler,
 		parameterName    = "id",
 		only             = [],
 		except           = [],
@@ -660,7 +660,7 @@ component
 			if ( !structIsEmpty( actionSet ) ) {
 				addRoute(
 					pattern  : "#thisPattern#/:#arguments.parameterName#/edit",
-					handler  : arguments.handler,
+					handler  : isNull( arguments.handler ) ? thisResource : arguments.handler,
 					action   : actionSet,
 					module   : arguments.module,
 					namespace: arguments.namespace,

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -491,7 +491,6 @@ component extends="coldbox.system.testing.BaseModelTest" {
 					then( "I should have a suite of routes for that resource", function(){
 						router.resources( [ "photos", "videos" ] );
 						var routes = router.getRoutes();
-						writeDump( var = routes );
 						expect( routes ).toBeArray();
 						expect( routes ).toHaveLength( 8 );
 						expect( routes[ 1 ].pattern ).toBe( "photos/:id/edit/" );
@@ -526,7 +525,6 @@ component extends="coldbox.system.testing.BaseModelTest" {
 					then( "I should have a suite of routes for that resource", function(){
 						router.resources( "photos,videos" );
 						var routes = router.getRoutes();
-						writeDump( var = routes );
 						expect( routes ).toBeArray();
 						expect( routes ).toHaveLength( 8 );
 						expect( routes[ 1 ].pattern ).toBe( "photos/:id/edit/" );

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -487,6 +487,76 @@ component extends="coldbox.system.testing.BaseModelTest" {
 						expect( routes[ 4 ].action ).toBe( { "GET" : "index", "POST" : "create" } );
 					} );
 				} );
+				given( "I register multiple resources using an array", function(){
+					then( "I should have a suite of routes for that resource", function(){
+						router.resources( [ "photos", "videos" ] );
+						var routes = router.getRoutes();
+						writeDump( var = routes );
+						expect( routes ).toBeArray();
+						expect( routes ).toHaveLength( 8 );
+						expect( routes[ 1 ].pattern ).toBe( "photos/:id/edit/" );
+						expect( routes[ 1 ].action ).toBe( { "GET" : "edit" } );
+						expect( routes[ 2 ].pattern ).toBe( "photos/new/" );
+						expect( routes[ 2 ].action ).toBe( { "GET" : "new" } );
+						expect( routes[ 3 ].pattern ).toBe( "photos/:id/" );
+						expect( routes[ 3 ].action ).toBe( {
+							"GET"    : "show",
+							"PATCH"  : "update",
+							"PUT"    : "update",
+							"DELETE" : "delete"
+						} );
+						expect( routes[ 4 ].pattern ).toBe( "photos/" );
+						expect( routes[ 4 ].action ).toBe( { "GET" : "index", "POST" : "create" } );
+						expect( routes[ 5 ].pattern ).toBe( "videos/:id/edit/" );
+						expect( routes[ 5 ].action ).toBe( { "GET" : "edit" } );
+						expect( routes[ 6 ].pattern ).toBe( "videos/new/" );
+						expect( routes[ 6 ].action ).toBe( { "GET" : "new" } );
+						expect( routes[ 7 ].pattern ).toBe( "videos/:id/" );
+						expect( routes[ 7 ].action ).toBe( {
+							"GET"    : "show",
+							"PATCH"  : "update",
+							"PUT"    : "update",
+							"DELETE" : "delete"
+						} );
+						expect( routes[ 8 ].pattern ).toBe( "videos/" );
+						expect( routes[ 8 ].action ).toBe( { "GET" : "index", "POST" : "create" } );
+					} );
+				} );
+				given( "I register multiple resources using a list", function(){
+					then( "I should have a suite of routes for that resource", function(){
+						router.resources( "photos,videos" );
+						var routes = router.getRoutes();
+						writeDump( var = routes );
+						expect( routes ).toBeArray();
+						expect( routes ).toHaveLength( 8 );
+						expect( routes[ 1 ].pattern ).toBe( "photos/:id/edit/" );
+						expect( routes[ 1 ].action ).toBe( { "GET" : "edit" } );
+						expect( routes[ 2 ].pattern ).toBe( "photos/new/" );
+						expect( routes[ 2 ].action ).toBe( { "GET" : "new" } );
+						expect( routes[ 3 ].pattern ).toBe( "photos/:id/" );
+						expect( routes[ 3 ].action ).toBe( {
+							"GET"    : "show",
+							"PATCH"  : "update",
+							"PUT"    : "update",
+							"DELETE" : "delete"
+						} );
+						expect( routes[ 4 ].pattern ).toBe( "photos/" );
+						expect( routes[ 4 ].action ).toBe( { "GET" : "index", "POST" : "create" } );
+						expect( routes[ 5 ].pattern ).toBe( "videos/:id/edit/" );
+						expect( routes[ 5 ].action ).toBe( { "GET" : "edit" } );
+						expect( routes[ 6 ].pattern ).toBe( "videos/new/" );
+						expect( routes[ 6 ].action ).toBe( { "GET" : "new" } );
+						expect( routes[ 7 ].pattern ).toBe( "videos/:id/" );
+						expect( routes[ 7 ].action ).toBe( {
+							"GET"    : "show",
+							"PATCH"  : "update",
+							"PUT"    : "update",
+							"DELETE" : "delete"
+						} );
+						expect( routes[ 8 ].pattern ).toBe( "videos/" );
+						expect( routes[ 8 ].action ).toBe( { "GET" : "index", "POST" : "create" } );
+					} );
+				} );
 			} );
 
 			story( "I can register a route with a condition", function() {


### PR DESCRIPTION
The [ColdBox docs](https://coldbox.ortusbooks.com/the-basics/routing/routing-dsl/resourceful-routes) state that you can declare multiple resources at once in the `Router.cfc#resources` method, either as an array
or as a list.  In practice, neither work completely.  An array throws an error in the framework and a list does not use the correct handler.  This commit fixes that behavior, but with some caveats.

First, the handler is no longer defaulted in the parameter list. It is instead defaulted each loop through the resources.  If you are only passing in the first argument to `resources` nothing really changes.  If you specify the `handler` argument manually, it will use that handler for each loop.

This is fine for registering a single resource, but is probably not what you want for multiple resources. In fact, this method's arguments don't work well when declaring multiple resources if you are not using the defaults.  I have seen that most projects end up declaring resources one at a time to change something like `handler` or `parameterName`.  I would argue that it would make ColdBox simpler and fit the usage in the developer world to make a `resource` method that registers a single resource and expect the developer to call it for each resource they want to register.  This could be introduced while deprecating the `resources` call for future removal from the framework.