### PR TITLE
Simplify path info cleanup

### DIFF
--- a/system/web/services/RoutingService.cfc
+++ b/system/web/services/RoutingService.cfc
@@ -1099,8 +1099,12 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 			results[ "scriptName" ] = replaceNoCase( results[ "scriptName" ], getContextRoot(), "" );
 		}
 
-		// Clean up the from script name path_info 
-		results[ "pathInfo" ] = reReplaceNoCase( results[ "pathInfo" ], getCGIElement( "script_name", arguments.event ), "" );
+		// Clean up the from script name path_info
+		results[ "pathInfo" ] = reReplaceNoCase(
+			results[ "pathInfo" ],
+			getCGIElement( "script_name", arguments.event ),
+			""
+		);
 
 		// clean 1 or > / in front of route in some cases, scope = one by default
 		results[ "pathInfo" ] = reReplaceNoCase( results[ "pathInfo" ], "^/+", "/" );

--- a/system/web/services/RoutingService.cfc
+++ b/system/web/services/RoutingService.cfc
@@ -1099,17 +1099,8 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 			results[ "scriptName" ] = replaceNoCase( results[ "scriptName" ], getContextRoot(), "" );
 		}
 
-		// Clean up the path_info from index.cfm
-		results[ "pathInfo" ] = reReplaceNoCase( results[ "pathInfo" ], "^[/\\]index\.cfm", "" );
-
-		// Clean the scriptname from the pathinfo if it is the first item in case this is a nested application
-		if ( len( results[ "scriptName" ] ) ) {
-			results[ "pathInfo" ] = reReplaceNoCase(
-				results[ "pathInfo" ],
-				"^#results[ "scriptName" ]#\/",
-				""
-			);
-		}
+		// Clean up the from script name path_info 
+		results[ "pathInfo" ] = reReplaceNoCase( results[ "pathInfo" ], getCGIElement( "script_name", arguments.event ), "" );
 
 		// clean 1 or > / in front of route in some cases, scope = one by default
 		results[ "pathInfo" ] = reReplaceNoCase( results[ "pathInfo" ], "^/+", "/" );

--- a/tests/specs/logging/appenders/DBAppenderTest.cfc
+++ b/tests/specs/logging/appenders/DBAppenderTest.cfc
@@ -32,9 +32,9 @@
 
 	function testEnsureTable(){
 		// drop table
-		try{
+		try {
 			queryExecute( "drop table logs" );
-		}catch( any e ){
+		} catch ( any e ) {
 			// Ignore, maybe it doesn't exist
 		}
 


### PR DESCRIPTION
@lmajano Can you review this change?  I think it simplifies the two different checks you had plus it allows ColdBox to work with a file other than index.cfm.  For example, my ColdBox legacy app template uses a missing template handler to route missing files like /about.cfm to ColdBox and this code fails to remove the script name from the path info.  Note, the issue of the script name being inside the path info seems to be unique to IIS.  Other web servers don't do this.  

You had a check to remove just `/index.cfm` specifically
Then you had a check to generically remove the script name WITH a trailing slash like `/foo/something.cfm/`
And finally, you have a check to remove any remaining leading `/` slashes from the path info.

If we replace those first two checks with a generic replacement of the `cgi.script_name` then I think we'll get the same behavior, but simpler and it will work with non-index.cfm pages.