### PR TITLE
Ensures the invalid event handler is fired correctly

### DIFF
--- a/system/web/services/HandlerService.cfc
+++ b/system/web/services/HandlerService.cfc
@@ -170,6 +170,8 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 			var targetInvalidEvent = invalidEvent( arguments.ehBean.getFullEvent(), arguments.ehBean );
 
 			// If we get here, then the invalid event kicked in and exists, else an exception is thrown above
+            // set the invalid event handler as the current event
+            oRequestContext.overrideEvent( targetInvalidEvent );
 			// Go retrieve the handler that will handle the invalid event so it can execute.
 			return getHandler( getHandlerBean( targetInvalidEvent ), oRequestContext );
 		}


### PR DESCRIPTION
Previously, if the handler existed but the action was incorrect, the invalid event lifecycle would not fire correctly.  To fix this, we override the event in the request context to be the invalid event handler event.

Fixes COLDBOX-964