### PR TITLE
Add a wirebox:targetID injection

### DIFF
--- a/system/aop/Mixer.cfc
+++ b/system/aop/Mixer.cfc
@@ -320,46 +320,48 @@ component accessors="true" {
 
 		// MD proxy Defaults
 		fncMD.name = arguments.jointPointMD.name;
-		if( structKeyExists( arguments.jointPointMD, "access" ) ){
+		if ( structKeyExists( arguments.jointPointMD, "access" ) ) {
 			fncMD.access = arguments.jointPointMD.access;
 		}
-		if( structKeyExists( arguments.jointPointMD, "output" ) ){
+		if ( structKeyExists( arguments.jointPointMD, "output" ) ) {
 			fncMD.output = arguments.jointPointMD.output;
 		}
-		if( structKeyExists( arguments.jointPointMD, "returntype" ) ){
+		if ( structKeyExists( arguments.jointPointMD, "returntype" ) ) {
 			fncMD.returntype = arguments.jointPointMD.returnType;
 		}
 		// Create Original Method Proxy Signature
-		if( fncMD.access eq "public" ){
-			udfOut.append( '<cfset this[ "#arguments.jointpoint#" ] = variables["aop_#hash( arguments.jointpoint )#" ]>#lb#' );
+		if ( fncMD.access eq "public" ) {
+			udfOut.append(
+				"<cfset this[ ""#arguments.jointpoint#"" ] = variables[""aop_#hash( arguments.jointpoint )#"" ]>#lb#"
+			);
 		}
 
-		var thisFNC = '
-		<:cffunction name="aop_#hash( arguments.jointpoint )#"
-					access="#fncMD.access#"
-					output="#fncMD.output#"
-					returntype="#fncMD.returntype#"
-					hint="WireBox AOP just rulez!"
+		var thisFNC = "
+		<:cffunction name=""aop_#hash( arguments.jointpoint )#""
+					access=""#fncMD.access#""
+					output=""#fncMD.output#""
+					returntype=""#fncMD.returntype#""
+					hint=""WireBox AOP just rulez!""
 		>
 			<cfscript>
 				// create new method invocation for this execution
-				var invocation = createObject( "component", "coldbox.system.aop.MethodInvocation" ).init(
-					method 			= "#arguments.jointPoint#",
+				var invocation = createObject( ""component"", ""coldbox.system.aop.MethodInvocation"" ).init(
+					method 			= ""#arguments.jointPoint#"",
 					args 			= arguments,
-					methodMetadata 	= "#mdJSON#",
+					methodMetadata 	= ""#mdJSON#"",
 					target 			= this,
-					targetName 		= "#mappingName#",
+					targetName 		= ""#mappingName#"",
 					targetMapping 	= this.$wbAOPTargetMapping,
-					interceptors 	= this.$wbAOPTargets[ "#arguments.jointPoint#" ].interceptors
+					interceptors 	= this.$wbAOPTargets[ ""#arguments.jointPoint#"" ].interceptors
 				);
 				// execute and return
 				return invocation.proceed();
 			</cfscript>
 		<:/cffunction>
 
-		<cfset variables[ "#arguments.jointpoint#" ] = variables[ "aop_#hash( arguments.jointpoint )#" ]>
-		<cfset structDelete( variables, "aop_#hash( jointpoint )#" ) >
-		';
+		<cfset variables[ ""#arguments.jointpoint#"" ] = variables[ ""aop_#hash( arguments.jointpoint )#"" ]>
+		<cfset structDelete( variables, ""aop_#hash( jointpoint )#"" ) >
+		";
 
 		// Do : replacement, due to inline compilation avoidances
 		thisFNC = replace( thisFNC, "<:", "<", "all" );

--- a/system/aop/Mixer.cfc
+++ b/system/aop/Mixer.cfc
@@ -320,48 +320,46 @@ component accessors="true" {
 
 		// MD proxy Defaults
 		fncMD.name = arguments.jointPointMD.name;
-		if ( structKeyExists( arguments.jointPointMD, "access" ) ) {
+		if( structKeyExists( arguments.jointPointMD, "access" ) ){
 			fncMD.access = arguments.jointPointMD.access;
 		}
-		if ( structKeyExists( arguments.jointPointMD, "output" ) ) {
+		if( structKeyExists( arguments.jointPointMD, "output" ) ){
 			fncMD.output = arguments.jointPointMD.output;
 		}
-		if ( structKeyExists( arguments.jointPointMD, "returntype" ) ) {
+		if( structKeyExists( arguments.jointPointMD, "returntype" ) ){
 			fncMD.returntype = arguments.jointPointMD.returnType;
 		}
 		// Create Original Method Proxy Signature
-		if ( fncMD.access eq "public" ) {
-			udfOut.append(
-				"<cfset this[ ""#arguments.jointpoint#"" ] = variables[""aop_#hash( arguments.jointpoint )#"" ]>#lb#"
-			);
+		if( fncMD.access eq "public" ){
+			udfOut.append( '<cfset this[ "#arguments.jointpoint#" ] = variables["aop_#hash( arguments.jointpoint )#" ]>#lb#' );
 		}
 
-		var thisFNC = "
-		<:cffunction name=""aop_#hash( arguments.jointpoint )#""
-					access=""#fncMD.access#""
-					output=""#fncMD.output#""
-					returntype=""#fncMD.returntype#""
-					hint=""WireBox AOP just rulez!""
+		var thisFNC = '
+		<:cffunction name="aop_#hash( arguments.jointpoint )#"
+					access="#fncMD.access#"
+					output="#fncMD.output#"
+					returntype="#fncMD.returntype#"
+					hint="WireBox AOP just rulez!"
 		>
 			<cfscript>
 				// create new method invocation for this execution
-				var invocation = createObject( ""component"", ""coldbox.system.aop.MethodInvocation"" ).init(
-					method 			= ""#arguments.jointPoint#"",
+				var invocation = createObject( "component", "coldbox.system.aop.MethodInvocation" ).init(
+					method 			= "#arguments.jointPoint#",
 					args 			= arguments,
-					methodMetadata 	= ""#mdJSON#"",
+					methodMetadata 	= "#mdJSON#",
 					target 			= this,
-					targetName 		= ""#mappingName#"",
+					targetName 		= "#mappingName#",
 					targetMapping 	= this.$wbAOPTargetMapping,
-					interceptors 	= this.$wbAOPTargets[ ""#arguments.jointPoint#"" ].interceptors
+					interceptors 	= this.$wbAOPTargets[ "#arguments.jointPoint#" ].interceptors
 				);
 				// execute and return
 				return invocation.proceed();
 			</cfscript>
 		<:/cffunction>
 
-		<cfset variables[ ""#arguments.jointpoint#"" ] = variables[ ""aop_#hash( arguments.jointpoint )#"" ]>
-		<cfset structDelete( variables, ""aop_#hash( jointpoint )#"" ) >
-		";
+		<cfset variables[ "#arguments.jointpoint#" ] = variables[ "aop_#hash( arguments.jointpoint )#" ]>
+		<cfset structDelete( variables, "aop_#hash( jointpoint )#" ) >
+		';
 
 		// Do : replacement, due to inline compilation avoidances
 		thisFNC = replace( thisFNC, "<:", "<", "all" );

--- a/system/ioc/Builder.cfc
+++ b/system/ioc/Builder.cfc
@@ -644,7 +644,11 @@ component serializable="false" accessors="true" {
 	 * @definition The dependency definition structure: name, dsl as keys
 	 * @targetObject The target object we are building the DSL dependency for
 	 */
-	private any function getWireBoxDSL( required definition, targetObject ){
+	private any function getWireBoxDSL(
+		required definition,
+		required targetID,
+		targetObject = ""
+	){
 		var thisType         = arguments.definition.dsl;
 		var thisTypeLen      = listLen( thisType, ":" );
 		var thisLocationType = "";
@@ -678,6 +682,9 @@ component serializable="false" accessors="true" {
 					}
 					case "properties": {
 						return variables.injector.getBinder().getProperties();
+					}
+					case "targetID": {
+						return arguments.targetID;
 					}
 				}
 				break;

--- a/system/ioc/Builder.cfc
+++ b/system/ioc/Builder.cfc
@@ -686,6 +686,14 @@ component serializable="false" accessors="true" {
 					case "targetID": {
 						return arguments.targetID;
 					}
+					case "objectMetadata": {
+						var binder  = variables.injector.getBinder();
+						var mapping = binder.getMapping( arguments.targetID );
+						if ( !mapping.isDiscovered() ) {
+							mapping.process( binder, variables.injector );
+						}
+						return mapping.getObjectMetadata();
+					}
 				}
 				break;
 			}

--- a/tests/specs/ioc/BuilderTest.cfc
+++ b/tests/specs/ioc/BuilderTest.cfc
@@ -322,6 +322,23 @@
 		data = { name : "luis", dsl : "wirebox:targetID" };
 		p    = builder.getWireBoxDSL( data, targetID );
 		assertEquals( targetID, p );
+
+		// wirebox:objectMetadata
+		data            = { name : "luis", dsl : "wirebox:objectMetadata" };
+		var mockMapping = createMock( "coldbox.system.ioc.config.Mapping" );
+		mockMapping.$( "isDiscovered", true );
+		mockMapping.$(
+			method             = "getObjectMetadata",
+			returns            = sampleObjectMetadata(),
+			preserveReturnType = false
+		);
+		mockBinder = createMock( "coldbox.system.ioc.config.Binder" )
+			.$( "getMapping" )
+			.$args( targetID )
+			.$results( mockMapping );
+		mockInjector.setBinder( mockBinder );
+		p = builder.getWireBoxDSL( data, targetID );
+		assertEquals( sampleObjectMetadata(), p );
 	}
 
 	function testbuildProviderMixer(){
@@ -377,6 +394,53 @@
 		var def    = { name : "service", dsl : "id:MyCFC" };
 		var target = builder.buildDSLDependency( definition = def, targetID = "MyCFC" );
 		expect( target ).toBe( mockObject, "id with alias" );
+	}
+
+	private struct function sampleObjectMetadata(){
+		return {
+			"remoteAddress" : "http://127.0.0.1:8599/cbtestharness/models/Photos.cfc?wsdl",
+			"hint"          : "I model a photos",
+			"path"          : "/home/elpete/code/github/ColdBox/coldbox-platform/test-harness/models/Photos.cfc",
+			"fullname"      : "test-harness.models.Photos",
+			"synchronized"  : false,
+			"properties"    : [],
+			"extends"       : {
+				"remoteAddress" : "http://127.0.0.1:8599/lucee/Component.cfc?wsdl",
+				"hint"          : "This is the Base Component",
+				"path"          : "/home/elpete/.CommandBox/server/EFAB5F85DB5928A5BC49A57B104C1B0E-coldbox-lucee@5/lucee-5.3.8.206/WEB-INF/lucee-web/context/Component.cfc",
+				"displayname"   : "Component",
+				"fullname"      : "lucee.Component",
+				"synchronized"  : false,
+				"properties"    : [],
+				"name"          : "lucee.Component",
+				"type"          : "component",
+				"accessors"     : false,
+				"persistent"    : false,
+				"functions"     : [],
+				"hashCode"      : 1199271094
+			},
+			"name"       : "test-harness.models.Photos",
+			"type"       : "component",
+			"accessors"  : true,
+			"persistent" : false,
+			"functions"  : [
+				{
+					"access"       : "public",
+					"position"     : { "start" : 12, "end" : 14 },
+					"hint"         : "Constructor",
+					"returnFormat" : "wddx",
+					"returntype"   : "Photos",
+					"output"       : true,
+					"closure"      : false,
+					"parameters"   : [],
+					"modifier"     : "",
+					"name"         : "init",
+					"owner"        : "/home/elpete/code/github/ColdBox/coldbox-platform/test-harness/models/Photos.cfc",
+					"description"  : ""
+				}
+			],
+			"hashCode" : 546083746
+		};
 	}
 
 }

--- a/tests/specs/ioc/BuilderTest.cfc
+++ b/tests/specs/ioc/BuilderTest.cfc
@@ -319,10 +319,7 @@
 		assertEquals( "luis", p );
 
 		// wirebox:targetID
-		data = {
-            name : "luis",
-            dsl : "wirebox:targetID"
-        };
+		data = { name : "luis", dsl : "wirebox:targetID" };
 		p    = builder.getWireBoxDSL( data, targetID );
 		assertEquals( targetID, p );
 	}

--- a/tests/specs/ioc/BuilderTest.cfc
+++ b/tests/specs/ioc/BuilderTest.cfc
@@ -261,44 +261,45 @@
 
 	function testgetWireBoxDSL(){
 		makePublic( builder, "getWireBoxDSL" );
-		var data = { name : "luis", dsl : "wirebox" };
+		var targetID = "testWireBoxDSL";
+		var data     = { name : "luis", dsl : "wirebox" };
 
 		// wirebox
-		var p = builder.getWireBoxDSL( data );
+		var p = builder.getWireBoxDSL( data, targetID );
 		expect( getMetadata( p ).name ).toMatch( "Injector" );
 
 		// wirebox:parent
 		data = { name : "luis", dsl : "wirebox:parent" };
 		mockInjector.$( "getParent", "" );
-		p = builder.getWireBoxDSL( data );
+		p = builder.getWireBoxDSL( data, targetID );
 		assertEquals( "", p );
 
 		// wirebox:eventmanager
 		data             = { name : "luis", dsl : "wirebox:eventManager" };
 		mockEventManager = createEmptyMock( "coldbox.system.core.events.EventPoolManager" );
 		mockInjector.setEventManager( mockEventManager );
-		p = builder.getWireBoxDSL( data );
+		p = builder.getWireBoxDSL( data, targetID );
 		assertEquals( mockEventManager, p );
 
 		// wirebox:binder
 		data       = { name : "luis", dsl : "wirebox:binder" };
 		mockBinder = createMock( "coldbox.system.ioc.config.Binder" );
 		mockInjector.setBinder( mockBinder );
-		p = builder.getWireBoxDSL( data );
+		p = builder.getWireBoxDSL( data, targetID );
 		assertEquals( mockBinder, p );
 
 		// wirebox:populator
 		data      = { name : "luis", dsl : "wirebox:populator" };
 		populator = createEmptyMock( "coldbox.system.core.dynamic.BeanPopulator" );
 		mockInjector.$( "getObjectPopulator", populator );
-		p = builder.getWireBoxDSL( data );
+		p = builder.getWireBoxDSL( data, targetID );
 		assertEquals( populator, p );
 
 		// wirebox:scope
 		data      = { name : "luis", dsl : "wirebox:scope:singleton" };
 		mockScope = createEmptyMock( "coldbox.system.ioc.scopes.Singleton" );
 		mockInjector.$( "getScope", mockScope );
-		p = builder.getWireBoxDSL( data );
+		p = builder.getWireBoxDSL( data, targetID );
 		assertEquals( mockScope, p );
 
 		// wirebox:properties
@@ -306,7 +307,7 @@
 		props      = { prop1 : "hello", name : "luis" };
 		mockBinder = createMock( "coldbox.system.ioc.config.Binder" ).setProperties( props );
 		mockInjector.setBinder( mockBinder );
-		p = builder.getWireBoxDSL( data );
+		p = builder.getWireBoxDSL( data, targetID );
 		assertEquals( props, p );
 
 		// wirebox:property:{}
@@ -314,8 +315,16 @@
 		props      = { prop1 : "hello", name : "luis" };
 		mockBinder = createMock( "coldbox.system.ioc.config.Binder" ).setProperties( props );
 		mockInjector.setBinder( mockBinder );
-		p = builder.getWireBoxDSL( data );
+		p = builder.getWireBoxDSL( data, targetID );
 		assertEquals( "luis", p );
+
+		// wirebox:targetID
+		data = {
+            name : "luis",
+            dsl : "wirebox:targetID"
+        };
+		p    = builder.getWireBoxDSL( data, targetID );
+		assertEquals( targetID, p );
 	}
 
 	function testbuildProviderMixer(){

--- a/tests/specs/ioc/InjectorCreationTest.cfc
+++ b/tests/specs/ioc/InjectorCreationTest.cfc
@@ -142,7 +142,7 @@
 	function testWebService() skip="isAdobe"{
 		ws = injector.getInstance( "coldboxWS" );
 
-		// 
+		//
 		if ( listFindNoCase( "Lucee", server.coldfusion.productname ) ) {
 			expect( getMetadata( ws ).name ).toMatch( "rpc" );
 		}

--- a/tests/specs/ioc/config/BinderTest.cfc
+++ b/tests/specs/ioc/config/BinderTest.cfc
@@ -123,9 +123,9 @@
 	}
 
 	function testParent(){
-		// 
+		//
 		// create "dependency" beans to be injected
-		// 
+		//
 
 		// alpha and bravo are in the abstract service
 		config.map( "someAlphaDAO" ).to( "models.parent.SomeAlphaDAO" );


### PR DESCRIPTION
This is used to get the targetID (usually the mapping name) used to create an object as a property on the object.