### PR TITLE
Always register new routes when conditions are provided

### DIFF
--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -830,6 +830,9 @@ component
 		// Check for existing route matches
 		var matchingRoutes = variables.routes.filter( function( route ){
 			return (
+				// Always register a new route when a condition is specified on either route
+				isSimpleValue( thisRoute.condition ) && isSimpleValue( route.condition )
+				&&
 				route.pattern == thisRoute.pattern
 				&&
 				route.domain == thisRoute.domain

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -488,6 +488,71 @@ component extends="coldbox.system.testing.BaseModelTest" {
 					} );
 				} );
 			} );
+
+			story( "I can register a route with a condition", function() {
+				given( "I register a route with a condition", function() {
+					then( "I should have a route with a condition closure specified", function() {
+						router.route( "/about" )
+							.withCondition( () => {
+								return url.keyExists( "firstName" );
+							} )
+							.withAction( { "GET": "getFirstName" } )
+							.toHandler( "About" );
+
+						var routes = router.getRoutes();
+						expect( routes ).toBeArray();
+						expect( routes ).toHaveLength( 1 );
+						expect( routes[ 1 ] ).toHaveKey( "condition" );
+						expect( isClosure( routes[ 1 ].condition ) || isCustomFunction( routes[ 1 ].condition ) ).toBeTrue( "Condition should be callable." );
+						expect( routes[ 1 ] ).toHaveKey( "handler" );
+						expect( routes[ 1 ].handler ).toBe( "About" );
+						expect( routes[ 1 ] ).toHaveKey( "action" );
+						expect( routes[ 1 ].action ).toBeStruct();
+						expect( routes[ 1 ].action ).toHaveKey( "GET" );
+						expect( routes[ 1 ].action.GET ).toBe( "getFirstName" );
+					} );
+				} );
+
+				given( "I register two routes with the same pattern and different conditions", function() {
+					then( "I should have two routes showing both conditions", function() {
+						router.route( "/about" )
+							.withCondition( () => {
+								return url.keyExists( "firstName" );
+							} )
+							.withAction( { "GET": "getFirstName" } )
+							.toHandler( "About" );
+
+						router.route( "/about" )
+							.withCondition( () => {
+								return url.keyExists( "lastName" );
+							} )
+							.withAction( { "GET": "getLastName" } )
+							.toHandler( "About" );
+
+							var routes = router.getRoutes();
+							expect( routes ).toBeArray();
+							expect( routes ).toHaveLength( 2 );
+
+							expect( routes[ 1 ] ).toHaveKey( "condition" );
+							expect( isClosure( routes[ 1 ].condition ) || isCustomFunction( routes[ 1 ].condition ) ).toBeTrue( "Condition should be callable." );
+							expect( routes[ 1 ] ).toHaveKey( "handler" );
+							expect( routes[ 1 ].handler ).toBe( "About" );
+							expect( routes[ 1 ] ).toHaveKey( "action" );
+							expect( routes[ 1 ].action ).toBeStruct();
+							expect( routes[ 1 ].action ).toHaveKey( "GET" );
+							expect( routes[ 1 ].action.GET ).toBe( "getFirstName" );
+
+							expect( routes[ 2 ] ).toHaveKey( "condition" );
+							expect( isClosure( routes[ 2 ].condition ) || isCustomFunction( routes[ 2 ].condition ) ).toBeTrue( "Condition should be callable." );
+							expect( routes[ 1 ] ).toHaveKey( "handler" );
+							expect( routes[ 1 ].handler ).toBe( "About" );
+							expect( routes[ 2 ] ).toHaveKey( "action" );
+							expect( routes[ 2 ].action ).toBeStruct();
+							expect( routes[ 2 ].action ).toHaveKey( "GET" );
+							expect( routes[ 2 ].action.GET ).toBe( "getLastName" );
+					} );
+				} );
+			} );
 		} );
 	}
 

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -493,7 +493,7 @@ component extends="coldbox.system.testing.BaseModelTest" {
 				given( "I register a route with a condition", function() {
 					then( "I should have a route with a condition closure specified", function() {
 						router.route( "/about" )
-							.withCondition( () => {
+							.withCondition( function() {
 								return url.keyExists( "firstName" );
 							} )
 							.withAction( { "GET": "getFirstName" } )
@@ -516,14 +516,14 @@ component extends="coldbox.system.testing.BaseModelTest" {
 				given( "I register two routes with the same pattern and different conditions", function() {
 					then( "I should have two routes showing both conditions", function() {
 						router.route( "/about" )
-							.withCondition( () => {
+							.withCondition( function() {
 								return url.keyExists( "firstName" );
 							} )
 							.withAction( { "GET": "getFirstName" } )
 							.toHandler( "About" );
 
 						router.route( "/about" )
-							.withCondition( () => {
+							.withCondition( function() {
 								return url.keyExists( "lastName" );
 							} )
 							.withAction( { "GET": "getLastName" } )


### PR DESCRIPTION
Conditions are a way to apply a function check before executing a route.  However, ColdBox also tries to intelligently merge routes when only the actions are different.  Conditions are tricky since they are functions and therefore not equatable or hashable. Because of this, if a condition is specified on a route always create a new route.  We will trust the developer not to make duplicate conditional routes.  And even if they do, ColdBox will handle it just fine.