### PR TITLE
Update BaseProxy.cfc

### DIFF
--- a/system/async/proxies/BaseProxy.cfc
+++ b/system/async/proxies/BaseProxy.cfc
@@ -135,6 +135,8 @@ component accessors="true" {
 		if ( server.keyExists( "lucee" ) ) {
 			// Nothing right now
 		} else {
+			// Ensure any DB connections used get returned to the connection pool. Without clearSqlProxy an executor will hold onto any connections it touched while running and they will not timeout/close, and no other code can use the connection except for the executor that last touched it.   Credit to Brad Wood for finding this!
+			createObject( 'java', 'coldfusion.sql.DataSrcImpl' ).clearSqlProxy();
 			variables.fusionContextStatic.setCurrent( javacast( "null", "" ) );
 		}
 	}


### PR DESCRIPTION
Added code to unloadContext to ensure any DB connections used get returned to the connection pool.

Without clearSqlProxy an executor will hold onto any connections it touched while running and they will not timeout/close, and no other code can use the connection except for the executor that last touched it.

Credit to Brad Wood for finding this!