### PR TITLE
Cache elixirPath lookups based on all arguments

### DIFF
--- a/system/modules/HTMLHelper/models/HTMLHelper.cfc
+++ b/system/modules/HTMLHelper/models/HTMLHelper.cfc
@@ -2528,12 +2528,13 @@ component
 		numeric version       = 3,
 		manifestRoot          = ""
 	){
+		var argumentsHash = hash( serializeJSON( arguments ) );
 		// Incoming Cleanup
 		arguments.fileName = reReplace( arguments.fileName, "^//?", "" );
 
 		// In local discovery cache?
-		if ( variables.cachedPaths.keyExists( arguments.filename ) ) {
-			return variables.cachedPaths[ arguments.filename ];
+		if ( variables.cachedPaths.keyExists( argumentsHash ) ) {
+			return variables.cachedPaths[ argumentsHash ];
 		}
 
 		// Prepare state checks
@@ -2543,13 +2544,13 @@ component
 
 		// Get the manifest location
 		var manifestPath = discoverElixirManifest( argumentCollection = arguments );
-
+		
 		// Calculate mapping for the asset in question
 		var mapping = ( arguments.useModuleRoot && len( arguments.currentModule ) ) ? event.getModuleRoot() : controller.getSetting(
 			"appMapping"
 		);
 
-		// Calculat href for asset delivery via Browser
+		// Calculate href for asset delivery via Browser
 		if ( mapping.len() ) {
 			var href = "/#mapping#/#includesLocation#/#arguments.fileName#";
 		} else {
@@ -2578,10 +2579,10 @@ component
 		// Is the key in the manifest?
 		var manifestDirectory = variables.elixirManifests[ hash( manifestPath ) ];
 		if ( !structKeyExists( manifestDirectory, key ) ) {
-			variables.cachedPaths[ arguments.fileName ] = arguments.fileName;
+			variables.cachedPaths[ argumentsHash ] = arguments.fileName;
 			return href;
 		}
-		variables.cachedPaths[ arguments.fileName ] = manifestDirectory[ key ];
+		variables.cachedPaths[ argumentsHash ] = manifestDirectory[ key ];
 		return "#manifestDirectory[ key ]#";
 	}
 

--- a/system/modules/HTMLHelper/models/HTMLHelper.cfc
+++ b/system/modules/HTMLHelper/models/HTMLHelper.cfc
@@ -2528,7 +2528,7 @@ component
 		numeric version       = 3,
 		manifestRoot          = ""
 	){
-		var argumentsHash = hash( serializeJSON( arguments ) );
+		var argumentsHash  = hash( serializeJSON( arguments ) );
 		// Incoming Cleanup
 		arguments.fileName = reReplace( arguments.fileName, "^//?", "" );
 
@@ -2544,7 +2544,7 @@ component
 
 		// Get the manifest location
 		var manifestPath = discoverElixirManifest( argumentCollection = arguments );
-		
+
 		// Calculate mapping for the asset in question
 		var mapping = ( arguments.useModuleRoot && len( arguments.currentModule ) ) ? event.getModuleRoot() : controller.getSetting(
 			"appMapping"

--- a/tests/specs/cache/providers/CacheBoxProviderTest.cfc
+++ b/tests/specs/cache/providers/CacheBoxProviderTest.cfc
@@ -172,8 +172,8 @@
 		var results = cache.getMulti( "test,test2" );
 		// debug(results);
 
-		expect(	isNull( results.test ) ).toBeFalse();
-		expect(	isNull( results.test2 ) ).toBeTrue();
+		expect( isNull( results.test ) ).toBeFalse();
+		expect( isNull( results.test2 ) ).toBeTrue();
 	}
 
 	function testgetCachedObjectMetadata(){

--- a/tests/specs/ioc/InjectorCreationTest.cfc
+++ b/tests/specs/ioc/InjectorCreationTest.cfc
@@ -142,7 +142,7 @@
 	function testWebService() skip="isAdobe"{
 		ws = injector.getInstance( "coldboxWS" );
 
-		//
+		// 
 		if ( listFindNoCase( "Lucee", server.coldfusion.productname ) ) {
 			expect( getMetadata( ws ).name ).toMatch( "rpc" );
 		}

--- a/tests/specs/ioc/config/samples/NoScopeBinder.cfc
+++ b/tests/specs/ioc/config/samples/NoScopeBinder.cfc
@@ -5,7 +5,7 @@
  * The default ColdBox WireBox Injector configuration object that is used when the
  * WireBox injector is created
  **/
- component extends="coldbox.system.ioc.config.Binder" {
+component extends="coldbox.system.ioc.config.Binder" {
 
 	/**
 	 * Configure WireBox, that's it!

--- a/tests/specs/web/flash/AbstractFlashScopeTest.cfc
+++ b/tests/specs/web/flash/AbstractFlashScopeTest.cfc
@@ -8,8 +8,8 @@
 		mockController.getConfigSettings().identifierProvider = function(){
 			return createUUID();
 		};
-		mockRService   = createMock( className = "coldbox.system.web.services.RequestService", clearMethods = true );
-		mockEvent      = createMock( className = "coldbox.system.web.context.RequestContext", clearMethods = true );
+		mockRService = createMock( className = "coldbox.system.web.services.RequestService", clearMethods = true );
+		mockEvent    = createMock( className = "coldbox.system.web.context.RequestContext", clearMethods = true );
 
 		mockController
 			.$( "getRequestService", mockRService )

--- a/tests/specs/web/flash/ColdboxCacheFlashTest.cfc
+++ b/tests/specs/web/flash/ColdboxCacheFlashTest.cfc
@@ -9,11 +9,11 @@
 
 				// mocks
 				session.sessionid = createUUID();
-				mockController = createMock( "coldbox.system.web.Controller" ).init( expandPath( "/root" ) );
+				mockController    = createMock( "coldbox.system.web.Controller" ).init( expandPath( "/root" ) );
 				mockController.getConfigSettings().identifierProvider = function(){
 					return createUUID();
 				};
-				mockCache         = createMock(
+				mockCache = createMock(
 					className    = "coldbox.system.cache.providers.CacheBoxProvider",
 					clearMethods = true
 				);


### PR DESCRIPTION
Before, elixirPath would only use fileName to cache and lookup full paths.
Paths could have the same name between different modules.  In that case,
the module that loaded first would be returned for every other module.
This fix takes all arguments into account to resolve those collisions.