### PR TITLE
Added new handler metadata property `cacheIncludeRcKeys`

### DIFF
--- a/system/cache/util/EventURLFacade.cfc
+++ b/system/cache/util/EventURLFacade.cfc
@@ -35,16 +35,22 @@ component accessors="true" {
 
 	/**
 	 * Build a unique hash from an incoming request context
+     * Note: the 'event' key is always ignored from the request collection
 	 *
 	 * @event A request context object
+     * @cacheIncludeRcKeys A list of keys to include ( '*'=all keys )
 	 */
-	string function getUniqueHash( required event ){
-		var rcTarget = arguments.event
-			.getCollection()
-			.filter( function( key, value ){
-				// Remove event, not needed for hashing purposes
-				return ( key != "event" );
-			} );
+	string function getUniqueHash( required event, string cacheIncludeRcKeys="*" ){
+
+        var rcTarget = arguments.event.getCollection().filter( function( key, value ){
+			return (
+                key != "event" && // Remove event, not needed for hashing purposes
+                (
+                    cacheIncludeRcKeys == "*" || // include all keys if *
+                    listFindNoCase( cacheIncludeRcKeys, key ) // or if the key is specified
+                )
+            );
+		} );
 
 		// systemOutput( "=====> uniquehash-rcTarget: #variables.jTreeMap.init( rcTarget ).toString()#", true );
 		// systemOutput( "=====> uniquehash-rcTargetHash: #hash( variables.jTreeMap.init( rcTarget ).toString() )#", true );
@@ -105,12 +111,13 @@ component accessors="true" {
 	 * @targetEvent The targeted ColdBox event executed
 	 * @targetContext The targeted request context object
 	 */
-	string function buildEventKey(
-		required keySuffix,
-		required targetEvent,
-		required targetContext
-	){
-		return buildBasicCacheKey( argumentCollection = arguments ) & getUniqueHash( arguments.targetContext );
+	string function buildEventKey( 
+        required keySuffix, 
+        required targetEvent, 
+        required targetContext, 
+        string cacheIncludeRcKeys="*" 
+    ){
+		return buildBasicCacheKey( argumentCollection=arguments ) & getUniqueHash( arguments.targetContext, arguments.cacheIncludeRcKeys );
 	}
 
 	/**

--- a/system/cache/util/EventURLFacade.cfc
+++ b/system/cache/util/EventURLFacade.cfc
@@ -35,22 +35,23 @@ component accessors="true" {
 
 	/**
 	 * Build a unique hash from an incoming request context
-     * Note: the 'event' key is always ignored from the request collection
+	 * Note: the 'event' key is always ignored from the request collection
 	 *
 	 * @event A request context object
-     * @cacheIncludeRcKeys A list of keys to include ( '*'=all keys )
+	 * @cacheIncludeRcKeys A list of keys to include ( '*'=all keys )
 	 */
-	string function getUniqueHash( required event, string cacheIncludeRcKeys="*" ){
-
-        var rcTarget = arguments.event.getCollection().filter( function( key, value ){
-			return (
-                key != "event" && // Remove event, not needed for hashing purposes
-                (
-                    cacheIncludeRcKeys == "*" || // include all keys if *
-                    listFindNoCase( cacheIncludeRcKeys, key ) // or if the key is specified
-                )
-            );
-		} );
+	string function getUniqueHash( required event, string cacheIncludeRcKeys = "*" ){
+		var rcTarget = arguments.event
+			.getCollection()
+			.filter( function( key, value ){
+				return (
+					key != "event" && // Remove event, not needed for hashing purposes
+					(
+						cacheIncludeRcKeys == "*" || // include all keys if *
+						listFindNoCase( cacheIncludeRcKeys, key ) // or if the key is specified
+					)
+				);
+			} );
 
 		// systemOutput( "=====> uniquehash-rcTarget: #variables.jTreeMap.init( rcTarget ).toString()#", true );
 		// systemOutput( "=====> uniquehash-rcTargetHash: #hash( variables.jTreeMap.init( rcTarget ).toString() )#", true );
@@ -111,13 +112,16 @@ component accessors="true" {
 	 * @targetEvent The targeted ColdBox event executed
 	 * @targetContext The targeted request context object
 	 */
-	string function buildEventKey( 
-        required keySuffix, 
-        required targetEvent, 
-        required targetContext, 
-        string cacheIncludeRcKeys="*" 
-    ){
-		return buildBasicCacheKey( argumentCollection=arguments ) & getUniqueHash( arguments.targetContext, arguments.cacheIncludeRcKeys );
+	string function buildEventKey(
+		required keySuffix,
+		required targetEvent,
+		required targetContext,
+		string cacheIncludeRcKeys = "*"
+	){
+		return buildBasicCacheKey( argumentCollection = arguments ) & getUniqueHash(
+			arguments.targetContext,
+			arguments.cacheIncludeRcKeys
+		);
 	}
 
 	/**

--- a/system/web/Controller.cfc
+++ b/system/web/Controller.cfc
@@ -654,7 +654,7 @@ component serializable="false" accessors="true" {
 			var cacheKey        = oEventURLFacade.buildBasicCacheKey(
 				keySuffix   = arguments.cacheSuffix,
 				targetEvent = arguments.event
-			) & hash( arguments.eventArguments.toString() );
+            ) & hash( arguments.eventArguments.toString() );
 
 			// Test if entry found in cache, and return if found.
 			var data = oCache.get( cacheKey );

--- a/system/web/Controller.cfc
+++ b/system/web/Controller.cfc
@@ -654,7 +654,7 @@ component serializable="false" accessors="true" {
 			var cacheKey        = oEventURLFacade.buildBasicCacheKey(
 				keySuffix   = arguments.cacheSuffix,
 				targetEvent = arguments.event
-            ) & hash( arguments.eventArguments.toString() );
+			) & hash( arguments.eventArguments.toString() );
 
 			// Test if entry found in cache, and return if found.
 			var data = oCache.get( cacheKey );

--- a/system/web/services/HandlerService.cfc
+++ b/system/web/services/HandlerService.cfc
@@ -189,7 +189,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 			!arguments.ehBean.getIsPrivate() AND
 			arguments.ehBean.getFullEvent() EQ oRequestContext.getCurrentEvent()
 		) {
-            // Get event action caching metadata
+			// Get event action caching metadata
 			var eventDictionaryEntry = getEventCachingMetadata( arguments.ehBean, oEventHandler );
 
 			// Do we need to cache this event's output after it executes??
@@ -199,12 +199,12 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 				structAppend( eventCachingData, eventDictionaryEntry, true );
 
 				// Create the Cache Key to save
-                eventCachingData.cacheKey = oEventURLFacade.buildEventKey(
-                    keySuffix           = eventDictionaryEntry.suffix,
-                    targetEvent         = arguments.ehBean.getFullEvent(),
-                    targetContext       = oRequestContext,
-                    cacheIncludeRcKeys  = eventDictionaryEntry.cacheIncludeRcKeys
-                );
+				eventCachingData.cacheKey = oEventURLFacade.buildEventKey(
+					keySuffix          = eventDictionaryEntry.suffix,
+					targetEvent        = arguments.ehBean.getFullEvent(),
+					targetContext      = oRequestContext,
+					cacheIncludeRcKeys = eventDictionaryEntry.cacheIncludeRcKeys
+				);
 
 				// Event is cacheable and we need to flag it so the Renderer caches it
 				oRequestContext.setEventCacheableEntry( eventCachingData );
@@ -630,13 +630,13 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 */
 	private struct function getNewMDEntry(){
 		return {
-			"cacheable"         : false,
-			"timeout"           : "",
-			"lastAccessTimeout" : "",
-			"cacheKey"          : "",
-			"suffix"            : "",
-			"provider"          : "template",
-            "cacheIncludeRcKeys": "*"
+			"cacheable"          : false,
+			"timeout"            : "",
+			"lastAccessTimeout"  : "",
+			"cacheKey"           : "",
+			"suffix"             : "",
+			"provider"           : "template",
+			"cacheIncludeRcKeys" : "*"
 		};
 	}
 
@@ -649,7 +649,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 * @return strc
 	 */
 	private struct function getEventCachingMetadata( required ehBean, required oEventHandler ){
-        var cacheKey = arguments.ehBean.getFullEvent();
+		var cacheKey = arguments.ehBean.getFullEvent();
 
 		// Double lock for race conditions
 		if ( !structKeyExists( variables.eventCacheDictionary, cacheKey ) ) {
@@ -670,8 +670,11 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 							"cacheLastAccessTimeout",
 							""
 						);
-						mdEntry.provider = arguments.ehBean.getActionMetadata( "cacheProvider", "template" );
-                        mdEntry.cacheIncludeRcKeys = arguments.ehBean.getActionMetadata( "cacheIncludeRcKeys", "*" );
+						mdEntry.provider           = arguments.ehBean.getActionMetadata( "cacheProvider", "template" );
+						mdEntry.cacheIncludeRcKeys = arguments.ehBean.getActionMetadata(
+							"cacheIncludeRcKeys",
+							"*"
+						);
 
 						// Handler Event Cache Key Suffix, this is global to the event
 						if (

--- a/system/web/services/HandlerService.cfc
+++ b/system/web/services/HandlerService.cfc
@@ -189,7 +189,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 			!arguments.ehBean.getIsPrivate() AND
 			arguments.ehBean.getFullEvent() EQ oRequestContext.getCurrentEvent()
 		) {
-			// Get event action caching metadata
+            // Get event action caching metadata
 			var eventDictionaryEntry = getEventCachingMetadata( arguments.ehBean, oEventHandler );
 
 			// Do we need to cache this event's output after it executes??
@@ -199,11 +199,12 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 				structAppend( eventCachingData, eventDictionaryEntry, true );
 
 				// Create the Cache Key to save
-				eventCachingData.cacheKey = oEventURLFacade.buildEventKey(
-					keySuffix     = eventDictionaryEntry.suffix,
-					targetEvent   = arguments.ehBean.getFullEvent(),
-					targetContext = oRequestContext
-				);
+                eventCachingData.cacheKey = oEventURLFacade.buildEventKey(
+                    keySuffix           = eventDictionaryEntry.suffix,
+                    targetEvent         = arguments.ehBean.getFullEvent(),
+                    targetContext       = oRequestContext,
+                    cacheIncludeRcKeys  = eventDictionaryEntry.cacheIncludeRcKeys
+                );
 
 				// Event is cacheable and we need to flag it so the Renderer caches it
 				oRequestContext.setEventCacheableEntry( eventCachingData );
@@ -634,7 +635,8 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 			"lastAccessTimeout" : "",
 			"cacheKey"          : "",
 			"suffix"            : "",
-			"provider"          : "template"
+			"provider"          : "template",
+            "cacheIncludeRcKeys": "*"
 		};
 	}
 
@@ -647,7 +649,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 * @return strc
 	 */
 	private struct function getEventCachingMetadata( required ehBean, required oEventHandler ){
-		var cacheKey = arguments.ehBean.getFullEvent();
+        var cacheKey = arguments.ehBean.getFullEvent();
 
 		// Double lock for race conditions
 		if ( !structKeyExists( variables.eventCacheDictionary, cacheKey ) ) {
@@ -669,6 +671,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 							""
 						);
 						mdEntry.provider = arguments.ehBean.getActionMetadata( "cacheProvider", "template" );
+                        mdEntry.cacheIncludeRcKeys = arguments.ehBean.getActionMetadata( "cacheIncludeRcKeys", "*" );
 
 						// Handler Event Cache Key Suffix, this is global to the event
 						if (

--- a/system/web/services/RequestService.cfc
+++ b/system/web/services/RequestService.cfc
@@ -154,7 +154,8 @@ component extends="coldbox.system.web.services.BaseService" {
 			eventCache[ "cacheKey" ] = oEventURLFacade.buildEventKey(
 				keySuffix     = eventDictionary.suffix,
 				targetEvent   = currentEvent,
-				targetContext = arguments.context
+				targetContext = arguments.context,
+                cacheIncludeRcKeys = eventDictionary.cacheIncludeRcKeys
 			);
 
 			// Check for Event Cache Purge

--- a/system/web/services/RequestService.cfc
+++ b/system/web/services/RequestService.cfc
@@ -152,10 +152,10 @@ component extends="coldbox.system.web.services.BaseService" {
 			eventCache.append( eventDictionary, true );
 			// Build the event cache key according to incoming request
 			eventCache[ "cacheKey" ] = oEventURLFacade.buildEventKey(
-				keySuffix     = eventDictionary.suffix,
-				targetEvent   = currentEvent,
-				targetContext = arguments.context,
-                cacheIncludeRcKeys = eventDictionary.cacheIncludeRcKeys
+				keySuffix          = eventDictionary.suffix,
+				targetEvent        = currentEvent,
+				targetContext      = arguments.context,
+				cacheIncludeRcKeys = eventDictionary.cacheIncludeRcKeys
 			);
 
 			// Check for Event Cache Purge

--- a/test-harness/handlers/eventcaching.cfc
+++ b/test-harness/handlers/eventcaching.cfc
@@ -46,6 +46,75 @@
 		return prc.data;
 	}
 
+    // cacheIncludeRcKeys (all keys)
+	function withIncludeAllRcKeys( event, rc, prc )
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheIncludeRcKeys="*"
+    {
+
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
+    // cacheIncludeRcKeys (no keys)
+    function withIncludeNoRcKeys( event, rc, prc )
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheIncludeRcKeys=""
+    {
+
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
+    // cacheIncludeRcKeys (1 RC key)
+    function withIncludeOneRcKey( event, rc, prc )
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheIncludeRcKeys="slug"
+    {
+
+        param rc.slug = "";
+        
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
+    // cacheIncludeRcKeys (RC 2 keys)
+    function withIncludeRcKeyList( event, rc, prc )
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheIncludeRcKeys="slug,id"
+    {
+
+        param rc.slug = "";
+        param rc.id = "";
+        
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
 	function cacheKeys( event, rc, prc ){
 		var keys = {
 			"template" : getCache( "template" ).getKeys(),

--- a/tests/specs/cache/providers/CacheBoxProviderTest.cfc
+++ b/tests/specs/cache/providers/CacheBoxProviderTest.cfc
@@ -172,8 +172,8 @@
 		var results = cache.getMulti( "test,test2" );
 		// debug(results);
 
-		expect(	isNull( results.test ) ).toBeFalse();
-		expect(	isNull( results.test2 ) ).toBeTrue();
+		expect( isNull( results.test ) ).toBeFalse();
+		expect( isNull( results.test2 ) ).toBeTrue();
 	}
 
 	function testgetCachedObjectMetadata(){

--- a/tests/specs/integration/EventCaching.cfc
+++ b/tests/specs/integration/EventCaching.cfc
@@ -24,157 +24,144 @@
 
 
 			it( "can do cached events with custom provider annotations", function(){
-				var event = execute( 
-                    event = "eventcaching.withProvider", 
-                    renderResults = true 
-                );
+				var event = execute( event = "eventcaching.withProvider", renderResults = true );
 				var prc   = event.getPrivateCollection();
 
 				expect( prc.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "provider" );
 				expect( prc.cbox_eventCacheableEntry.provider ).toBe( "default" );
 			} );
 
-            it( "can handle different RC collections", function(){
-				
-                // execute an event and specify a queryString variable
-                var event1 = execute( 
-                    event = "eventcaching", 
-                    renderResults = true,
-                    queryString="id=1" 
-                );
+			it( "can handle different RC collections", function(){
+				// execute an event and specify a queryString variable
+				var event1 = execute(
+					event         = "eventcaching",
+					renderResults = true,
+					queryString   = "id=1"
+				);
 				var prc1 = event1.getPrivateCollection();
 
-                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
 				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "*" );
 
-                // reset to simulate another request with a different rc scope
-                setup();
+				// reset to simulate another request with a different rc scope
+				setup();
 
-                var event2 = execute( 
-                    event = "eventcaching", 
-                    renderResults = true,
-                    queryString="id=2" 
-                );
-				
-                var prc2 = event2.getPrivateCollection();
+				var event2 = execute(
+					event         = "eventcaching",
+					renderResults = true,
+					queryString   = "id=2"
+				);
 
-                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				var prc2 = event2.getPrivateCollection();
+
+				expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
 				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "*" );
 
-                // because the default cache considers the rc scope, the cache keys should be different
-                expect( prc1.cbox_eventCacheableEntry.cacheKey ).notToBe( prc2.cbox_eventCacheableEntry.cacheKey );
-
+				// because the default cache considers the rc scope, the cache keys should be different
+				expect( prc1.cbox_eventCacheableEntry.cacheKey ).notToBe( prc2.cbox_eventCacheableEntry.cacheKey );
 			} );
 
-            it( "can handle the cacheIncludeRcKeys metadata", function(){
-				
-                // execute an event and specify a queryString variable
-                var event1 = execute( 
-                    event = "eventcaching.withIncludeAllRcKeys", 
-                    renderResults = true,
-                    queryString="id=1" 
-                );
+			it( "can handle the cacheIncludeRcKeys metadata", function(){
+				// execute an event and specify a queryString variable
+				var event1 = execute(
+					event         = "eventcaching.withIncludeAllRcKeys",
+					renderResults = true,
+					queryString   = "id=1"
+				);
 				var prc1 = event1.getPrivateCollection();
 
-                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
 				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "*" );
-
 			} );
 
-            it( "can ignore the rc scope", function(){
-				
-                // execute an event and specify a queryString variable
-                var event1 = execute( 
-                    event = "eventcaching.withIncludeNoRcKeys", 
-                    renderResults = true,
-                    queryString="id=1" 
-                );
+			it( "can ignore the rc scope", function(){
+				// execute an event and specify a queryString variable
+				var event1 = execute(
+					event         = "eventcaching.withIncludeNoRcKeys",
+					renderResults = true,
+					queryString   = "id=1"
+				);
 				var prc1 = event1.getPrivateCollection();
 
-                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
 				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "" );
 
-                // reset to simulate another request
-                setup();
+				// reset to simulate another request
+				setup();
 
-                var event2 = execute( 
-                    event = "eventcaching.withIncludeNoRcKeys", 
-                    renderResults = true,
-                    queryString="id=2" 
-                );
-				
-                var prc2 = event2.getPrivateCollection();
+				var event2 = execute(
+					event         = "eventcaching.withIncludeNoRcKeys",
+					renderResults = true,
+					queryString   = "id=2"
+				);
 
-                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				var prc2 = event2.getPrivateCollection();
+
+				expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
 				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "" );
 
-                // because we ignore the RC, the cache key should match
-                expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
-
+				// because we ignore the RC, the cache key should match
+				expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
 			} );
 
-            it( "can isolate specific RC scope keys and ignore the rest", function(){
-				
-                // execute an event and specify a queryString variable
-                var event1 = execute( 
-                    event = "eventcaching.withIncludeOneRcKey", 
-                    renderResults = true,
-                    queryString="id=1&slug=foo" 
-                );
+			it( "can isolate specific RC scope keys and ignore the rest", function(){
+				// execute an event and specify a queryString variable
+				var event1 = execute(
+					event         = "eventcaching.withIncludeOneRcKey",
+					renderResults = true,
+					queryString   = "id=1&slug=foo"
+				);
 				var prc1 = event1.getPrivateCollection();
 
-                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
 				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug" );
 
-                // reset to simulate another request
-                setup();
+				// reset to simulate another request
+				setup();
 
-                var event2 = execute( 
-                    event = "eventcaching.withIncludeOneRcKey", 
-                    renderResults = true,
-                    queryString="id=2&slug=foo" 
-                );
-				
-                var prc2 = event2.getPrivateCollection();
+				var event2 = execute(
+					event         = "eventcaching.withIncludeOneRcKey",
+					renderResults = true,
+					queryString   = "id=2&slug=foo"
+				);
 
-                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				var prc2 = event2.getPrivateCollection();
+
+				expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
 				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug" );
 
-                // because we ignore the RC, the cache key should match
-                expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
-
+				// because we ignore the RC, the cache key should match
+				expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
 			} );
 
-            it( "can handle a list of specific RC scope keys and ignore the rest", function(){
-				
-                // execute an event and specify a queryString variable
-                var event1 = execute( 
-                    event = "eventcaching.withIncludeRcKeyList", 
-                    renderResults = true,
-                    queryString="id=1&slug=foo&source=google" 
-                );
+			it( "can handle a list of specific RC scope keys and ignore the rest", function(){
+				// execute an event and specify a queryString variable
+				var event1 = execute(
+					event         = "eventcaching.withIncludeRcKeyList",
+					renderResults = true,
+					queryString   = "id=1&slug=foo&source=google"
+				);
 				var prc1 = event1.getPrivateCollection();
 
-                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
 				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug,id" );
 
-                // reset to simulate another request
-                setup();
+				// reset to simulate another request
+				setup();
 
-                var event2 = execute( 
-                    event = "eventcaching.withIncludeRcKeyList", 
-                    renderResults = true,
-                    queryString="id=1&slug=foo&source=bing" 
-                );
-				
-                var prc2 = event2.getPrivateCollection();
+				var event2 = execute(
+					event         = "eventcaching.withIncludeRcKeyList",
+					renderResults = true,
+					queryString   = "id=1&slug=foo&source=bing"
+				);
 
-                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				var prc2 = event2.getPrivateCollection();
+
+				expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
 				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug,id" );
 
-                // because we ignore the RC, the cache key should match
-                expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
-
+				// because we ignore the RC, the cache key should match
+				expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
 			} );
 
 			var formats = [ "json", "xml", "pdf" ];

--- a/tests/specs/integration/EventCaching.cfc
+++ b/tests/specs/integration/EventCaching.cfc
@@ -19,16 +19,162 @@
 
 				expect( prc.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "provider" );
 				expect( prc.cbox_eventCacheableEntry.provider ).toBe( "template" );
-				// debug( prc.cbox_eventCacheableEntry );
+				debug( prc.cbox_eventCacheableEntry );
 			} );
 
 
 			it( "can do cached events with custom provider annotations", function(){
-				var event = execute( event = "eventcaching.withProvider", renderResults = true );
+				var event = execute( 
+                    event = "eventcaching.withProvider", 
+                    renderResults = true 
+                );
 				var prc   = event.getPrivateCollection();
 
 				expect( prc.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "provider" );
 				expect( prc.cbox_eventCacheableEntry.provider ).toBe( "default" );
+			} );
+
+            it( "can handle different RC collections", function(){
+				
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching", 
+                    renderResults = true,
+                    queryString="id=1" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "*" );
+
+                // reset to simulate another request with a different rc scope
+                setup();
+
+                var event2 = execute( 
+                    event = "eventcaching", 
+                    renderResults = true,
+                    queryString="id=2" 
+                );
+				
+                var prc2 = event2.getPrivateCollection();
+
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "*" );
+
+                // because the default cache considers the rc scope, the cache keys should be different
+                expect( prc1.cbox_eventCacheableEntry.cacheKey ).notToBe( prc2.cbox_eventCacheableEntry.cacheKey );
+
+			} );
+
+            it( "can handle the cacheIncludeRcKeys metadata", function(){
+				
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withIncludeAllRcKeys", 
+                    renderResults = true,
+                    queryString="id=1" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "*" );
+
+			} );
+
+            it( "can ignore the rc scope", function(){
+				
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withIncludeNoRcKeys", 
+                    renderResults = true,
+                    queryString="id=1" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "" );
+
+                // reset to simulate another request
+                setup();
+
+                var event2 = execute( 
+                    event = "eventcaching.withIncludeNoRcKeys", 
+                    renderResults = true,
+                    queryString="id=2" 
+                );
+				
+                var prc2 = event2.getPrivateCollection();
+
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "" );
+
+                // because we ignore the RC, the cache key should match
+                expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
+
+			} );
+
+            it( "can isolate specific RC scope keys and ignore the rest", function(){
+				
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withIncludeOneRcKey", 
+                    renderResults = true,
+                    queryString="id=1&slug=foo" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug" );
+
+                // reset to simulate another request
+                setup();
+
+                var event2 = execute( 
+                    event = "eventcaching.withIncludeOneRcKey", 
+                    renderResults = true,
+                    queryString="id=2&slug=foo" 
+                );
+				
+                var prc2 = event2.getPrivateCollection();
+
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug" );
+
+                // because we ignore the RC, the cache key should match
+                expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
+
+			} );
+
+            it( "can handle a list of specific RC scope keys and ignore the rest", function(){
+				
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withIncludeRcKeyList", 
+                    renderResults = true,
+                    queryString="id=1&slug=foo&source=google" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug,id" );
+
+                // reset to simulate another request
+                setup();
+
+                var event2 = execute( 
+                    event = "eventcaching.withIncludeRcKeyList", 
+                    renderResults = true,
+                    queryString="id=1&slug=foo&source=bing" 
+                );
+				
+                var prc2 = event2.getPrivateCollection();
+
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug,id" );
+
+                // because we ignore the RC, the cache key should match
+                expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
+
 			} );
 
 			var formats = [ "json", "xml", "pdf" ];

--- a/tests/specs/ioc/InjectorCreationTest.cfc
+++ b/tests/specs/ioc/InjectorCreationTest.cfc
@@ -142,7 +142,7 @@
 	function testWebService() skip="isAdobe"{
 		ws = injector.getInstance( "coldboxWS" );
 
-		//
+		// 
 		if ( listFindNoCase( "Lucee", server.coldfusion.productname ) ) {
 			expect( getMetadata( ws ).name ).toMatch( "rpc" );
 		}

--- a/tests/specs/ioc/config/samples/NoScopeBinder.cfc
+++ b/tests/specs/ioc/config/samples/NoScopeBinder.cfc
@@ -5,7 +5,7 @@
  * The default ColdBox WireBox Injector configuration object that is used when the
  * WireBox injector is created
  **/
- component extends="coldbox.system.ioc.config.Binder" {
+component extends="coldbox.system.ioc.config.Binder" {
 
 	/**
 	 * Configure WireBox, that's it!

--- a/tests/specs/web/flash/AbstractFlashScopeTest.cfc
+++ b/tests/specs/web/flash/AbstractFlashScopeTest.cfc
@@ -8,8 +8,8 @@
 		mockController.getConfigSettings().identifierProvider = function(){
 			return createUUID();
 		};
-		mockRService   = createMock( className = "coldbox.system.web.services.RequestService", clearMethods = true );
-		mockEvent      = createMock( className = "coldbox.system.web.context.RequestContext", clearMethods = true );
+		mockRService = createMock( className = "coldbox.system.web.services.RequestService", clearMethods = true );
+		mockEvent    = createMock( className = "coldbox.system.web.context.RequestContext", clearMethods = true );
 
 		mockController
 			.$( "getRequestService", mockRService )

--- a/tests/specs/web/flash/ColdboxCacheFlashTest.cfc
+++ b/tests/specs/web/flash/ColdboxCacheFlashTest.cfc
@@ -9,11 +9,11 @@
 
 				// mocks
 				session.sessionid = createUUID();
-				mockController = createMock( "coldbox.system.web.Controller" ).init( expandPath( "/root" ) );
+				mockController    = createMock( "coldbox.system.web.Controller" ).init( expandPath( "/root" ) );
 				mockController.getConfigSettings().identifierProvider = function(){
 					return createUUID();
 				};
-				mockCache         = createMock(
+				mockCache = createMock(
 					className    = "coldbox.system.cache.providers.CacheBoxProvider",
 					clearMethods = true
 				);


### PR DESCRIPTION
This pull request is in response to [this discussion](https://community.ortussolutions.com/t/coldbox-6-4-event-caching-and-ignoring-rc-scope/8886) in the Coldbox community.

This new feature for Coldbox gives developers more flexibility with event caching and different RC scopes. The end result should be more efficient caching and improved page load speed for many users.

**The Problem:**
Currently, event caching considers the entire `RC` scope when generating a cache key.  This means that changing any URL or FORM variable on a request will force Coldbox to generate a new cache entry. This behavior is problematic for a few reasons:
1.  A malicious attacker could take advantage and create an unlimited number of cache entries for the same page simply by adding a random URL variable. 
2. Marketing efforts often require appending a unique tracking variable to a URL (e.g. `utm_source`).  In this type of scenario, there is no need to create a new cached event for every unique URL.

**The Solution**
I was inspired by Wirebox's populator include/exclude arguments which lets developers specify a list of keys to consider when populating an entity.   My idea was to create a new metadata property called `cacheIncludeRcKeys` which would allow specifying a list of `RC` keys to include when generating a cache key.  All keys not in the list are ignored.  To maintain backward compatibility, the default value for `cacheIncludeRcKeys` is `*` which considers all keys.

How Does it Work?
Simply include a new metadata attribute  `cacheIncludeRcKeys` to a handler and specify a list of `RC` keys you want to be included in the cache key generation process.  Here are some examples:

```
function show( event, rc, prc ) cache="true" cacheTimeout="10" cacheIncludeRcKeys="slug" {
  ...
}
```

The above code will ignore all `RC` keys except for `slug` when generating a cache key.  So, if you had a route `pages/:slug` resolve to `pages.show`, the following URLs would all utilize the same cache key:
https://mysite.com/pages/foo
https://mysite.com/pages/foo?utm_source=google
https://mysite.com/pages/foo?utm_source=bing

You can also include multiple `RC` keys by specifying a list in the metadata attribute like this:
```
function show( event, rc, prc ) cache="true" cacheTimeout="10" cacheIncludeRcKeys="slug,id" {
  ...
}
```

@lmajano I know you are probably busy with preparations for Into The Box so no need to rush on this one. I'll be attending the conference in person if you would like to chat about this PR.  Looking forward to catching up with you and the entire Ortus team. :)
