### PR TITLE
COLDBOX-1010: Add isNull checks

### DIFF
--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -1658,13 +1658,13 @@ component serializable="false" accessors="true" {
 	 */
 	function setHTTPHeader( statusCode, statusText = "", name, value = "" ){
 		// status code? We do not add to response headers as this is a separate marker identifier to the response
-		if ( structKeyExists( arguments, "statusCode" ) && !isNull( arguments.statusCode ) ) {
+		if ( !isNull( arguments.statusCode ) ) {
 			getPageContext()
 				.getResponse()
 				.setStatus( javacast( "int", arguments.statusCode ), javacast( "string", arguments.statusText ) );
 		}
 		// Name Exists
-		else if ( structKeyExists( arguments, "name" ) && !isNull( arguments.name ) ) {
+		else if ( !isNull( arguments.name ) ) {
 			getPageContext()
 				.getResponse()
 				.addHeader( javacast( "string", arguments.name ), javacast( "string", arguments.value ) );

--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -1658,13 +1658,13 @@ component serializable="false" accessors="true" {
 	 */
 	function setHTTPHeader( statusCode, statusText = "", name, value = "" ){
 		// status code? We do not add to response headers as this is a separate marker identifier to the response
-		if ( structKeyExists( arguments, "statusCode" ) ) {
+		if ( structKeyExists( arguments, "statusCode" ) && !isNull( arguments.statusCode ) ) {
 			getPageContext()
 				.getResponse()
 				.setStatus( javacast( "int", arguments.statusCode ), javacast( "string", arguments.statusText ) );
 		}
 		// Name Exists
-		else if ( structKeyExists( arguments, "name" ) ) {
+		else if ( structKeyExists( arguments, "name" ) && !isNull( arguments.statusCode ) ) {
 			getPageContext()
 				.getResponse()
 				.addHeader( javacast( "string", arguments.name ), javacast( "string", arguments.value ) );

--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -1664,7 +1664,7 @@ component serializable="false" accessors="true" {
 				.setStatus( javacast( "int", arguments.statusCode ), javacast( "string", arguments.statusText ) );
 		}
 		// Name Exists
-		else if ( structKeyExists( arguments, "name" ) && !isNull( arguments.statusCode ) ) {
+		else if ( structKeyExists( arguments, "name" ) && !isNull( arguments.name ) ) {
 			getPageContext()
 				.getResponse()
 				.addHeader( javacast( "string", arguments.name ), javacast( "string", arguments.value ) );


### PR DESCRIPTION
When Lucee's NULL support is enabled (see resolved COLDBOX-1010 which has `this.nullsupport=true` in the Application.cfc), I found a specific location that stops ColdBox from loading when running a rest-hmvc installation.

In the past structKeyExists returned false if the key did exist but was assigned a NULL.  With null support enabled, if the key was created and was given a value of NULL, the old comparison no longer works.  Because you're following that up with a javacast() call, we need to add an additional !isNull() check.