### PR TITLE
Better handling of different HTTP verb methods for the same route

### DIFF
--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -848,16 +848,21 @@ component
 			var actions         = {};
 			var matchingActions = isStruct( matchingRoute.action ) ? matchingRoute.action : {};
 			structAppend( actions, matchingActions, true );
-			for ( var verb in matchingRoute.verbs ) {
-				structInsert( actions, verb, matchingRoute.event );
-			}
+            if ( matchingRoute.event != "" ) {
+                for ( var verb in matchingRoute.verbs ) {
+                    structInsert( actions, verb, matchingRoute.event );
+                }
+            }
 			var thisRouteActions = isStruct( thisRoute.action ) ? thisRoute.action : {};
 			structAppend( actions, thisRouteActions, true );
-			for ( var verb in thisRoute.verbs ) {
-				structInsert( actions, verb, thisRoute.event );
-			}
+            if ( thisRoute.event != "" ) {
+                for ( var verb in thisRoute.verbs ) {
+                    structInsert( actions, verb, thisRoute.event );
+                }
+            }
 			matchingRoute.action = actions;
-			matchingRoute.verbs  = "";
+			matchingRoute.verbs  = structKeyList( actions );
+            matchingRoute.event = "";
 			return this;
 		}
 

--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -848,21 +848,21 @@ component
 			var actions         = {};
 			var matchingActions = isStruct( matchingRoute.action ) ? matchingRoute.action : {};
 			structAppend( actions, matchingActions, true );
-            if ( matchingRoute.event != "" ) {
-                for ( var verb in matchingRoute.verbs ) {
-                    structInsert( actions, verb, matchingRoute.event );
-                }
-            }
+			if ( matchingRoute.event != "" ) {
+				for ( var verb in matchingRoute.verbs ) {
+					structInsert( actions, verb, matchingRoute.event );
+				}
+			}
 			var thisRouteActions = isStruct( thisRoute.action ) ? thisRoute.action : {};
 			structAppend( actions, thisRouteActions, true );
-            if ( thisRoute.event != "" ) {
-                for ( var verb in thisRoute.verbs ) {
-                    structInsert( actions, verb, thisRoute.event );
-                }
-            }
+			if ( thisRoute.event != "" ) {
+				for ( var verb in thisRoute.verbs ) {
+					structInsert( actions, verb, thisRoute.event );
+				}
+			}
 			matchingRoute.action = actions;
 			matchingRoute.verbs  = structKeyList( actions );
-            matchingRoute.event = "";
+			matchingRoute.event  = "";
 			return this;
 		}
 

--- a/system/web/services/RoutingService.cfc
+++ b/system/web/services/RoutingService.cfc
@@ -307,50 +307,50 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 			if ( routeResults.route.module.len() ) {
 				discoveredEvent = routeResults.route.module & ":" & discoveredEvent;
 			}
-        }
+		}
 
-        // Process HTTP Verbs
-        if (
-            routeResults.route.verbs.len()
-            and
-            !routeResults.route.verbs.listFindNoCase( httpMethod )
-        ) {
-            // Mark as invalid HTTP Exception
-            arguments.event.setIsInvalidHTTPMethod( true );
-            if ( variables.log.canDebug() ) {
-                variables.log.debug( "Invalid HTTP Method detected: #httpMethod#", routeResults.route );
-            }
-        }
+		// Process HTTP Verbs
+		if (
+			routeResults.route.verbs.len()
+			and
+			!routeResults.route.verbs.listFindNoCase( httpMethod )
+		) {
+			// Mark as invalid HTTP Exception
+			arguments.event.setIsInvalidHTTPMethod( true );
+			if ( variables.log.canDebug() ) {
+				variables.log.debug( "Invalid HTTP Method detected: #httpMethod#", routeResults.route );
+			}
+		}
 
-        // If the struct is empty, reset it to an empty string so it goes down the correct code path later on.
-        if ( isStruct( routeResults.route.action ) && structIsEmpty( routeResults.route.action ) ) {
-            routeResults.route.action = "";
-        }
+		// If the struct is empty, reset it to an empty string so it goes down the correct code path later on.
+		if ( isStruct( routeResults.route.action ) && structIsEmpty( routeResults.route.action ) ) {
+			routeResults.route.action = "";
+		}
 
-        // Check if using HTTP method actions via struct
-        if ( isStruct( routeResults.route.action ) ) {
-            // Verify HTTP method used is valid
-            if ( structKeyExists( routeResults.route.action, httpMethod ) ) {
-                discoveredEvent &= ( discoveredEvent == "" ? "" : "." ) & "#routeResults.route.action[ httpMethod ]#";
-                // Send for logging in debug mode
-                if ( variables.log.canDebug() ) {
-                    variables.log.debug(
-                        "Matched HTTP Method (#HTTPMethod#) to routed action: #routeResults.route.action[ httpMethod ]#"
-                    );
-                }
-            } else {
-                // Mark as invalid HTTP Exception
-                discoveredEvent &= ".onInvalidHTTPMethod";
-                arguments.event.setIsInvalidHTTPMethod( true );
-                if ( variables.log.canDebug() ) {
-                    variables.log.debug( "Invalid HTTP Method detected: #httpMethod#", routeResults.route );
-                }
-            }
-        }
-        // Simple value action
-        else if ( !isStruct( routeREsults.route.action ) && routeResults.route.action.len() ) {
-            discoveredEvent &= ( discoveredEvent == "" ? "" : "." ) & "#routeResults.route.action#";
-        }
+		// Check if using HTTP method actions via struct
+		if ( isStruct( routeResults.route.action ) ) {
+			// Verify HTTP method used is valid
+			if ( structKeyExists( routeResults.route.action, httpMethod ) ) {
+				discoveredEvent &= ( discoveredEvent == "" ? "" : "." ) & "#routeResults.route.action[ httpMethod ]#";
+				// Send for logging in debug mode
+				if ( variables.log.canDebug() ) {
+					variables.log.debug(
+						"Matched HTTP Method (#HTTPMethod#) to routed action: #routeResults.route.action[ httpMethod ]#"
+					);
+				}
+			} else {
+				// Mark as invalid HTTP Exception
+				discoveredEvent &= ".onInvalidHTTPMethod";
+				arguments.event.setIsInvalidHTTPMethod( true );
+				if ( variables.log.canDebug() ) {
+					variables.log.debug( "Invalid HTTP Method detected: #httpMethod#", routeResults.route );
+				}
+			}
+		}
+		// Simple value action
+		else if ( !isStruct( routeREsults.route.action ) && routeResults.route.action.len() ) {
+			discoveredEvent &= ( discoveredEvent == "" ? "" : "." ) & "#routeResults.route.action#";
+		}
 		// end if action exists
 
 		// See if View is Dispatched

--- a/system/web/services/RoutingService.cfc
+++ b/system/web/services/RoutingService.cfc
@@ -307,51 +307,51 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 			if ( routeResults.route.module.len() ) {
 				discoveredEvent = routeResults.route.module & ":" & discoveredEvent;
 			}
+        }
 
-			// Process HTTP Verbs
-			if (
-				routeResults.route.verbs.len()
-				and
-				!routeResults.route.verbs.listFindNoCase( httpMethod )
-			) {
-				// Mark as invalid HTTP Exception
-				arguments.event.setIsInvalidHTTPMethod( true );
-				if ( variables.log.canDebug() ) {
-					variables.log.debug( "Invalid HTTP Method detected: #httpMethod#", routeResults.route );
-				}
-			}
+        // Process HTTP Verbs
+        if (
+            routeResults.route.verbs.len()
+            and
+            !routeResults.route.verbs.listFindNoCase( httpMethod )
+        ) {
+            // Mark as invalid HTTP Exception
+            arguments.event.setIsInvalidHTTPMethod( true );
+            if ( variables.log.canDebug() ) {
+                variables.log.debug( "Invalid HTTP Method detected: #httpMethod#", routeResults.route );
+            }
+        }
 
-			// If the struct is empty, reset it to an empty string so it goes down the correct code path later on.
-			if ( isStruct( routeResults.route.action ) && structIsEmpty( routeResults.route.action ) ) {
-				routeResults.route.action = "";
-			}
+        // If the struct is empty, reset it to an empty string so it goes down the correct code path later on.
+        if ( isStruct( routeResults.route.action ) && structIsEmpty( routeResults.route.action ) ) {
+            routeResults.route.action = "";
+        }
 
-			// Check if using HTTP method actions via struct
-			if ( isStruct( routeResults.route.action ) ) {
-				// Verify HTTP method used is valid
-				if ( structKeyExists( routeResults.route.action, httpMethod ) ) {
-					discoveredEvent &= ".#routeResults.route.action[ httpMethod ]#";
-					// Send for logging in debug mode
-					if ( variables.log.canDebug() ) {
-						variables.log.debug(
-							"Matched HTTP Method (#HTTPMethod#) to routed action: #routeResults.route.action[ httpMethod ]#"
-						);
-					}
-				} else {
-					// Mark as invalid HTTP Exception
-					discoveredEvent &= ".onInvalidHTTPMethod";
-					arguments.event.setIsInvalidHTTPMethod( true );
-					if ( variables.log.canDebug() ) {
-						variables.log.debug( "Invalid HTTP Method detected: #httpMethod#", routeResults.route );
-					}
-				}
-			}
-			// Simple value action
-			else if ( !isStruct( routeREsults.route.action ) && routeResults.route.action.len() ) {
-				discoveredEvent &= ".#routeResults.route.action#";
-			}
-		}
-		// end if handler exists
+        // Check if using HTTP method actions via struct
+        if ( isStruct( routeResults.route.action ) ) {
+            // Verify HTTP method used is valid
+            if ( structKeyExists( routeResults.route.action, httpMethod ) ) {
+                discoveredEvent &= ( discoveredEvent == "" ? "" : "." ) & "#routeResults.route.action[ httpMethod ]#";
+                // Send for logging in debug mode
+                if ( variables.log.canDebug() ) {
+                    variables.log.debug(
+                        "Matched HTTP Method (#HTTPMethod#) to routed action: #routeResults.route.action[ httpMethod ]#"
+                    );
+                }
+            } else {
+                // Mark as invalid HTTP Exception
+                discoveredEvent &= ".onInvalidHTTPMethod";
+                arguments.event.setIsInvalidHTTPMethod( true );
+                if ( variables.log.canDebug() ) {
+                    variables.log.debug( "Invalid HTTP Method detected: #httpMethod#", routeResults.route );
+                }
+            }
+        }
+        // Simple value action
+        else if ( !isStruct( routeREsults.route.action ) && routeResults.route.action.len() ) {
+            discoveredEvent &= ( discoveredEvent == "" ? "" : "." ) & "#routeResults.route.action#";
+        }
+		// end if action exists
 
 		// See if View is Dispatched
 		if ( routeResults.route.view.len() ) {

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -203,9 +203,9 @@ component extends="coldbox.system.testing.BaseModelTest" {
 						} );
 						var verbs = listToArray( routes[ 1 ].verbs );
 						expect( verbs ).toHaveLength( 3 );
-                        expect( verbs ).toInclude( "GET" );
-                        expect( verbs ).toInclude( "POST" );
-                        expect( verbs ).toInclude( "DELETE" );
+						expect( verbs ).toInclude( "GET" );
+						expect( verbs ).toInclude( "POST" );
+						expect( verbs ).toInclude( "DELETE" );
 					} );
 				} );
 			} );

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -178,8 +178,9 @@ component extends="coldbox.system.testing.BaseModelTest" {
 
 				given( "different HTTP verbs for the same route", function(){
 					then( "both verbs should be registered", function(){
-						router.post( "photos/", "photos.create" );
-						router.get( "photos/", "photos.index" );
+						router.post( "photos/", "Photos.create" );
+						router.get( "photos/", "Photos.index" );
+						router.delete( "photos/", "BulkPhotos.delete" );
 
 						var routes = router.getRoutes();
 						expect( routes ).toBeArray();
@@ -187,10 +188,15 @@ component extends="coldbox.system.testing.BaseModelTest" {
 						expect( routes[ 1 ].pattern ).toBe( "photos/" );
 						expect( routes[ 1 ].action ).toBeStruct();
 						expect( routes[ 1 ].action ).toHaveLength(
-							2,
+							3,
 							"The registered route should have two actions"
 						);
-						expect( routes[ 1 ].action ).toBe( { "GET" : "photos.index", "POST" : "photos.create" } );
+                        expect( routes[ 1 ].event ).toBe( "", "The event must be empty for multiple HTTP verbs" );
+                        expect( routes[ 1 ].handler ).toBe( "", "No handler should be defined so the actions can define one" );
+						expect( routes[ 1 ].action ).toBe( { "GET" : "Photos.index", "POST" : "Photos.create", "DELETE": "BulkPhotos.delete" } );
+                        var verbs = routes[ 1 ].verbs;
+                        listSort( verbs, "textnocase", "asc" );
+						expect( verbs ).toBe( "DELETE,GET,POST" );
 					} );
 				} );
 			} );

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -201,9 +201,11 @@ component extends="coldbox.system.testing.BaseModelTest" {
 							"POST"   : "Photos.create",
 							"DELETE" : "BulkPhotos.delete"
 						} );
-						var verbs = routes[ 1 ].verbs;
-						listSort( verbs, "textnocase", "asc" );
-						expect( verbs ).toBe( "DELETE,GET,POST" );
+						var verbs = listToArray( routes[ 1 ].verbs );
+						expect( verbs ).toHaveLength( 3 );
+                        expect( verbs ).toInclude( "GET" );
+                        expect( verbs ).toInclude( "POST" );
+                        expect( verbs ).toInclude( "DELETE" );
 					} );
 				} );
 			} );

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -191,11 +191,18 @@ component extends="coldbox.system.testing.BaseModelTest" {
 							3,
 							"The registered route should have two actions"
 						);
-                        expect( routes[ 1 ].event ).toBe( "", "The event must be empty for multiple HTTP verbs" );
-                        expect( routes[ 1 ].handler ).toBe( "", "No handler should be defined so the actions can define one" );
-						expect( routes[ 1 ].action ).toBe( { "GET" : "Photos.index", "POST" : "Photos.create", "DELETE": "BulkPhotos.delete" } );
-                        var verbs = routes[ 1 ].verbs;
-                        listSort( verbs, "textnocase", "asc" );
+						expect( routes[ 1 ].event ).toBe( "", "The event must be empty for multiple HTTP verbs" );
+						expect( routes[ 1 ].handler ).toBe(
+							"",
+							"No handler should be defined so the actions can define one"
+						);
+						expect( routes[ 1 ].action ).toBe( {
+							"GET"    : "Photos.index",
+							"POST"   : "Photos.create",
+							"DELETE" : "BulkPhotos.delete"
+						} );
+						var verbs = routes[ 1 ].verbs;
+						listSort( verbs, "textnocase", "asc" );
 						expect( verbs ).toBe( "DELETE,GET,POST" );
 					} );
 				} );

--- a/tests/specs/web/routing/RoutingServiceTest.cfc
+++ b/tests/specs/web/routing/RoutingServiceTest.cfc
@@ -144,7 +144,130 @@
 					mockEvent.removeValue( "format" );
 				} );
 			} );
+
+            it( "can use a full event from the action block if no event or handler is defined", function() {
+                var mockEvent = createMock( "coldbox.system.web.context.RequestContext" ).init(
+                    controller = getController(),
+                    properties = {
+                        defaultLayout : "Main.cfm",
+                        defaultView   : "",
+                        eventName     : "event",
+                        modules       : {}
+                    }
+                );
+
+                var routeResults = { "route": initRouteDefinition( overrides = {
+                    "handler": "",
+                    "event": "",
+                    "action": {
+                        "GET": "MyHandler.index",
+                        "POST": "MyOtherHandler.create"
+                    }
+                } ), "params": {} };
+
+                var discoveredEventGET = variables.routingService.processRoute(
+                    routeResults = routeResults,
+                    event = mockEvent,
+                    rc = mockEvent.getCollection(),
+                    prc = mockEvent.getPrivateCollection()
+                );
+
+                expect( discoveredEventGET ).toBe( "MyHandler.index" );
+
+                mockEvent.$( "getHTTPMethod", "POST" );
+
+                var discoveredEventPOST = variables.routingService.processRoute(
+                    routeResults = routeResults,
+                    event = mockEvent,
+                    rc = mockEvent.getCollection(),
+                    prc = mockEvent.getPrivateCollection()
+                );
+
+                expect( discoveredEventPOST ).toBe( "MyOtherHandler.create" );
+            } );
+
+            it( "appends a handler from a route definition if it exists", function() {
+                var mockEvent = createMock( "coldbox.system.web.context.RequestContext" ).init(
+                    controller = getController(),
+                    properties = {
+                        defaultLayout : "Main.cfm",
+                        defaultView   : "",
+                        eventName     : "event",
+                        modules       : {}
+                    }
+                );
+
+                var routeResults = { "route": initRouteDefinition( overrides = {
+                    "handler": "MyHandler",
+                    "event": "",
+                    "action": {
+                        "GET": "index",
+                        "POST": "create",
+                        "PUT": "update"
+                    }
+                } ), "params": {} };
+
+                var discoveredEventGET = variables.routingService.processRoute(
+                    routeResults = routeResults,
+                    event = mockEvent,
+                    rc = mockEvent.getCollection(),
+                    prc = mockEvent.getPrivateCollection()
+                );
+
+                expect( discoveredEventGET ).toBe( "MyHandler.index" );
+
+                mockEvent.$( "getHTTPMethod", "PUT" );
+
+                var discoveredEventPOST = variables.routingService.processRoute(
+                    routeResults = routeResults,
+                    event = mockEvent,
+                    rc = mockEvent.getCollection(),
+                    prc = mockEvent.getPrivateCollection()
+                );
+
+                expect( discoveredEventPOST ).toBe( "MyHandler.update" );
+            } );
+
 		} );
 	}
 
+    /**
+     * Returns a new route definition
+     */
+    private struct function initRouteDefinition( struct overrides = {} ) {
+		structAppend( arguments.overrides, {
+			"action"                : "", // The action to execute
+			"append"                : true, // Was this route appended or pre/prended
+			"condition"             : "", // The condition closure which must be true for the route to match
+			// TODO: Consider deprecating this since now we have a `-regex()` placeholder
+			"constraints"           : {}, // If we have any regex constraints on placeholders.
+			"domain"                : "", // The domain attached to the route
+			"event"                 : "", // The full event syntax to execute
+			"handler"               : "", // The handler to execute
+			"headers"               : {}, // The HTTP response headers to respond with
+			"layout"                : "", // The layout to proxy to
+			"layoutModule"          : "", // If the layout comes from a module
+			"meta"                  : {}, // Route metadata if any
+			"module"                : "", // The module event we must execute
+			"moduleRouting"         : "", // This routes to a module
+			"name"                  : "", // The named route
+			"namespace"             : "", // The namespace this route belongs to
+			"namespaceRouting"      : "", // This routes to a namespace
+			"packageResolverExempt" : false, // If true, it does not resolve packages by convention, by default we do
+			"pattern"               : "", // The regex pattern used for matching
+			"prc"                   : {}, // The PRC params to add incorporate if matched
+			"rc"                    : {}, // The RC params to add incorporate if matched
+			"redirect"              : "", // The redirection location
+			"response"              : "", // Do we have an inline response closure
+			"ssl"                   : false, // Are we forcing SSL
+			"statusCode"            : 200, // The response status code
+			"statusText"            : "Ok", // The response status text
+			"valuePairTranslation"  : true, // If we translate name-value pairs in the URL by convention
+			"verbs"                 : "", // The HTTP Verbs allowed
+			"view"                  : "", // The view to proxy to
+			"viewModule"            : "", // If the view comes from a module
+			"viewNoLayout"          : false // If we use a layout or not
+		}, false );
+        return arguments.overrides;
+	}
 }

--- a/tests/specs/web/routing/RoutingServiceTest.cfc
+++ b/tests/specs/web/routing/RoutingServiceTest.cfc
@@ -145,129 +145,139 @@
 				} );
 			} );
 
-            it( "can use a full event from the action block if no event or handler is defined", function() {
-                var mockEvent = createMock( "coldbox.system.web.context.RequestContext" ).init(
-                    controller = getController(),
-                    properties = {
-                        defaultLayout : "Main.cfm",
-                        defaultView   : "",
-                        eventName     : "event",
-                        modules       : {}
-                    }
-                );
+			it( "can use a full event from the action block if no event or handler is defined", function(){
+				var mockEvent = createMock( "coldbox.system.web.context.RequestContext" ).init(
+					controller = getController(),
+					properties = {
+						defaultLayout : "Main.cfm",
+						defaultView   : "",
+						eventName     : "event",
+						modules       : {}
+					}
+				);
 
-                var routeResults = { "route": initRouteDefinition( overrides = {
-                    "handler": "",
-                    "event": "",
-                    "action": {
-                        "GET": "MyHandler.index",
-                        "POST": "MyOtherHandler.create"
-                    }
-                } ), "params": {} };
+				var routeResults = {
+					"route" : initRouteDefinition(
+						overrides = {
+							"handler" : "",
+							"event"   : "",
+							"action"  : {
+								"GET"  : "MyHandler.index",
+								"POST" : "MyOtherHandler.create"
+							}
+						}
+					),
+					"params" : {}
+				};
 
-                var discoveredEventGET = variables.routingService.processRoute(
-                    routeResults = routeResults,
-                    event = mockEvent,
-                    rc = mockEvent.getCollection(),
-                    prc = mockEvent.getPrivateCollection()
-                );
+				var discoveredEventGET = variables.routingService.processRoute(
+					routeResults = routeResults,
+					event        = mockEvent,
+					rc           = mockEvent.getCollection(),
+					prc          = mockEvent.getPrivateCollection()
+				);
 
-                expect( discoveredEventGET ).toBe( "MyHandler.index" );
+				expect( discoveredEventGET ).toBe( "MyHandler.index" );
 
-                mockEvent.$( "getHTTPMethod", "POST" );
+				mockEvent.$( "getHTTPMethod", "POST" );
 
-                var discoveredEventPOST = variables.routingService.processRoute(
-                    routeResults = routeResults,
-                    event = mockEvent,
-                    rc = mockEvent.getCollection(),
-                    prc = mockEvent.getPrivateCollection()
-                );
+				var discoveredEventPOST = variables.routingService.processRoute(
+					routeResults = routeResults,
+					event        = mockEvent,
+					rc           = mockEvent.getCollection(),
+					prc          = mockEvent.getPrivateCollection()
+				);
 
-                expect( discoveredEventPOST ).toBe( "MyOtherHandler.create" );
-            } );
+				expect( discoveredEventPOST ).toBe( "MyOtherHandler.create" );
+			} );
 
-            it( "appends a handler from a route definition if it exists", function() {
-                var mockEvent = createMock( "coldbox.system.web.context.RequestContext" ).init(
-                    controller = getController(),
-                    properties = {
-                        defaultLayout : "Main.cfm",
-                        defaultView   : "",
-                        eventName     : "event",
-                        modules       : {}
-                    }
-                );
+			it( "appends a handler from a route definition if it exists", function(){
+				var mockEvent = createMock( "coldbox.system.web.context.RequestContext" ).init(
+					controller = getController(),
+					properties = {
+						defaultLayout : "Main.cfm",
+						defaultView   : "",
+						eventName     : "event",
+						modules       : {}
+					}
+				);
 
-                var routeResults = { "route": initRouteDefinition( overrides = {
-                    "handler": "MyHandler",
-                    "event": "",
-                    "action": {
-                        "GET": "index",
-                        "POST": "create",
-                        "PUT": "update"
-                    }
-                } ), "params": {} };
+				var routeResults = {
+					"route" : initRouteDefinition(
+						overrides = {
+							"handler" : "MyHandler",
+							"event"   : "",
+							"action"  : { "GET" : "index", "POST" : "create", "PUT" : "update" }
+						}
+					),
+					"params" : {}
+				};
 
-                var discoveredEventGET = variables.routingService.processRoute(
-                    routeResults = routeResults,
-                    event = mockEvent,
-                    rc = mockEvent.getCollection(),
-                    prc = mockEvent.getPrivateCollection()
-                );
+				var discoveredEventGET = variables.routingService.processRoute(
+					routeResults = routeResults,
+					event        = mockEvent,
+					rc           = mockEvent.getCollection(),
+					prc          = mockEvent.getPrivateCollection()
+				);
 
-                expect( discoveredEventGET ).toBe( "MyHandler.index" );
+				expect( discoveredEventGET ).toBe( "MyHandler.index" );
 
-                mockEvent.$( "getHTTPMethod", "PUT" );
+				mockEvent.$( "getHTTPMethod", "PUT" );
 
-                var discoveredEventPOST = variables.routingService.processRoute(
-                    routeResults = routeResults,
-                    event = mockEvent,
-                    rc = mockEvent.getCollection(),
-                    prc = mockEvent.getPrivateCollection()
-                );
+				var discoveredEventPOST = variables.routingService.processRoute(
+					routeResults = routeResults,
+					event        = mockEvent,
+					rc           = mockEvent.getCollection(),
+					prc          = mockEvent.getPrivateCollection()
+				);
 
-                expect( discoveredEventPOST ).toBe( "MyHandler.update" );
-            } );
-
+				expect( discoveredEventPOST ).toBe( "MyHandler.update" );
+			} );
 		} );
 	}
 
-    /**
-     * Returns a new route definition
-     */
-    private struct function initRouteDefinition( struct overrides = {} ) {
-		structAppend( arguments.overrides, {
-			"action"                : "", // The action to execute
-			"append"                : true, // Was this route appended or pre/prended
-			"condition"             : "", // The condition closure which must be true for the route to match
-			// TODO: Consider deprecating this since now we have a `-regex()` placeholder
-			"constraints"           : {}, // If we have any regex constraints on placeholders.
-			"domain"                : "", // The domain attached to the route
-			"event"                 : "", // The full event syntax to execute
-			"handler"               : "", // The handler to execute
-			"headers"               : {}, // The HTTP response headers to respond with
-			"layout"                : "", // The layout to proxy to
-			"layoutModule"          : "", // If the layout comes from a module
-			"meta"                  : {}, // Route metadata if any
-			"module"                : "", // The module event we must execute
-			"moduleRouting"         : "", // This routes to a module
-			"name"                  : "", // The named route
-			"namespace"             : "", // The namespace this route belongs to
-			"namespaceRouting"      : "", // This routes to a namespace
-			"packageResolverExempt" : false, // If true, it does not resolve packages by convention, by default we do
-			"pattern"               : "", // The regex pattern used for matching
-			"prc"                   : {}, // The PRC params to add incorporate if matched
-			"rc"                    : {}, // The RC params to add incorporate if matched
-			"redirect"              : "", // The redirection location
-			"response"              : "", // Do we have an inline response closure
-			"ssl"                   : false, // Are we forcing SSL
-			"statusCode"            : 200, // The response status code
-			"statusText"            : "Ok", // The response status text
-			"valuePairTranslation"  : true, // If we translate name-value pairs in the URL by convention
-			"verbs"                 : "", // The HTTP Verbs allowed
-			"view"                  : "", // The view to proxy to
-			"viewModule"            : "", // If the view comes from a module
-			"viewNoLayout"          : false // If we use a layout or not
-		}, false );
-        return arguments.overrides;
+	/**
+	 * Returns a new route definition
+	 */
+	private struct function initRouteDefinition( struct overrides = {} ){
+		structAppend(
+			arguments.overrides,
+			{
+				"action"                : "", // The action to execute
+				"append"                : true, // Was this route appended or pre/prended
+				"condition"             : "", // The condition closure which must be true for the route to match
+				// TODO: Consider deprecating this since now we have a `-regex()` placeholder
+				"constraints"           : {}, // If we have any regex constraints on placeholders.
+				"domain"                : "", // The domain attached to the route
+				"event"                 : "", // The full event syntax to execute
+				"handler"               : "", // The handler to execute
+				"headers"               : {}, // The HTTP response headers to respond with
+				"layout"                : "", // The layout to proxy to
+				"layoutModule"          : "", // If the layout comes from a module
+				"meta"                  : {}, // Route metadata if any
+				"module"                : "", // The module event we must execute
+				"moduleRouting"         : "", // This routes to a module
+				"name"                  : "", // The named route
+				"namespace"             : "", // The namespace this route belongs to
+				"namespaceRouting"      : "", // This routes to a namespace
+				"packageResolverExempt" : false, // If true, it does not resolve packages by convention, by default we do
+				"pattern"               : "", // The regex pattern used for matching
+				"prc"                   : {}, // The PRC params to add incorporate if matched
+				"rc"                    : {}, // The RC params to add incorporate if matched
+				"redirect"              : "", // The redirection location
+				"response"              : "", // Do we have an inline response closure
+				"ssl"                   : false, // Are we forcing SSL
+				"statusCode"            : 200, // The response status code
+				"statusText"            : "Ok", // The response status text
+				"valuePairTranslation"  : true, // If we translate name-value pairs in the URL by convention
+				"verbs"                 : "", // The HTTP Verbs allowed
+				"view"                  : "", // The view to proxy to
+				"viewModule"            : "", // If the view comes from a module
+				"viewNoLayout"          : false // If we use a layout or not
+			},
+			false
+		);
+		return arguments.overrides;
 	}
+
 }


### PR DESCRIPTION
Multiple methods targeting the same route but with different HTTP verbs will now correctly configure the route to call the correct action.

Additionally, actions for a specific pattern can now point to different handlers, if desired.

Resolves COLDBOX-1027