### PR TITLE
Fix Elixir Path for Apps in Subfolders

### DIFF
--- a/system/modules/HTMLHelper/models/HTMLHelper.cfc
+++ b/system/modules/HTMLHelper/models/HTMLHelper.cfc
@@ -2583,7 +2583,7 @@ component
 		}
 		if ( mapping.len() ) {
 			variables.cachedPaths[ argumentsHash ] = "/#mapping#" & manifestDirectory[ key ];
-		} else { 
+		} else {
 			variables.cachedPaths[ argumentsHash ] = manifestDirectory[ key ];
 		}
 		return variables.cachedPaths[ argumentsHash ]

--- a/system/modules/HTMLHelper/models/HTMLHelper.cfc
+++ b/system/modules/HTMLHelper/models/HTMLHelper.cfc
@@ -2552,7 +2552,7 @@ component
 
 		// Calculate href for asset delivery via Browser
 		var href = "/#includesLocation#/#arguments.fileName#";
-		var key = reReplace( href, "^//?", "" );
+		var key  = reReplace( href, "^//?", "" );
 		if ( mapping.len() ) {
 			var href = "/#mapping#/#includesLocation#/#arguments.fileName#";
 		}

--- a/system/modules/HTMLHelper/models/HTMLHelper.cfc
+++ b/system/modules/HTMLHelper/models/HTMLHelper.cfc
@@ -2581,8 +2581,12 @@ component
 			variables.cachedPaths[ argumentsHash ] = arguments.fileName;
 			return href;
 		}
-		variables.cachedPaths[ argumentsHash ] = manifestDirectory[ key ];
-		return "#manifestDirectory[ key ]#";
+		if ( mapping.len() ) {
+			variables.cachedPaths[ argumentsHash ] = "/#mapping#" & manifestDirectory[ key ];
+		} else { 
+			variables.cachedPaths[ argumentsHash ] = manifestDirectory[ key ];
+		}
+		return variables.cachedPaths[ argumentsHash ]
 	}
 
 	/**

--- a/system/modules/HTMLHelper/models/HTMLHelper.cfc
+++ b/system/modules/HTMLHelper/models/HTMLHelper.cfc
@@ -2551,12 +2551,11 @@ component
 		);
 
 		// Calculate href for asset delivery via Browser
+		var href = "/#includesLocation#/#arguments.fileName#";
+		var key = reReplace( href, "^//?", "" );
 		if ( mapping.len() ) {
 			var href = "/#mapping#/#includesLocation#/#arguments.fileName#";
-		} else {
-			var href = "/#includesLocation#/#arguments.fileName#";
 		}
-		var key = reReplace( href, "^//?", "" );
 
 		// Only read, parse and store once the manifest
 		if ( !variables.elixirManifests.keyExists( "elixirManifest-#hash( manifestPath )#" ) ) {


### PR DESCRIPTION
The KEY being generated was based off the href, which included the app mapping, which is incorrect.
Since my manifest file is from the root of the app, the app mapping would never be in the key, and therefore this was not working.

By making these changes, it works as it was previously for apps in the root, but now has a chance to work in apps in subfolders.


If i ask for 
css/app.css in /gavin/publications 
it was looking for the key /gavin/publications/includes/css/app.css in the manifest - but it was /includes/css/app.css
So it usually just spits out what i put in there, 

So i was trying to hack it with /includes/css/app.css but it was just giving it back to me because /gavin/publications/includes/includes/css/app.css doesn't exist, so it works in dev, but it would never give me the manifest path... so in prod it blows up.

But with these two fixes, it uses the right thing for the key, the right thing for the href, and it adds the app mapping if you need it for outputting... so now it works.