### PR TITLE
Make unloadAll() in ModuleService more resilient

### DIFF
--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -912,10 +912,13 @@ component extends="coldbox.system.web.services.BaseService" {
 	 * Unload all registered modules
 	 */
 	ModuleService function unloadAll(){
-		// Unload all modules
-		variables.registeredModules.each( function( key, module ){
-			unload( arguments.key );
-		} );
+		// If the registeredModules key exists, and isn't the default empty string
+		if( structKeyExists( variables, "registeredModules" ) && isStruct( variables.registeredModules ) ){
+			// Unload all modules
+			variables.registeredModules.each( function( key, module ){
+				unload( arguments.key );
+			} );
+		}
 		return this;
 	}
 

--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -913,7 +913,7 @@ component extends="coldbox.system.web.services.BaseService" {
 	 */
 	ModuleService function unloadAll(){
 		// If the registeredModules key exists, and isn't the default empty string
-		if( structKeyExists( variables, "registeredModules" ) && isStruct( variables.registeredModules ) ){
+		if ( structKeyExists( variables, "registeredModules" ) && isStruct( variables.registeredModules ) ) {
 			// Unload all modules
 			variables.registeredModules.each( function( key, module ){
 				unload( arguments.key );


### PR DESCRIPTION
Make unloadAll function more resilient of broken coldbox inits, with no registeredModules key, or if the key exists with default value of an empty string.
When running tests, with the app in a subfolder, on Adobe 2018, this would stop all my tests.
Possibly showing another issue, but this makes it more resilient regardless.

This change solved all of my test failures.