### PR TITLE
Proxy with app key

### DIFF
--- a/system/remote/ColdboxProxy.cfc
+++ b/system/remote/ColdboxProxy.cfc
@@ -13,7 +13,12 @@ component serializable="false" accessors="true" {
 	property name="COLDBOX_APP_KEY";
 
 	// Setup Default Namespace Key for controller locations
-	variables.COLDBOX_APP_KEY = application.cbBootstrap.getCOLDBOX_APP_KEY();
+	if(isDefined("application.cbBootstrap")) {
+		variables.COLDBOX_APP_KEY = application.cbBootstrap.getCOLDBOX_APP_KEY();
+	}
+	else {
+		variables.COLDBOX_APP_KEY = "cbController";
+	}
 
 	// Remote proxies are created by the CFML engine without calling init(),
 	// so autowire in here in the pseduo constructor

--- a/system/remote/ColdboxProxy.cfc
+++ b/system/remote/ColdboxProxy.cfc
@@ -13,7 +13,7 @@ component serializable="false" accessors="true" {
 	property name="COLDBOX_APP_KEY";
 
 	// Setup Default Namespace Key for controller locations
-	variables.COLDBOX_APP_KEY = "cbController";
+	variables.COLDBOX_APP_KEY = application.cbBootstrap.getCOLDBOX_APP_KEY();
 
 	// Remote proxies are created by the CFML engine without calling init(),
 	// so autowire in here in the pseduo constructor


### PR DESCRIPTION
CBORM and I would assume other proxy objects fail when using an app key. Right now the COLDBOX_APP_KEY variable in the ColdboxProxy cfc is set to cbController and can't be changed. It would probably make sense to grab the value for this from the bootstrap if it exists.

When using this with CBORM you still need to do an ormReload in your onApplicationStart function though since the cborm.models.EventHandler for the CFORM is loaded before the bootstrap is created so your app key will not be included in that component initially.