### PR TITLE
Replace IIF and urlEncodedFormat

### DIFF
--- a/system/cache/report/skins/default/CacheContentReport.cfm
+++ b/system/cache/report/skins/default/CacheContentReport.cfm
@@ -20,7 +20,7 @@
 		<tr <cfif x mod 2 eq 0>class="even"</cfif> id="cbox_cache_tr_#urlEncodedFormat(thisKey)#">
 	  	<!--- Link --->
 		<td align="left">
-		  	<a href="javascript:cachebox_openwindow('#URLBase##iif(Find("?", URLBase), DE('&'), DE('?'))#debugpanel=cacheviewer&cbox_cacheName=#arguments.cacheName#&cbox_cacheEntry=#urlEncodedFormat( thisKey )#','CacheViewer',650,375,'resizable,scrollbars,status')"
+		  	<a href="javascript:cachebox_openwindow('#URLBase##(Find("?", URLBase) ? '&' : '?')#debugpanel=cacheviewer&cbox_cacheName=#arguments.cacheName#&cbox_cacheEntry=#encodeForJavascript( thisKey )#','CacheViewer',650,375,'resizable,scrollbars,status')"
 			   title="#thisKey#">
 		  	#thisKey#
 			</a>


### PR DESCRIPTION
Replace IIF and urlEncodedFormat with modern versions
Use of `IIF` is discouraged as it evaluates the expression
Use of `urlEncodedFormat` is discouraged in deference to more specialised versions
This change will apply to Cachebox and therefore ColdBox and Wirebox