### PR TITLE
Patch/reinit fail fast adjustments

### DIFF
--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -156,7 +156,8 @@ component serializable="false" accessors="true" {
 						// Remove any context stragglers
 						structDelete( request, "cb_requestContext" );
 					} catch ( any e ) {
-						application.fwReinit = false;
+						// reset our application state to prevent any stale app keys from hanging around
+						applicationStop();
 						rethrow;
 					}
 				}

--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -30,8 +30,8 @@ component serializable="false" accessors="true" {
 	param name="COLDBOX_APP_KEY"       default="cbController";
 	param name="COLDBOX_APP_MAPPING"   default="";
 	param name="appHash"               default="#hash( getBaseTemplatePath() )#";
-	param name="lockTimeout" default="30" type="numeric";
-	param name="COLDBOX_FAIL_FAST" default="true";
+	param name="lockTimeout" 		   default="30" type="numeric";
+	param name="COLDBOX_FAIL_FAST" 	   default="true";
 
 	/**
 	 * Constructor, called by your Application CFC

--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -139,6 +139,7 @@ component serializable="false" accessors="true" {
 					try {
 						// Tell the word we are reiniting
 						application.fwReinit = true;
+						request.isReinitRequestor = true;
 						// Verify if we are Reiniting?
 						if (
 							structKeyExists( application, appKey ) AND application[ appKey ].getColdboxInitiated() AND needReinit
@@ -476,9 +477,10 @@ component serializable="false" accessors="true" {
 	boolean function onRequestStart( required targetPage ) output=true{
 		// Global flag to denote if we are in mid reinit or not.
 		cfparam( name = "application.fwReinit", default = false );
+		cfparam( name = "request.isReinitRequestor", default = false );
 
 		// Fail fast so users coming in during a reinit just get a please try again message.
-		if ( application.fwReinit ) {
+		if ( application.fwReinit && !request.isReinitRequestor ) {
 			// Closure or UDF
 			if ( isClosure( variables.COLDBOX_FAIL_FAST ) || isCustomFunction( variables.COLDBOX_FAIL_FAST ) ) {
 				variables.COLDBOX_FAIL_FAST();

--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -156,9 +156,8 @@ component serializable="false" accessors="true" {
 						// Remove any context stragglers
 						structDelete( request, "cb_requestContext" );
 					} catch ( any e ) {
-						rethrow;
-					} finally {
 						application.fwReinit = false;
+						rethrow;
 					}
 				}
 			}

--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -139,7 +139,6 @@ component serializable="false" accessors="true" {
 					try {
 						// Tell the word we are reiniting
 						application.fwReinit = true;
-						request.isReinitRequestor = true;
 						// Verify if we are Reiniting?
 						if (
 							structKeyExists( application, appKey ) AND application[ appKey ].getColdboxInitiated() AND needReinit
@@ -155,9 +154,13 @@ component serializable="false" accessors="true" {
 						loadColdBox();
 						// Remove any context stragglers
 						structDelete( request, "cb_requestContext" );
+						application.fwReinit = false;
 					} catch ( any e ) {
-						// reset our application state to prevent any stale app keys from hanging around
-						applicationStop();
+						// Something really went wrong reiniting. Try to clear out things
+						structDelete( application, appKey );
+						structDelete( application, "wirebox" );
+						structClear( request );
+						application.fwReinit = false;
 						rethrow;
 					}
 				}

--- a/system/web/services/LoaderService.cfc
+++ b/system/web/services/LoaderService.cfc
@@ -86,10 +86,6 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 		// Activate All Modules
 		variables.controller.getModuleService().activateAllModules();
 
-		// Flag the initiation, Framework is ready to serve requests. Praise be to GOD.
-		variables.controller.setColdboxInitiated( true );
-		variables.log.info( "+++ ColdBox is ready to serve requests" );
-
 		// Execute afterConfigurationLoad
 		variables.controller
 			.getInterceptorService()
@@ -104,6 +100,10 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 		variables.controller
 			.getInterceptorService()
 			.announce( "afterAspectsLoad" );
+
+		// Flag the initiation, Framework is ready to serve requests. Praise be to GOD.
+		variables.controller.setColdboxInitiated( true );
+		variables.log.info( "+++ ColdBox is ready to serve requests" );
 
 		// We are now done, rock and roll!!
 		return this;


### PR DESCRIPTION
This PR attempts to solve several issues related to the "fail fast" approach, as well as a potentially stale/incorrect application state when an error occurs on a reinit:

1. Moves the framework readiness flag until post-afterAspectsLoad, to ensure the application, itself is fully initialized before serving traffic
2. Adds a `reinitRequestor` key to the request scope, during the reinit process, to prevent the requestor of the reinit from being trapped in the fail fast 503
3. Changes to use a full `applicationStop` to clear out potentially bad application keys if there is an error during the reinit lifecycle.  This will then fire the full `applicationStart` on next request and will prevent Coldbox from serving traffic in a partially loaded state