### PR TITLE
Update BeanPopulator for Hibernate 5 in Lucee

### DIFF
--- a/system/core/dynamic/BeanPopulator.cfc
+++ b/system/core/dynamic/BeanPopulator.cfc
@@ -363,14 +363,15 @@ component {
 
 						var getEntityMap = function(){
 							try {
-								// older, deprecated syntax for pre-Hibernate5
-								return structKeyArray( ormGetSessionFactory().getAllClassMetadata() );
+								// Double array functions to convert from native java to cf java
+								// Hibernate v5+
+								return arrayToList( ormGetSessionFactory().getMetaModel().getAllEntityNames() ).listToArray();
 							} catch( any e ){
-								if ( ! listContains( e.message, "getAllClassMetadata is no longer supported" ) ){
+								if ( ! listContains( e.message, "getMetaModel" ) ){
 									rethrow;
 								}
-								// Double array functions to convert from native java to cf java
-								return arrayToList( ormGetSessionFactory().getMetaModel().getAllEntityNames() ).listToArray();
+								// Pre-Hibernate 5 syntax
+								return structKeyArray( ormGetSessionFactory().getAllClassMetadata() );
 							}
 						};
 

--- a/system/core/dynamic/BeanPopulator.cfc
+++ b/system/core/dynamic/BeanPopulator.cfc
@@ -362,15 +362,11 @@ component {
 						}
 
 						var getEntityMap = function(){
-							try {
+							if( listFirst( variables.util.getHibernateVersion(), "." ) >= 5 ){
 								// Double array functions to convert from native java to cf java
-								// Hibernate v5+
 								return arrayToList( ormGetSessionFactory().getMetaModel().getAllEntityNames() ).listToArray();
-							} catch( any e ){
-								if ( ! listContains( e.message, "getMetaModel" ) ){
-									rethrow;
-								}
-								// Pre-Hibernate 5 syntax
+							} else {
+								// Hibernate v4 and older
 								return structKeyArray( ormGetSessionFactory().getAllClassMetadata() );
 							}
 						};

--- a/system/core/dynamic/BeanPopulator.cfc
+++ b/system/core/dynamic/BeanPopulator.cfc
@@ -362,11 +362,15 @@ component {
 						}
 
 						var getEntityMap = function(){
-							if( listFind( "2018,2021", server.coldfusion.productVersion.listFirst() ) ){
+							try {
+								// older, deprecated syntax for pre-Hibernate5
+								return structKeyArray( ormGetSessionFactory().getAllClassMetadata() );
+							} catch( any e ){
+								if ( ! listContains( e.message, "getAllClassMetadata is no longer supported" ) ){
+									rethrow;
+								}
 								// Double array functions to convert from native java to cf java
 								return arrayToList( ormGetSessionFactory().getMetaModel().getAllEntityNames() ).listToArray();
-							} else {
-								return structKeyArray( ormGetSessionFactory().getAllClassMetadata() );
 							}
 						};
 

--- a/system/core/util/Util.cfc
+++ b/system/core/util/Util.cfc
@@ -501,4 +501,18 @@ component {
 		return loc.parent;
 	}
 
+	/**
+	 * Get the Hibernate version string from Hibernate or Hibernate bundle version
+	 */
+	public string function getHibernateVersion(){
+		var version = createObject( "java", "org.hibernate.Version" );
+
+		if ( version.getVersionString() != "[WORKING]" ){
+			return version.getVersionString();
+		} else {
+			// Due to the insanity of a broken `MANIFEST.MF` in the Lucee Hibernate bundle, we need to pull the `Bundle-Version` instead
+			return version.getClass().getClassLoader().getBundle().getVersion().toString();
+		}
+	}
+
 }


### PR DESCRIPTION
The `ormGetSessionFactory().getAllClassMetadata()` syntax is deprecated (and throws an error!) in Hibernate v5+, but ColdBox only switches syntax based on the Coldfusion server name. :/ 

This PR updates ColdBox to support the newest version of the Lucee Hibernate extension.