### PR TITLE
Fixes and improvements to DBAppender

### DIFF
--- a/system/logging/appenders/DBAppender.cfc
+++ b/system/logging/appenders/DBAppender.cfc
@@ -26,6 +26,9 @@
 **/
 component accessors="true" extends="coldbox.system.logging.AbstractAppender" {
 
+	// Default column names
+	variables.columns = ["id", "severity", "category", "logdate", "appendername", "message", "extrainfo"];
+
     /**
 	 * Constructor
 	 *
@@ -45,8 +48,6 @@ component accessors="true" extends="coldbox.system.logging.AbstractAppender" {
        	// Init supertype
 		super.init( argumentCollection=arguments );
 
-		// valid columns
-		variables.columns = ["id", "severity", "category", "logdate", "appendername", "message", "extrainfo"];
 		// UUID generator
 		variables.uuid = createobject( "java", "java.util.UUID" );
 


### PR DESCRIPTION
This pull request makes the following changes to DBAppender in LogBox:
1. **Allow developers to use a subset of the columns in the `columnMap` property.**
   Currently, if the `columnMap` property is used, then the map must have all the columns as keys, even if only one of the columns needs changing. This results in extra code needed to be written.

   This change allows developers to only map the columns that need changing and use the default column name if not mapped.
2. **Fix the `ensureTable` and `doRotation` methods to use mapped column names when editing the table.**
   Currently, these methods use the default column names even if the `columnMap` property is defined. A consequence is that a table with incorrect column names could be created when the `autoCreate` property is `true` and the `columnMap` property is used.
3. **Make DBAppender easier to extend when creating custom appenders.**
   By moving `variables.columns` from the constructor to the pseudo-constructor, a subclass could implement adding new columns by just overriding `variables.columns` (in the pseudo-constructor or before `super.init`) and `processQueueElement`.

   Currently, `variables.columns` is defined in the constructor followed by setup methods which use `variables.columns`. This means that a subcomponent must also override the method `checkColumnMap` to check the new columns in addition to overriding `variables.columns` after `super.init` or an error might be thrown.