### PR TITLE
fix category for async logger

### DIFF
--- a/system/logging/Logger.cfc
+++ b/system/logging/Logger.cfc
@@ -362,13 +362,14 @@ component accessors="true"{
 						message="#arguments.message#"
 						severity="#arguments.severity#"
 						extraInfo="#arguments.extraInfo#"
+                        category="#arguments.category#"
 					{
 						var target = this;
 						if( !hasAppenders() ){
 							target = getRootLogger();
 						}
 						var thisAppender = target.getAppender( attributes.appenderName );
-						thread.logEvent = new coldbox.system.logging.LogEvent( message=attributes.message, severity=attributes.severity, extraInfo=attributes.extraInfo );
+						thread.logEvent = new coldbox.system.logging.LogEvent( message=attributes.message, severity=attributes.severity, extraInfo=attributes.extraInfo, category=attributes.category );
 						thisAppender.logMessage( thread.logEvent );
 					}
 


### PR DESCRIPTION
async logger had no category, instead some default category or appendername was reported
see
https://ortussolutions.atlassian.net/browse/COLDBOX-1001
for details