### PR TITLE
Remove boolean type for jsonQueryFormat, allow ANY

### DIFF
--- a/system/core/conversion/DataMarshaller.cfc
+++ b/system/core/conversion/DataMarshaller.cfc
@@ -39,7 +39,7 @@ component accessors="true" singleton {
 		required data,
 		encoding                = "UTF-8",
 		jsonCallback            = "",
-		boolean jsonQueryFormat = true,
+		jsonQueryFormat 				= true,
 		xmlColumnList           = "",
 		boolean xmlUseCDATA     = false,
 		xmlListDelimiter        = ",",


### PR DESCRIPTION
Remove boolean type check for jsonQueryFormat to allow passing 'row', 'column'  or 'struct' to serializeJson(). This was a regression from earlier releases.

[COLDBOX-981](https://ortussolutions.atlassian.net/browse/COLDBOX-981)