### PR TITLE
🐛 FIX: Correct trailing comma syntax error in Bootstrap.cfc

### DIFF
--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -52,7 +52,7 @@ component serializable="false" accessors="true" {
 		string COLDBOX_APP_KEY,
 		string COLDBOX_APP_MAPPING = "",
 		any COLDBOX_FAIL_FAST      = true,
-		string COLDBOX_WEB_MAPPING = "",
+		string COLDBOX_WEB_MAPPING = ""
 	){
 		variables.COLDBOX_CONFIG_FILE 	= arguments.COLDBOX_CONFIG_FILE;
 		variables.COLDBOX_APP_ROOT_PATH = arguments.COLDBOX_APP_ROOT_PATH;

--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -2,8 +2,9 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano <lmajano@ortussolutions.com>
  * Loads the framwork into memory and provides a ColdBox application.
+ *
+ * @author Luis Majano <lmajano@ortussolutions.com>
  */
 component serializable="false" accessors="true" {
 
@@ -54,11 +55,11 @@ component serializable="false" accessors="true" {
 		any COLDBOX_FAIL_FAST      = true,
 		string COLDBOX_WEB_MAPPING = ""
 	){
-		variables.COLDBOX_CONFIG_FILE 	= arguments.COLDBOX_CONFIG_FILE;
+		variables.COLDBOX_CONFIG_FILE   = arguments.COLDBOX_CONFIG_FILE;
 		variables.COLDBOX_APP_ROOT_PATH = arguments.COLDBOX_APP_ROOT_PATH;
-		variables.COLDBOX_APP_MAPPING 	= arguments.COLDBOX_APP_MAPPING;
-		variables.COLDBOX_WEB_MAPPING 	= arguments.COLDBOX_WEB_MAPPING;
-		variables.COLDBOX_FAIL_FAST 	= arguments.COLDBOX_FAIL_FAST;
+		variables.COLDBOX_APP_MAPPING   = arguments.COLDBOX_APP_MAPPING;
+		variables.COLDBOX_WEB_MAPPING   = arguments.COLDBOX_WEB_MAPPING;
+		variables.COLDBOX_FAIL_FAST     = arguments.COLDBOX_FAIL_FAST;
 
 		// App Key Check
 		if ( structKeyExists( arguments, "COLDBOX_APP_KEY" ) AND len( trim( arguments.COLDBOX_APP_KEY ) ) ) {
@@ -101,7 +102,13 @@ component serializable="false" accessors="true" {
 		// Create Brand New Controller
 		application[ appKey ] = new coldbox.system.web.Controller( COLDBOX_APP_ROOT_PATH, appKey );
 		// Setup the Framework And Application
-		application[ appKey ].getLoaderService().loadApplication( COLDBOX_CONFIG_FILE, COLDBOX_APP_MAPPING, COLDBOX_WEB_MAPPING );
+		application[ appKey ]
+			.getLoaderService()
+			.loadApplication(
+				COLDBOX_CONFIG_FILE,
+				COLDBOX_APP_MAPPING,
+				COLDBOX_WEB_MAPPING
+			);
 		// Get the reinit key
 		// Application Start Handler
 		try {
@@ -630,6 +637,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Process an exception and returns a rendered bug report
+	 *
 	 * @controller The ColdBox Controller
 	 * @exception  The ColdFusion exception
 	 */
@@ -708,6 +716,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Process render data setup
+	 *
 	 * @controller  The ColdBox controller
 	 * @statusCode  The status code to send
 	 * @statusText  The status text to send

--- a/system/EventHandler.cfc
+++ b/system/EventHandler.cfc
@@ -3,6 +3,7 @@
  * www.ortussolutions.com
  * ---
  * Base class for all event handlers
+ *
  * @author Luis Majano <lmajano@ortussolutions.com>
  */
 component
@@ -40,6 +41,7 @@ component
 
 	/**
 	 * Constructor
+	 *
 	 * @controller The ColdBox controller
 	 *
 	 * @return EventHandler
@@ -65,6 +67,7 @@ component
 
 	/**
 	 * Verifies if an action exists in the current event handler, public or private
+	 *
 	 * @action The action to verify that it exists and it is a function
 	 */
 	boolean function _actionExists( required action ){
@@ -81,6 +84,7 @@ component
 
 	/**
 	 * Return action metadata in the current event handler, public or private
+	 *
 	 * @action The action to get the metadata from
 	 */
 	struct function _actionMetadata( required action ){
@@ -89,6 +93,7 @@ component
 
 	/**
 	 * _privateInvoker for private events
+	 *
 	 * @method        The method to execute
 	 * @argCollection The arguments to execute the method with.
 	 */

--- a/system/FrameworkSupertype.cfc
+++ b/system/FrameworkSupertype.cfc
@@ -3,6 +3,7 @@
  * www.ortussolutions.com
  * ---
  * Base class for all things Box
+ *
  * @author Luis Majano <lmajano@ortussolutions.com>
  */
 component serializable="false" accessors="true" {
@@ -31,10 +32,10 @@ component serializable="false" accessors="true" {
 	 * @targetObject  The object requesting the dependency, usually only used by DSL lookups
 	 * @injector      The child injector to use when retrieving the instance
 	 *
+	 * @return The requested instance
+	 *
 	 * @throws InstanceNotFoundException - When the requested instance cannot be found
 	 * @throws InvalidChildInjector      - When you request an instance from an invalid child injector name
-	 *
-	 * @return The requested instance
 	 **/
 	function getInstance(
 		name,
@@ -139,8 +140,7 @@ component serializable="false" accessors="true" {
 	/**
 	 * Render out a view
 	 *
-	 * @deprecated Use view() instead
-	 *
+	 * @deprecated             Use view() instead
 	 * @view                   The the view to render, if not passed, then we look in the request context for the current set view.
 	 * @args                   A struct of arguments to pass into the view for rendering, will be available as 'args' in the view.
 	 * @module                 The module to render the view from explicitly
@@ -223,8 +223,7 @@ component serializable="false" accessors="true" {
 	/**
 	 * Renders an external view anywhere that cfinclude works.
 	 *
-	 * @deprecated Use `externalView()` instead
-	 *
+	 * @deprecated             Use `externalView()` instead
 	 * @view                   The the view to render
 	 * @args                   A struct of arguments to pass into the view for rendering, will be available as 'args' in the view.
 	 * @cache                  Cached the view output or not, defaults to false
@@ -275,8 +274,7 @@ component serializable="false" accessors="true" {
 	/**
 	 * Render a layout or a layout + view combo
 	 *
-	 * @deprecated Use `layout()` instead
-	 *
+	 * @deprecated    Use `layout()` instead
 	 * @layout        The layout to render out
 	 * @module        The module to explicitly render this layout from
 	 * @view          The view to render within this layout
@@ -403,9 +401,9 @@ component serializable="false" accessors="true" {
 	 * @name         The key of the setting
 	 * @defaultValue If not found in config, default return value
 	 *
-	 * @throws SettingNotFoundException
-	 *
 	 * @return The requested setting
+	 *
+	 * @throws SettingNotFoundException
 	 */
 	function getSetting( required name, defaultValue ){
 		return variables.controller.getSetting( argumentCollection = arguments );
@@ -417,9 +415,9 @@ component serializable="false" accessors="true" {
 	 * @name         The key to get
 	 * @defaultValue The default value if it doesn't exist
 	 *
-	 * @throws SettingNotFoundException
-	 *
 	 * @return The framework setting value
+	 *
+	 * @throws SettingNotFoundException
 	 */
 	function getColdBoxSetting( required name, defaultValue ){
 		return variables.controller.getColdBoxSetting( argumentCollection = arguments );
@@ -472,9 +470,9 @@ component serializable="false" accessors="true" {
 	 *
 	 * @module The module to retrieve the configuration structure from
 	 *
-	 * @throws InvalidModuleException - The module passed is invalid
-	 *
 	 * @return The struct requested
+	 *
+	 * @throws InvalidModuleException - The module passed is invalid
 	 */
 	struct function getModuleConfig( required module ){
 		var mConfig = variables.controller.getSetting( "modules" );
@@ -533,9 +531,9 @@ component serializable="false" accessors="true" {
 	 * @cacheProvider          The provider to cache this event rendering in, defaults to 'template'
 	 * @prePostExempt          If true, pre/post handlers will not be fired. Defaults to false
 	 *
-	 * @throws InvalidArgumentException
-	 *
 	 * @return null or anything produced from the route
+	 *
+	 * @throws InvalidArgumentException
 	 */
 	any function runRoute(
 		required name,
@@ -659,9 +657,9 @@ component serializable="false" accessors="true" {
 	 *
 	 * @udflibrary The UDF library to inject
 	 *
-	 * @throws UDFLibraryNotFoundException - When the requested library cannot be found
-	 *
 	 * @return FrameworkSuperType
+	 *
+	 * @throws UDFLibraryNotFoundException - When the requested library cannot be found
 	 */
 	any function includeUDF( required udflibrary ){
 		// Init the mixin location and caches reference

--- a/system/Interceptor.cfc
+++ b/system/Interceptor.cfc
@@ -77,8 +77,9 @@ component
 	 * @property     The property to retrieve
 	 * @defaultValue The default value to return if property does not exist
 	 *
-	 * @throws InvalidPropertyException
 	 * @return The property value requested or the default value if not found
+	 *
+	 * @throws InvalidPropertyException
 	 */
 	any function getProperty( required property, defaultValue ){
 		if ( structKeyExists( variables.properties, arguments.property ) ) {

--- a/system/RestHandler.cfc
+++ b/system/RestHandler.cfc
@@ -465,7 +465,7 @@ component extends="EventHandler" {
 	 * @rc    The rc reference
 	 * @prc   The prc reference
 	 *
-	 * @returns 404:Not Found
+	 * @return 404:Not Found
 	 */
 	function onInvalidRoute( event, rc, prc ){
 		arguments.event
@@ -514,7 +514,7 @@ component extends="EventHandler" {
 	 * @prc     The prc reference
 	 * @message The failure message sent in the request package
 	 *
-	 * @returns 417:Expectation Failed
+	 * @return 417:Expectation Failed
 	 */
 	function onExpectationFailed(
 		event   = getRequestContext(),

--- a/system/aop/Matcher.cfc
+++ b/system/aop/Matcher.cfc
@@ -93,6 +93,7 @@ component accessors="true" {
 
 	/**
 	 * Matches a class to this matcher according to its criteria
+	 *
 	 * @target              The target to match against to
 	 * @mapping             The target mapping to match against
 	 * @mapping.doc_generic coldbox.system.ioc.config.Mapping
@@ -114,6 +115,7 @@ component accessors="true" {
 
 	/**
 	 * Matches a method to this matcher according to its criteria
+	 *
 	 * @metadata The UDF metadata to use for matching
 	 */
 	boolean function matchMethod( required metadata ){
@@ -133,6 +135,7 @@ component accessors="true" {
 
 	/**
 	 * Go through all the rules in this matcher and match
+	 *
 	 * @metadata The UDF metadata to use for matching
 	 */
 	private boolean function matchMethodRules( required metadata ){
@@ -180,6 +183,7 @@ component accessors="true" {
 
 	/**
 	 * Go through all the rules in this matcher and match
+	 *
 	 * @target              The target to match against to
 	 * @mapping             The target mapping to match against
 	 * @mapping.doc_generic coldbox.system.ioc.config.Mapping
@@ -232,6 +236,7 @@ component accessors="true" {
 
 	/**
 	 * Match against return types in methods only
+	 *
 	 * @type The type of return to match against.  Only for method matching
 	 */
 	function returns( required type ){
@@ -241,6 +246,7 @@ component accessors="true" {
 
 	/**
 	 * Matches annotations on components or methods with or without a value
+	 *
 	 * @annotation The annotation to discover
 	 * @value      The value of the annotation that must match. OPTIONAL
 	 */
@@ -255,6 +261,7 @@ component accessors="true" {
 
 	/**
 	 * Match one, list or array of mapping names. Class Matching Only.
+	 *
 	 * @mappings One, list or array of mappings to match
 	 */
 	function mappings( required mappings ){
@@ -267,6 +274,7 @@ component accessors="true" {
 
 	/**
 	 * Matches against a family of components according to the passed classPath. Class Matching Only.
+	 *
 	 * @classPath The class path to verify instance of
 	 */
 	function instanceOf( required classPath ){
@@ -276,6 +284,7 @@ component accessors="true" {
 
 	/**
 	 * Matches a class path or method name to this regular expression
+	 *
 	 * @regex The regular expression to match against
 	 */
 	function regex( required regex ){
@@ -285,6 +294,7 @@ component accessors="true" {
 
 	/**
 	 * A list, one or an array of methods to explicitly match
+	 *
 	 * @methods One, list or array of methods to match
 	 */
 	function methods( required methods ){
@@ -297,6 +307,7 @@ component accessors="true" {
 
 	/**
 	 * AND this matcher with another matcher
+	 *
 	 * @matcher             The matcher to AND this matcher with
 	 * @matcher.doc_generic coldbox.system.aop.Matcher
 	 */
@@ -307,6 +318,7 @@ component accessors="true" {
 
 	/**
 	 * OR this matcher with another matcher
+	 *
 	 * @matcher             The matcher to AND this matcher with
 	 * @matcher.doc_generic coldbox.system.aop.Matcher
 	 */

--- a/system/aop/MethodInterceptor.cfc
+++ b/system/aop/MethodInterceptor.cfc
@@ -8,6 +8,7 @@ interface {
 
 	/**
 	 * Invoke an AOP method invocation
+	 *
 	 * @invocation             The invocation object
 	 * @invocation.doc_generic coldbox.system.aop.methodInvocation
 	 */

--- a/system/aop/MethodInvocation.cfc
+++ b/system/aop/MethodInvocation.cfc
@@ -50,6 +50,7 @@ component accessors="true" {
 
 	/**
 	 * Constructor
+	 *
 	 * @method                    The method name that was intercepted
 	 * @args                      The argument collection that was intercepted
 	 * @methodMetadata            The method metadata that was intercepted
@@ -92,6 +93,7 @@ component accessors="true" {
 
 	/**
 	 * Increment the interceptor index pointer
+	 *
 	 * @return MethodInvocation
 	 */
 	function incrementInterceptorIndex(){
@@ -101,6 +103,7 @@ component accessors="true" {
 
 	/**
 	 * Set args
+	 *
 	 * @return MethodInvocation
 	 */
 	function setArgs( required args ){

--- a/system/aop/Mixer.cfc
+++ b/system/aop/Mixer.cfc
@@ -49,7 +49,8 @@ component accessors="true" {
 
 	/**
 	 * Listener constructor
-	 * @injector
+	 *
+	 * @injector  
 	 * @properties
 	 */
 	function configure( required injector, required properties ){
@@ -127,10 +128,10 @@ component accessors="true" {
 
 	/**
 	 * Build an aspect dictionary for incoming target objects
+	 *
 	 * @target  The incoming target
 	 * @mapping The incoming target mapping
 	 * @idCode  The incoming target identifier
-	 *
 	 */
 	private function buildClassMatchDictionary(
 		required target,
@@ -182,11 +183,11 @@ component accessors="true" {
 
 	/**
 	 * Build and weave all necessary advices on an object via method matching
+	 *
 	 * @target     The incoming target
 	 * @mapping    The incoming target mapping
 	 * @dictionary The target aspect dictionary
 	 * @idCode     The incoming target identifier
-	 *
 	 */
 	private function AOPBuilder(
 		required target,
@@ -222,11 +223,11 @@ component accessors="true" {
 
 	/**
 	 * Process target methods for AOP weaving
+	 *
 	 * @target     The incoming target
 	 * @mapping    The incoming target mapping
 	 * @metadata   The incoming target metadata
 	 * @dictionary The target aspect dictionary
-	 *
 	 */
 	private function processTargetMethods(
 		required target,
@@ -291,12 +292,12 @@ component accessors="true" {
 
 	/**
 	 * Weave an advise into a jointpoint
+	 *
 	 * @target       The incoming target
 	 * @mapping      The incoming target mapping
 	 * @jointPoint   The jointpoint to proxy
 	 * @jointPointMD The jointpoint metadata to proxy
 	 * @aspects      The aspects to weave into the jointpoint
-	 *
 	 */
 	private function weaveAdvice(
 		required target,
@@ -415,8 +416,8 @@ component accessors="true" {
 
 	/**
 	 * Build out interceptors according to their aspect names
-	 * @aspects The aspects to construct
 	 *
+	 * @aspects The aspects to construct
 	 */
 	private array function buildInterceptors( required aspects ){
 		var interceptors = [];
@@ -431,9 +432,9 @@ component accessors="true" {
 
 	/**
 	 * Decorate a target with AOP capabilities
+	 *
 	 * @target  The incoming target
 	 * @mapping The incoming target mapping
-	 *
 	 */
 	private function decorateAOPTarget( required target, required mapping ){
 		// Create targets struct for method proxing

--- a/system/aop/MixerUtil.cfc
+++ b/system/aop/MixerUtil.cfc
@@ -17,6 +17,7 @@ component {
 
 	/**
 	 * Store JointPoint information
+	 *
 	 * @jointpoint   The jointpoint to proxy
 	 * @interceptors The jointpoint interceptors
 	 *
@@ -32,6 +33,7 @@ component {
 
 	/**
 	 * Invoke a mixed in proxy method
+	 *
 	 * @method The method to proxy execute
 	 * @args   The method args to proxy execute
 	 */
@@ -41,6 +43,7 @@ component {
 
 	/**
 	 * Mix in a template on an injected target
+	 *
 	 * @templatePath The template to mix in
 	 *
 	 * @return Instance
@@ -52,6 +55,7 @@ component {
 
 	/**
 	 * Remove a method from this target mixin
+	 *
 	 * @methodName The method to poof away!
 	 *
 	 * @return Instance
@@ -67,6 +71,7 @@ component {
 
 	/**
 	 * Write an aspect to disk
+	 *
 	 * @genPath The location path
 	 * @code    The code to write
 	 *
@@ -79,6 +84,7 @@ component {
 
 	/**
 	 * Remove an aspect from disk
+	 *
 	 * @filePath The location path
 	 *
 	 * @return Instance

--- a/system/aop/aspects/CFTransaction.cfc
+++ b/system/aop/aspects/CFTransaction.cfc
@@ -23,6 +23,7 @@ component
 
 	/**
 	 * Invoke an AOP method invocation
+	 *
 	 * @invocation             The invocation object
 	 * @invocation.doc_generic coldbox.system.aop.methodInvocation
 	 */

--- a/system/aop/aspects/MethodLogger.cfc
+++ b/system/aop/aspects/MethodLogger.cfc
@@ -19,6 +19,7 @@ component implements="coldbox.system.aop.MethodInterceptor" accessors="true" {
 
 	/**
 	 * Constructor
+	 *
 	 * @logResults Log results or not
 	 */
 	function init( boolean logResults = true ){
@@ -28,6 +29,7 @@ component implements="coldbox.system.aop.MethodInterceptor" accessors="true" {
 
 	/**
 	 * Invoke an AOP method invocation
+	 *
 	 * @invocation             The invocation object
 	 * @invocation.doc_generic coldbox.system.aop.methodInvocation
 	 */

--- a/system/async/AsyncManager.cfc
+++ b/system/async/AsyncManager.cfc
@@ -69,8 +69,7 @@ component accessors="true" singleton {
 	 * - cached : An unbounded pool where the number of threads will grow according to the tasks it needs to service. The threads are killed by a default 60 second timeout if not used and the pool shrinks back
 	 * - scheduled : A pool to use for scheduled tasks that can run one time or periodically
 	 *
-	 * @see https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html
-	 *
+	 * @see            https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html
 	 * @name           The name of the executor used for registration
 	 * @type           The type of executor to build fixed, cached, single, scheduled
 	 * @threads        How many threads to assign to the thread scheduler, default is 20
@@ -98,8 +97,8 @@ component accessors="true" singleton {
 
 	/**
 	 * Build a Java executor according to passed type and threads
-	 * @see https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html
 	 *
+	 * @see            https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html
 	 * @type           Available types are: fixed, cached, single, scheduled, {WireBoxID}
 	 * @threads        The number of threads to seed the executor with, if it allows it
 	 * @debug          Add output debugging
@@ -184,8 +183,9 @@ component accessors="true" singleton {
 	 *
 	 * @name The executor name
 	 *
-	 * @throws ExecutorNotFoundException
 	 * @return The executor object: coldbox.system.async.executors.Executor
+	 *
+	 * @throws ExecutorNotFoundException
 	 */
 	Executor function getExecutor( required name ){
 		if ( hasExecutor( arguments.name ) ) {

--- a/system/async/executors/Executor.cfc
+++ b/system/async/executors/Executor.cfc
@@ -107,9 +107,9 @@ component accessors="true" singleton {
 	 * @timeout  The maximum time to wait
 	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 *
-	 * @throws InterruptedException - if interrupted while waiting
-	 *
 	 * @return true if all tasks have completed following shut down
+	 *
+	 * @throws InterruptedException - if interrupted while waiting
 	 */
 	boolean function awaitTermination( required numeric timeout, timeUnit = "milliseconds" ){
 		return variables.native.awaitTermination(

--- a/system/async/executors/ExecutorBuilder.cfc
+++ b/system/async/executors/ExecutorBuilder.cfc
@@ -23,8 +23,7 @@ component singleton {
 	/**
 	 * Creates a thread pool that reuses a fixed number of threads operating off a shared unbounded queue.
 	 *
-	 * @see https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html
-	 *
+	 * @see     https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html
 	 * @threads The number of threads in the pool, defaults to 20
 	 *
 	 * @return ExecutorService: The newly created thread pool
@@ -49,8 +48,7 @@ component singleton {
 	 * Creates a thread pool that can schedule commands to run after a given delay,
 	 * or to execute periodically.
 	 *
-	 * @see https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ScheduledExecutorService.html
-	 *
+	 * @see          https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ScheduledExecutorService.html
 	 * @corePoolSize The number of threads to keep in the pool, even if they are idle, default is 20
 	 *
 	 * @return ScheduledExecutorService: The newly created thread pool

--- a/system/async/executors/ScheduledExecutor.cfc
+++ b/system/async/executors/ScheduledExecutor.cfc
@@ -32,9 +32,9 @@ component extends="Executor" accessors="true" singleton {
 	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 * @method   The default method to execute if the runnable is a CFC, defaults to `run()`
 	 *
-	 * @throws RejectedExecutionException - if the task cannot be scheduled for execution
-	 *
 	 * @return ScheduledFuture representing pending completion of the task and whose get() method will return null upon completion
+	 *
+	 * @throws RejectedExecutionException - if the task cannot be scheduled for execution
 	 */
 	ScheduledFuture function schedule(
 		required task,
@@ -81,10 +81,10 @@ component extends="Executor" accessors="true" singleton {
 	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 * @method   The default method to execute if the runnable is a CFC, defaults to `run()`
 	 *
+	 * @return a ScheduledFuture representing pending completion of the task, and whose get() method will throw an exception upon cancellation
+	 *
 	 * @throws RejectedExecutionException - if the task cannot be scheduled for execution
 	 * @throws IllegalArgumentException   - if period less than or equal to zero
-	 *
-	 * @return a ScheduledFuture representing pending completion of the task, and whose get() method will throw an exception upon cancellation
 	 */
 	ScheduledFuture function scheduleAtFixedRate(
 		required task,
@@ -120,10 +120,10 @@ component extends="Executor" accessors="true" singleton {
 	 * @timeUnit    The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 * @method      The default method to execute if the runnable is a CFC, defaults to `run()`
 	 *
+	 * @return a ScheduledFuture representing pending completion of the task, and whose get() method will throw an exception upon cancellation
+	 *
 	 * @throws RejectedExecutionException - if the task cannot be scheduled for execution
 	 * @throws IllegalArgumentException   - if spacedDelay less than or equal to zero
-	 *
-	 * @return a ScheduledFuture representing pending completion of the task, and whose get() method will throw an exception upon cancellation
 	 */
 	ScheduledFuture function scheduleWithFixedDelay(
 		required task,
@@ -152,9 +152,8 @@ component extends="Executor" accessors="true" singleton {
 	 * Build out a new scheduled task
 	 *
 	 * @deprecated DO NOT USE, use newTask() instead
-	 *
-	 * @task   The closure or cfc that represents the task
-	 * @method The method on the cfc to call, defaults to "run" (optional)
+	 * @task       The closure or cfc that represents the task
+	 * @method     The method on the cfc to call, defaults to "run" (optional)
 	 */
 	ScheduledTask function newSchedule( required task, method = "run" ){
 		return this.newTask( argumentCollection = arguments );

--- a/system/async/tasks/Future.cfc
+++ b/system/async/tasks/Future.cfc
@@ -91,7 +91,7 @@ component accessors="true" {
 	 * If not already completed, completes this Future with a CancellationException.
 	 * Dependent Futures that have not already completed will also complete exceptionally, with a CompletionException caused by this CancellationException.
 	 *
-	 * @returns true if this task is now cancelled
+	 * @return true if this task is now cancelled
 	 */
 	boolean function cancel( boolean mayInterruptIfRunning = true ){
 		return variables.native.cancel( javacast( "boolean", arguments.mayInterruptIfRunning ) );
@@ -160,7 +160,7 @@ component accessors="true" {
 	 *
 	 * @message An optional message to add to the exception to be thrown.
 	 *
-	 * @returns The same Future
+	 * @return The same Future
 	 */
 	Future function completeExceptionally( message = "Future operation completed with manual exception" ){
 		variables.native.completeExceptionally(
@@ -185,10 +185,10 @@ component accessors="true" {
 	 *
 	 * @defaultValue If the returned value is null, then we can pass a default value to return
 	 *
+	 * @return The result value
+	 *
 	 * @throws CompletionException   - if this future completed exceptionally or a completion computation threw an exception
 	 * @throws CancellationException - if the computation was cancelled
-	 *
-	 * @return The result value
 	 */
 	any function join( defaultValue ){
 		var results = variables.native.join();
@@ -210,8 +210,9 @@ component accessors="true" {
 	 * @timeUnit     The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 * @defaultValue If the Future did not produce a value, then it will return this default value.
 	 *
-	 * @returns The result value
-	 * @throws CancellationException, ExecutionException, InterruptedException, TimeoutException
+	 * @return The result value
+	 *
+	 * @throws CancellationException , ExecutionException, InterruptedException, TimeoutException
 	 */
 	any function get(
 		numeric timeout = 0,
@@ -255,9 +256,9 @@ component accessors="true" {
 	 *
 	 * @defaultValue The value to return if not completed
 	 *
-	 * @returns The result value, if completed, else the given defaultValue
+	 * @return The result value, if completed, else the given defaultValue
 	 *
-	 * @throws CancellationException, CompletionException
+	 * @throws CancellationException , CompletionException
 	 */
 	function getNow( required defaultValue ){
 		return variables.native.getNow( arguments.defaultValue );
@@ -812,8 +813,9 @@ component accessors="true" {
 	 * @timeout  The timeout to use when waiting for each item to be processed
 	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 *
-	 * @throws UnsupportedCollectionException - When something other than an array or struct is passed as items
 	 * @return An array or struct with the items processed in parallel
+	 *
+	 * @throws UnsupportedCollectionException - When something other than an array or struct is passed as items
 	 */
 	any function allApply( items, fn, executor, timeout, timeUnit ){
 		var incomingExecutor = arguments.executor ?: "";
@@ -911,7 +913,7 @@ component accessors="true" {
 	 * @timeout  The timeout value to use, defaults to forever
 	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 *
-	 * @returns This future
+	 * @return This future
 	 */
 	Future function withTimeout( numeric timeout = 0, string timeUnit = "milliseconds" ){
 		variables.futureTimeout = arguments;

--- a/system/async/tasks/FutureTask.cfc
+++ b/system/async/tasks/FutureTask.cfc
@@ -32,7 +32,7 @@ component accessors="true" {
 	 * If not already completed, completes this Future with a CancellationException.
 	 * Dependent Futures that have not already completed will also complete exceptionally, with a CompletionException caused by this CancellationException.
 	 *
-	 * @returns true if this task is now cancelled
+	 * @return true if this task is now cancelled
 	 */
 	boolean function cancel( boolean mayInterruptIfRunning = true ){
 		return variables.native.cancel( javacast( "boolean", arguments.mayInterruptIfRunning ) );
@@ -46,8 +46,9 @@ component accessors="true" {
 	 * @timeUnit     The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 * @defaultValue If the Future did not produce a value, then it will return this default value.
 	 *
-	 * @returns The result value
-	 * @throws CancellationException, ExecutionException, InterruptedException, TimeoutException
+	 * @return The result value
+	 *
+	 * @throws CancellationException , ExecutionException, InterruptedException, TimeoutException
 	 */
 	any function get(
 		numeric timeout = 0,

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -234,8 +234,7 @@ component accessors="true" {
 	/**
 	 * Set the timezone for this task using the task identifier else we default to our scheduler
 	 *
-	 * @see https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/ZoneId.html
-	 *
+	 * @see      https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/ZoneId.html
 	 * @timezone The timezone string identifier
 	 */
 	ScheduledTask function setTimezone( required timezone ){
@@ -580,7 +579,7 @@ component accessors="true" {
 	 * Calling this method prevents task frequencies to overlap.  By default all tasks are executed with an
 	 * interval but ccould potentially overlap if they take longer to execute than the period.
 	 *
-	 * @period
+	 * @period  
 	 * @timeUnit
 	 */
 	ScheduledTask function withNoOverlaps(){

--- a/system/async/tasks/Scheduler.cfc
+++ b/system/async/tasks/Scheduler.cfc
@@ -75,8 +75,7 @@ component accessors="true" singleton {
 	/**
 	 * Set the timezone for all tasks to use using the timezone string identifier
 	 *
-	 * @see https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/ZoneId.html
-	 *
+	 * @see      https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/ZoneId.html
 	 * @timezone The timezone string identifier
 	 */
 	Scheduler function setTimezone( required timezone ){
@@ -241,7 +240,6 @@ component accessors="true" singleton {
 	 *
 	 * @task      The task that got executed
 	 * @exception The ColdFusion exception object
-	 *
 	 */
 	function onAnyTaskError( required task, required exception ){
 	}
@@ -251,7 +249,6 @@ component accessors="true" singleton {
 	 *
 	 * @task   The task that got executed
 	 * @result The result (if any) that the task produced
-	 *
 	 */
 	function onAnyTaskSuccess( required task, result ){
 	}
@@ -260,7 +257,6 @@ component accessors="true" singleton {
 	 * Called before ANY task runs
 	 *
 	 * @task The task about to be executed
-	 *
 	 */
 	function beforeAnyTask( required task ){
 	}
@@ -270,7 +266,6 @@ component accessors="true" singleton {
 	 *
 	 * @task   The task that got executed
 	 * @result The result (if any) that the task produced
-	 *
 	 */
 	function afterAnyTask( required task, result ){
 	}
@@ -314,9 +309,9 @@ component accessors="true" singleton {
 	 *
 	 * @name The name of the task
 	 *
-	 * @throws UnregisteredTaskException if no task is found under that name
-	 *
 	 * @return The task record struct: { name, task, future, scheduledAt, registeredAt, error, errorMessage, stacktrace }
+	 *
+	 * @throws UnregisteredTaskException if no task is found under that name
 	 */
 	struct function getTaskRecord( required name ){
 		if ( hasTask( arguments.name ) ) {

--- a/system/async/time/ChronoUnit.cfc
+++ b/system/async/time/ChronoUnit.cfc
@@ -69,10 +69,10 @@ component singleton {
 	 * @target   The cf date/time or string object representing the date/time
 	 * @timezone If passed, we will use this timezone to build the temporal object. Else we default to UTC
 	 *
+	 * @return A Java temporal object as java.time.LocalDateTime
+	 *
 	 * @throws DateTimeException  - if the zone ID has an invalid format
 	 * @throws ZoneRulesException - if the zone ID is a region ID that cannot be found
-	 *
-	 * @return A Java temporal object as java.time.LocalDateTime
 	 */
 	function toLocalDateTime( required target, timezone ){
 		return this
@@ -91,10 +91,10 @@ component singleton {
 	 * @target   The cf date/time or string object representing the date/time
 	 * @timezone If passed, we will use this timezone to build the temporal object. Else we default to UTC
 	 *
+	 * @return A Java temporal object as java.time.LocalDate
+	 *
 	 * @throws DateTimeException  - if the zone ID has an invalid format
 	 * @throws ZoneRulesException - if the zone ID is a region ID that cannot be found
-	 *
-	 * @return A Java temporal object as java.time.LocalDate
 	 */
 	function toLocalDate( required target, timezone ){
 		return this
@@ -110,14 +110,13 @@ component singleton {
 	/**
 	 * Get the Java Zone ID of the passed in timezone identifier string
 	 *
-	 * @see https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/ZoneId.html
-	 *
+	 * @see      https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/ZoneId.html
 	 * @timezone The String timezone identifier
+	 *
+	 * @return Java Timezone java.time.ZoneId
 	 *
 	 * @throws DateTimeException  - if the zone ID has an invalid format
 	 * @throws ZoneRulesException - if the zone ID is a region ID that cannot be found
-	 *
-	 * @return Java Timezone java.time.ZoneId
 	 */
 	function getTimezone( required timezone ){
 		return this.ZoneId.of( javacast( "string", arguments.timezone ) );

--- a/system/async/time/Duration.cfc
+++ b/system/async/time/Duration.cfc
@@ -407,8 +407,7 @@ component accessors="true" {
 	 * "-PT6H3M"    -- parses as "-6 hours and -3 minutes"
 	 * "-PT-6H+3M"  -- parses as "+6 hours and -3 minutes"
 	 *
-	 * @see https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)
-	 *
+	 * @see  https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)
 	 * @text The string to parse and build up to a duration
 	 */
 	Duration function parse( required text ){

--- a/system/async/time/Period.cfc
+++ b/system/async/time/Period.cfc
@@ -313,8 +313,7 @@ component accessors="true" {
 	 * "P-1Y2M"          -- Period.of(-1, 2, 0)
 	 * "-P1Y2M"          -- Period.of(-1, -2, 0)
 	 *
-	 * @see https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Period.html#parse(java.lang.CharSequence)
-	 *
+	 * @see  https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Period.html#parse(java.lang.CharSequence)
 	 * @text The string to parse and build up to a period
 	 */
 	Period function parse( required text ){

--- a/system/cache/AbstractCacheBoxProvider.cfc
+++ b/system/cache/AbstractCacheBoxProvider.cfc
@@ -55,6 +55,7 @@ component accessors=true serializable=false {
 	property name="cacheId" default="";
 	/**
 	 * ColdBox Utility object
+	 *
 	 * @doc_generic coldbox.system.core.util.Util
 	 */
 	property name="utility";
@@ -257,7 +258,6 @@ component accessors=true serializable=false {
 	 *
 	 * @keys   The comma delimited list or an array of keys to lookup in the cache
 	 * @prefix A prefix to prepend to the keys with, if any
-	 *
 	 * @struct {key:boolean}
 	 */
 	struct function lookupMulti( required keys, prefix = "" ){
@@ -282,7 +282,6 @@ component accessors=true serializable=false {
 	 *
 	 * @keys   The comma delimited list or an array of keys to lookup in the cache
 	 * @prefix A prefix to prepend to the keys with, if any
-	 *
 	 * @struct {key:boolean}
 	 */
 	struct function getMulti( required keys, prefix = "" ){

--- a/system/cache/CacheFactory.cfc
+++ b/system/cache/CacheFactory.cfc
@@ -2,10 +2,11 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ----
- * @author Luis Majano
  *
  * The main CacheBox factory and configuration of caches. From this factory
  * is where you will get all the caches you need to work with or register more caches.
+ *
+ * @author Luis Majano
  **/
 component accessors=true serializable=false {
 
@@ -54,12 +55,14 @@ component accessors=true serializable=false {
 
 	/**
 	 * The Global AsyncManager
+	 *
 	 * @see coldbox.system.async.AsyncManager
 	 */
 	property name="asyncManager";
 
 	/**
 	 * The logBox task scheduler executor
+	 *
 	 * @see coldbox.system.async.executors.ScheduledExecutor
 	 */
 	property name="taskScheduler";
@@ -264,8 +267,9 @@ component accessors=true serializable=false {
 	 *
 	 * @name The cache name to get
 	 *
-	 * @throws CacheFactory.CacheNotFoundException
 	 * @return coldbox.system.cache.providers.ICacheProvider
+	 *
+	 * @throws CacheFactory.CacheNotFoundException
 	 */
 	function getCache( required name ){
 		lock name="#variables.lockName#" type="readonly" timeout="20" throwontimeout="true" {
@@ -294,9 +298,9 @@ component accessors=true serializable=false {
 	/**
 	 * Add a default named cache to our registry, create it, config it, register it and return it of type: coldbox.system.cache.providers.ICacheProvider
 	 *
-	 * @name The name of the default cache to create
-	 *
+	 * @name  The name of the default cache to create
 	 * @throw CacheFactory.InvalidNameException,CacheFactory.CacheExistsException
+	 *
 	 * @return coldbox.system.cache.providers.ICacheProvider
 	 */
 	function addDefaultCache( required name ){

--- a/system/cache/config/CacheBoxConfig.cfc
+++ b/system/cache/config/CacheBoxConfig.cfc
@@ -76,6 +76,7 @@ component accessors="true" {
 
 	/**
 	 * Set the logBox Configuration to use
+	 *
 	 * @config The configuration file to use
 	 */
 	CacheBoxConfig function logBoxConfig( required string config ){
@@ -199,10 +200,10 @@ component accessors="true" {
 
 	/**
 	 * Define the cachebox factory scope registration
+	 *
 	 * @enabled Enable registration
 	 * @scope   The scope to register on, defaults to application scope
 	 * @key     The key to use in the scope, defaults to cachebox
-
 	 */
 	function scopeRegistration(
 		boolean enabled = variables.DEFAULTS.scopeRegistration.enabled,

--- a/system/cache/policies/AbstractEvictionPolicy.cfc
+++ b/system/cache/policies/AbstractEvictionPolicy.cfc
@@ -24,6 +24,7 @@ component
 
 	/**
 	 * Constructor
+	 *
 	 * @cacheProvider             The associated cache provider
 	 * @cacheProvider.doc_generic coldbox.system.cache.providers.ICacheProvider
 	 */
@@ -103,6 +104,7 @@ component
 
 	/**
 	 * Get utility object
+	 *
 	 * @return coldbox.system.core.util.Util
 	 */
 	private function getUtil(){

--- a/system/cache/policies/LFU.cfc
+++ b/system/cache/policies/LFU.cfc
@@ -2,16 +2,18 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.coldbox.org | www.luismajano.com | www.ortussolutions.com
  * ----
- * @author  original: Luis Majano, cfscript: Ben Koshy
  * LFU Eviction Policy Command
  * Removes entities from the cache that are used the least.
  * More information can be found here:
  * http://en.wikipedia.org/wiki/Least_Frequently_Used
+ *
+ * @author original: Luis Majano, cfscript: Ben Koshy
  */
 component extends="coldbox.system.cache.policies.AbstractEvictionPolicy" {
 
 	/**
 	 * Constructor
+	 *
 	 * @cacheProvider The associated cache provider of type: coldbox.system.cache.providers.ICacheProvider" doc_generic="coldbox.system.cache.providers.ICacheProvider
 	 */
 	LFU function init( required any cacheProvider ){

--- a/system/cache/policies/LIFO.cfc
+++ b/system/cache/policies/LIFO.cfc
@@ -2,7 +2,6 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ----
- * @author  original: Luis Majano, cfscript: Francesco Pepe
  *
  * This is a LIFO eviction Policy meaning that the first object placed on cache
  * will be the last one to come out. This is usually a structure that represents
@@ -10,11 +9,14 @@
  *
  * More information can be found here:
  * http://en.wikipedia.org/wiki/FIFO
+ *
+ * @author original: Luis Majano, cfscript: Francesco Pepe
  */
 component extends="coldbox.system.cache.policies.AbstractEvictionPolicy" {
 
 	/**
 	 * This is the constructor
+	 *
 	 * @cacheProvider The associated cache provider of type: coldbox.system.cache.providers.ICacheProvider" doc_generic="coldbox.system.cache.providers.ICacheProvider
 	 */
 	LIFO function init( required any cacheProvider ){

--- a/system/cache/policies/LRU.cfc
+++ b/system/cache/policies/LRU.cfc
@@ -13,6 +13,7 @@ component extends="coldbox.system.cache.policies.AbstractEvictionPolicy" {
 
 	/**
 	 * This is the constructor
+	 *
 	 * @cacheProvider The associated cache provider of type: coldbox.system.cache.providers.ICacheProvider" doc_generic="coldbox.system.cache.providers.ICacheProvider
 	 */
 	LRU function init( required any cacheProvider ){

--- a/system/cache/providers/CFColdBoxProvider.cfc
+++ b/system/cache/providers/CFColdBoxProvider.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * This CacheBox provider communicates with the built in caches in the Adobe Engine for ColdBox Apps
+ *
+ * @author Luis Majano
  */
 component
 	accessors   ="true"

--- a/system/cache/providers/CFProvider.cfc
+++ b/system/cache/providers/CFProvider.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * This CacheBox provider communicates with the built in caches in the Adobe ColdFusion Engines
+ *
+ * @author Luis Majano
  */
 component
 	accessors   ="true"

--- a/system/cache/providers/CacheBoxColdBoxProvider.cfc
+++ b/system/cache/providers/CacheBoxColdBoxProvider.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * This CacheBox provider communicates with the built in CacheBox caches
+ *
+ * @author Luis Majano
  */
 component
 	accessors   ="true"

--- a/system/cache/providers/CacheBoxProvider.cfc
+++ b/system/cache/providers/CacheBoxProvider.cfc
@@ -2,7 +2,6 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * This CacheBox provider is our own enterprise cache implementation with many options and storage providers.
  *
@@ -15,6 +14,8 @@
  * - cacheFactory : The linkage to the cachebox factory
  * - eventManager : The linkage to the event manager
  * - cacheID : The unique identity code of this CFC
+ *
+ * @author Luis Majano
  */
 component
 	accessors   ="true"
@@ -35,18 +36,21 @@ component
 
 	/**
 	 * The eviction policy to use on the cache storage: Defaults to LRU
+	 *
 	 * @doc_generic coldbox.system.cache.policies.IEvictionPolicy
 	 */
 	property name="evictionPolicy";
 
 	/**
 	 * The object storage object
+	 *
 	 * @doc_generic coldbox.system.cache.store.IObjectStore
 	 */
 	property name="objectStore";
 
 	/**
 	 * The cache stats object
+	 *
 	 * @doc_generic coldbox.system.cache.util.CacheStats
 	 */
 	property name="stats";
@@ -634,8 +638,7 @@ component
 	 * Announce a key expiration
 	 *
 	 * @objectKey The key target
-	 *
-	 * @result CacheBoxProvider
+	 * @result    CacheBoxProvider
 	 */
 	private function announceExpiration( required objectKey ){
 		// Execute afterCacheElementExpired Interception

--- a/system/cache/providers/ICacheProvider.cfc
+++ b/system/cache/providers/ICacheProvider.cfc
@@ -2,10 +2,11 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * The main interface for a CacheBox cache provider.  You need to implement all the methods in order for CacheBox to work correctly for the implementing cache provider.
  * Many of the methods return itself, so they are documented in the <pre>@return</pre> annotation since interfaces are very janky in acf11 and 2016
+ *
+ * @author Luis Majano
  */
 interface {
 

--- a/system/cache/providers/IColdBoxProvider.cfc
+++ b/system/cache/providers/IColdBoxProvider.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * The main interface to produce a ColdBox Application cache.
+ *
+ * @author Luis Majano
  */
 interface extends="coldbox.system.cache.providers.ICacheProvider" {
 

--- a/system/cache/providers/LuceeColdboxProvider.cfc
+++ b/system/cache/providers/LuceeColdboxProvider.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * This CacheBox provider communicates with the built in caches in the Lucee Engine for ColdBox Apps
+ *
+ * @author Luis Majano
  */
 component
 	accessors   ="true"

--- a/system/cache/providers/LuceeProvider.cfc
+++ b/system/cache/providers/LuceeProvider.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * This CacheBox provider communicates with the built in caches in the Lucee Engine
+ *
+ * @author Luis Majano
  */
 component
 	accessors   ="true"

--- a/system/cache/providers/MockProvider.cfc
+++ b/system/cache/providers/MockProvider.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ----
- * @luis Majano
  *
  * A mock cache provider that keeps cache data in a simple map for testing and assertions
+ *
+ * @luis Majano
  **/
 component
 	accessors   =true

--- a/system/cache/report/ReportHandler.cfc
+++ b/system/cache/report/ReportHandler.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * The ColdBox CacheBox Report Handler
+ *
+ * @author Luis Majano
  */
 component accessors="true" serializable="false" {
 

--- a/system/cache/store/BlackHoleStore.cfc
+++ b/system/cache/store/BlackHoleStore.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * I am the fastest way to cache objects. I am so fast because I don't do anything. I'm really a tool to use when working on caching strategies. When I am in use nothing is cached. It just vanishes.
+ *
+ * @author Luis Majano
  */
 component implements="coldbox.system.cache.store.IObjectStore" accessors=true {
 

--- a/system/cache/store/ConcurrentSoftReferenceStore.cfc
+++ b/system/cache/store/ConcurrentSoftReferenceStore.cfc
@@ -2,10 +2,11 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * I am a concurrent soft reference object store. In other words, I am fancy!
  * This store is case-sensitive
+ *
+ * @author Luis Majano
  */
 component extends="coldbox.system.cache.store.ConcurrentStore" accessors=true {
 

--- a/system/cache/store/ConcurrentStore.cfc
+++ b/system/cache/store/ConcurrentStore.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * I am a concurrent object store. In other words, I am fancy! This store is case-sensitive
+ *
+ * @author Luis Majano
  */
 component implements="coldbox.system.cache.store.IObjectStore" accessors="true" {
 

--- a/system/cache/store/DiskStore.cfc
+++ b/system/cache/store/DiskStore.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * I am a disk store, I am not that fancy as I am slower.
+ *
+ * @author Luis Majano
  */
 component implements="coldbox.system.cache.store.IObjectStore" accessors="true" {
 

--- a/system/cache/store/IObjectStore.cfc
+++ b/system/cache/store/IObjectStore.cfc
@@ -2,10 +2,11 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * The main interface for CacheBox object storages.
  * A store is a physical counterpart to a cache, in which objects are kept, indexed and monitored.
+ *
+ * @author Luis Majano
  */
 interface {
 

--- a/system/cache/store/JDBCStore.cfc
+++ b/system/cache/store/JDBCStore.cfc
@@ -2,7 +2,6 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * I am a cool cool JDBC Store for CacheBox
  * You need to create the table first with the following columns
@@ -21,6 +20,8 @@
  * We also recommend indexes for: hits, created, lastAccessed, timeout and isExpired columns.
  *
  * Or look in the /coldbox/system/cache/store/sql/*.sql for you sql script for your DB.
+ *
+ * @author Luis Majano
  */
 component implements="coldbox.system.cache.store.IObjectStore" accessors="true" {
 

--- a/system/cache/store/indexers/JDBCMetadataIndexer.cfc
+++ b/system/cache/store/indexers/JDBCMetadataIndexer.cfc
@@ -2,10 +2,11 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * This is a utility object that helps object stores keep their elements indexed
  * and stored nicely.  It is also a nice way to give back metadata results.
+ *
+ * @author Luis Majano
  */
 component extends="coldbox.system.cache.store.indexers.MetadataIndexer" accessors="true" {
 
@@ -190,8 +191,8 @@ component extends="coldbox.system.cache.store.indexers.MetadataIndexer" accessor
 	 * Get an array of sorted keys for this indexer according to parameters
 	 *
 	 * @objectKey
-	 * @property
-	 * @value
+	 * @property 
+	 * @value    
 	 */
 	array function getSortedKeys(
 		required property,

--- a/system/cache/store/indexers/MetadataIndexer.cfc
+++ b/system/cache/store/indexers/MetadataIndexer.cfc
@@ -2,10 +2,11 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * This is a utility object that helps object stores keep their elements indexed and stored nicely.
  * It is also a nice way to give back metadata results.
+ *
+ * @author Luis Majano
  */
 component accessors="true" {
 
@@ -28,7 +29,6 @@ component accessors="true" {
 	 * Constructor
 	 *
 	 * @fields The list or array of fields to bind this index on
-	 *
 	 */
 	function init( required fields ){
 		// Create metadata pool
@@ -169,8 +169,8 @@ component accessors="true" {
 	 * Get an array of sorted keys for this indexer according to parameters
 	 *
 	 * @objectKey
-	 * @property
-	 * @value
+	 * @property 
+	 * @value    
 	 */
 	array function getSortedKeys(
 		required property,

--- a/system/cache/util/CacheStats.cfc
+++ b/system/cache/util/CacheStats.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * This is a cache statistics object.  We do not use internal method calls but leverage the properties directly so it is faster.
+ *
+ * @author Luis Majano
  */
 component implements="coldbox.system.cache.util.IStats" accessors="true" {
 

--- a/system/cache/util/ElementCleaner.cfc
+++ b/system/cache/util/ElementCleaner.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * A ColdBox utility to help clean cached objects for ColdBox Application Caches
+ *
+ * @author Luis Majano
  */
 component accessors="true" serializable="false" {
 

--- a/system/cache/util/EventURLFacade.cfc
+++ b/system/cache/util/EventURLFacade.cfc
@@ -130,6 +130,7 @@ component accessors="true" {
 
 	/**
 	 * Builds a basic cache key without the hash component
+	 *
 	 * @keySuffix   The key suffix used
 	 * @targetEvent The targeted ColdBox event string
 	 */

--- a/system/cache/util/IStats.cfc
+++ b/system/cache/util/IStats.cfc
@@ -2,9 +2,10 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano
  *
  * The main interface for a CacheBox cache provider statistics object
+ *
+ * @author Luis Majano
  */
 interface {
 

--- a/system/core/collections/ScopeStorage.cfc
+++ b/system/core/collections/ScopeStorage.cfc
@@ -18,6 +18,7 @@ component {
 
 	/**
 	 * Store a value in a scope
+	 *
 	 * @key   The key
 	 * @value The value
 	 * @scope The ColdFusion Scope
@@ -30,6 +31,7 @@ component {
 
 	/**
 	 * Delete a value in a scope
+	 *
 	 * @key   The key
 	 * @scope The ColdFusion Scope
 	 */
@@ -43,6 +45,7 @@ component {
 
 	/**
 	 * Get a value in a scope
+	 *
 	 * @key          The key
 	 * @scope        The CF Scope
 	 * @defaultValue The default value
@@ -67,6 +70,7 @@ component {
 
 	/**
 	 * Check if a key exists
+	 *
 	 * @key   The key
 	 * @scope The CF Scope
 	 */
@@ -76,6 +80,7 @@ component {
 
 	/**
 	 * Get a scope reference
+	 *
 	 * @scope The CF Scope
 	 */
 	any function getScope( required scope ){
@@ -136,6 +141,7 @@ component {
 
 	/**
 	 * Check if a scope is valid, else throws exception
+	 *
 	 * @scope The CF Scope
 	 */
 	any function scopeCheck( required scope ){

--- a/system/core/conversion/DataMarshaller.cfc
+++ b/system/core/conversion/DataMarshaller.cfc
@@ -31,8 +31,9 @@ component accessors="true" singleton {
 	 * @xmlRootName      XML Only: The name of the initial root element of the XML packet
 	 * @pdfArgs          All the PDF arguments to pass along to the CFDocument tag.
 	 *
+	 * @return Marshalled content according to type and arguments
+	 *
 	 * @throws InvalidMarshallingType - When an invalid rendering type is detected
-	 * @returns Marshalled content according to type and arguments
 	 */
 	function marshallData(
 		required type,

--- a/system/core/conversion/ObjectMarshaller.cfc
+++ b/system/core/conversion/ObjectMarshaller.cfc
@@ -52,6 +52,7 @@ component accessors="true" {
 
 	/**
 	 * Serialize via objectSave()
+	 *
 	 * @target The complex object, such as a query or CFC, that will be serialized.
 	 */
 	function serializeWithObjectSave( any target ){

--- a/system/core/events/EventPool.cfc
+++ b/system/core/events/EventPool.cfc
@@ -108,7 +108,6 @@ component accessors="true" {
 	 *
 	 * @target The target object
 	 * @data   The data used in the interception call
-	 *
 	 */
 	private function invoker( required target, required data ){
 		var results = invoke(

--- a/system/core/events/EventPoolManager.cfc
+++ b/system/core/events/EventPoolManager.cfc
@@ -131,7 +131,7 @@ component accessors="true" {
 	/**
 	 * Get an object from the pool
 	 *
-	 * @name  The name of the object
+	 * @name The name of the object
 	 *
 	 * @throws EventPoolManager.ObjectNotFound
 	 */
@@ -154,7 +154,7 @@ component accessors="true" {
 	 *
 	 * @customStates A comma delimited list or array of custom interception states to append. If they already exists, then they will not be added again.
 	 *
-	 * @return  The current interception points
+	 * @return The current interception points
 	 */
 	array function appendInterceptionPoints( required customStates ){
 		// Inflate custom points

--- a/system/ioc/Builder.cfc
+++ b/system/ioc/Builder.cfc
@@ -476,10 +476,10 @@ component serializable="false" accessors="true" {
 	 * @targetID     The target ID we are building this dependency for
 	 * @targetObject The target object we are building the DSL dependency for
 	 *
+	 * @return The requested object or null if not found and not required
+	 *
 	 * @throws IllegalDSLException            - When requesting a ColdBox/CacheBox DSL dependency and the library is not linked
 	 * @throws DSLDependencyNotFoundException - If the requested object is not found and it is required
-	 *
-	 * @return The requested object or null if not found and not required
 	 */
 	function buildDSLDependency(
 		required definition,

--- a/system/ioc/Injector.cfc
+++ b/system/ioc/Injector.cfc
@@ -101,12 +101,14 @@ component
 
 	/**
 	 * The Global AsyncManager
+	 *
 	 * @see coldbox.system.async.AsyncManager
 	 */
 	property name="asyncManager";
 
 	/**
 	 * The logBox task scheduler executor
+	 *
 	 * @see coldbox.system.async.executors.ScheduledExecutor
 	 */
 	property name="taskScheduler";
@@ -422,10 +424,10 @@ component
 	 * @targetObject  The object requesting the dependency, usually only used by DSL lookups
 	 * @injector      The child injector to use when retrieving the instance
 	 *
+	 * @return The requested instance
+	 *
 	 * @throws InstanceNotFoundException - When the requested instance cannot be found
 	 * @throws InvalidChildInjector      - When you request an instance from an invalid child injector name
-	 *
-	 * @return The requested instance
 	 **/
 	function getInstance(
 		name,
@@ -939,6 +941,7 @@ component
 
 	/**
 	 * Get a registered scope in this injector by name
+	 *
 	 * @scope The scope name
 	 */
 	function getScope( required any scope ){
@@ -1048,6 +1051,7 @@ component
 
 	/**
 	 * Process after DI completion routines
+	 *
 	 * @targetObject      The target object to do some goodness on
 	 * @DICompleteMethods The array of DI completion methods to call
 	 */

--- a/system/ioc/config/Binder.cfc
+++ b/system/ioc/config/Binder.cfc
@@ -249,9 +249,9 @@ component accessors="true" {
 	 * @name         The name of the property to get
 	 * @defaultValue The default value if property is not found
 	 *
-	 * @throws PropertyNotFoundException - If the property is not found and no default sent
-	 *
 	 * @return Property value
+	 *
+	 * @throws PropertyNotFoundException - If the property is not found and no default sent
 	 */
 	function getProperty( required name, defaultValue ){
 		// Prop Check
@@ -325,8 +325,9 @@ component accessors="true" {
 	 *
 	 * @name The name of the mapping
 	 *
-	 * @throws MappingNotFoundException - If the named mapping has not been registered
 	 * @return coldbox.system.ioc.config.Mapping
+	 *
+	 * @throws MappingNotFoundException - If the named mapping has not been registered
 	 */
 	Mapping function getMapping( required name ){
 		if ( structKeyExists( variables.mappings, arguments.name ) ) {

--- a/system/ioc/scopes/CFScopes.cfc
+++ b/system/ioc/scopes/CFScopes.cfc
@@ -24,7 +24,6 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true" {
 	/**
 	 * Configure the scope for operation and returns itself
 	 *
-	 *
 	 * @injector             The linked WireBox injector
 	 * @injector.doc_generic coldbox.system.ioc.Injector
 	 *
@@ -39,7 +38,6 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true" {
 
 	/**
 	 * Retrieve an object from scope or create it if not found in scope
-	 *
 	 *
 	 * @mapping             The linked WireBox injector
 	 * @mapping.doc_generic coldbox.system.ioc.config.Mapping

--- a/system/ioc/scopes/CacheBox.cfc
+++ b/system/ioc/scopes/CacheBox.cfc
@@ -24,7 +24,6 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true" {
 	/**
 	 * Configure the scope for operation and returns itself
 	 *
-	 *
 	 * @injector             The linked WireBox injector
 	 * @injector.doc_generic coldbox.system.ioc.Injector
 	 *
@@ -39,7 +38,6 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true" {
 
 	/**
 	 * Retrieve an object from scope or create it if not found in scope
-	 *
 	 *
 	 * @mapping             The linked WireBox injector
 	 * @mapping.doc_generic coldbox.system.ioc.config.Mapping

--- a/system/ioc/scopes/IScope.cfc
+++ b/system/ioc/scopes/IScope.cfc
@@ -9,7 +9,6 @@ interface {
 	/**
 	 * Configure the scope for operation and returns itself
 	 *
-	 *
 	 * @injector             The linked WireBox injector
 	 * @injector.doc_generic coldbox.system.ioc.Injector
 	 *
@@ -19,7 +18,6 @@ interface {
 
 	/**
 	 * Retrieve an object from scope or create it if not found in scope
-	 *
 	 *
 	 * @mapping             The linked WireBox injector
 	 * @mapping.doc_generic coldbox.system.ioc.config.Mapping

--- a/system/ioc/scopes/NoScope.cfc
+++ b/system/ioc/scopes/NoScope.cfc
@@ -19,7 +19,6 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true" {
 	/**
 	 * Configure the scope for operation and returns itself
 	 *
-	 *
 	 * @injector             The linked WireBox injector
 	 * @injector.doc_generic coldbox.system.ioc.Injector
 	 *
@@ -33,7 +32,6 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true" {
 
 	/**
 	 * Retrieve an object from scope or create it if not found in scope
-	 *
 	 *
 	 * @mapping             The linked WireBox injector
 	 * @mapping.doc_generic coldbox.system.ioc.config.Mapping

--- a/system/ioc/scopes/RequestScope.cfc
+++ b/system/ioc/scopes/RequestScope.cfc
@@ -19,7 +19,6 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true" {
 	/**
 	 * Configure the scope for operation and returns itself
 	 *
-	 *
 	 * @injector             The linked WireBox injector
 	 * @injector.doc_generic coldbox.system.ioc.Injector
 	 *
@@ -33,7 +32,6 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true" {
 
 	/**
 	 * Retrieve an object from scope or create it if not found in scope
-	 *
 	 *
 	 * @mapping             The linked WireBox injector
 	 * @mapping.doc_generic coldbox.system.ioc.config.Mapping

--- a/system/ioc/scopes/Singleton.cfc
+++ b/system/ioc/scopes/Singleton.cfc
@@ -24,7 +24,6 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true" {
 	/**
 	 * Configure the scope for operation and returns itself
 	 *
-	 *
 	 * @injector             The linked WireBox injector
 	 * @injector.doc_generic coldbox.system.ioc.Injector
 	 *
@@ -39,7 +38,6 @@ component implements="coldbox.system.ioc.scopes.IScope" accessors="true" {
 
 	/**
 	 * Retrieve an object from scope or create it if not found in scope
-	 *
 	 *
 	 * @mapping             The linked WireBox injector
 	 * @mapping.doc_generic coldbox.system.ioc.config.Mapping

--- a/system/logging/LogBox.cfc
+++ b/system/logging/LogBox.cfc
@@ -53,12 +53,14 @@ component accessors="true" {
 
 	/**
 	 * The Global AsyncManager
+	 *
 	 * @see coldbox.system.async.AsyncManager
 	 */
 	property name="asyncManager";
 
 	/**
 	 * The logBox task scheduler executor
+	 *
 	 * @see coldbox.system.async.executors.ScheduledExecutor
 	 */
 	property name="taskScheduler";

--- a/system/logging/LogLevels.cfc
+++ b/system/logging/LogLevels.cfc
@@ -3,6 +3,7 @@
  * www.ortussolutions.com
  * ---
  * The different logging levels available in LogBox. Log levels available in the this scope: OFF=-1, FATAL=0, ERROR=1, WARN=2, INFO=3, DEBUG=4
+ *
  * @author Luis Majano <lmajano@ortussolutions.com>
  */
 component {

--- a/system/logging/appenders/SocketAppender.cfc
+++ b/system/logging/appenders/SocketAppender.cfc
@@ -31,7 +31,7 @@ component accessors="true" extends="coldbox.system.logging.AbstractAppender" {
 	 * @levelMin   The default log level for this appender, by default it is 0. Optional. ex: LogBox.logLevels.WARN
 	 * @levelMax   The default log level for this appender, by default it is 5. Optional. ex: LogBox.logLevels.WARN
 	 *
-	 * @throws SocketAppender.HostNotFound,SocketAppender.PortNotFound
+	 * @throws SocketAppender.HostNotFound ,SocketAppender.PortNotFound
 	 */
 	function init(
 		required name,

--- a/system/modules/HTMLHelper/models/HTMLHelper.cfc
+++ b/system/modules/HTMLHelper/models/HTMLHelper.cfc
@@ -148,6 +148,7 @@ component
 
 	/**
 	 * Generate line breaks
+	 *
 	 * @count The number
 	 */
 	function br( numeric count = 1 ){
@@ -156,6 +157,7 @@ component
 
 	/**
 	 * Generate non-breaking spaces
+	 *
 	 * @count The number
 	 */
 	function nbs( numeric count = 1 ){
@@ -164,6 +166,7 @@ component
 
 	/**
 	 * Generate headers
+	 *
 	 * @content The content
 	 * @size    The size
 	 */
@@ -173,6 +176,7 @@ component
 
 	/**
 	 * Generate tags
+	 *
 	 * @tag      The tag to generate
 	 * @content  The content
 	 * @data     The data-{key} elements to add
@@ -222,6 +226,7 @@ component
 
 	/**
 	 * Generate anchors
+	 *
 	 * @name The name of the anchor
 	 * @text The text of the link
 	 * @data The data-{key} elements to add
@@ -546,6 +551,7 @@ component
 
 	/**
 	 * Slugify a string for URL Safety
+	 *
 	 * @str       Target to slugify
 	 * @maxLength The maximum number of characters for the slug
 	 * @allow     a regex safe list of additional characters to allow
@@ -581,6 +587,7 @@ component
 
 	/**
 	 * Creates auto discovery links for RSS and ATOM feeds.
+	 *
 	 * @type  Type of feed: RSS or ATOM or Custom Type
 	 * @href  Te href link to discover
 	 * @rel   The rel attribute
@@ -2921,7 +2928,6 @@ component
 	 * @tag    The tag to wrap with
 	 * @end    Start or end of tag
 	 * @attrs  The attributes of the tag
-	 *
 	 */
 	private function wrapTag(
 		required buffer,
@@ -2950,6 +2956,7 @@ component
 
 	/**
 	 * Make pretty text
+	 *
 	 * @text Target
 	 */
 	private string function makePretty( required text ){
@@ -2962,6 +2969,7 @@ component
 
 	/**
 	 * Prepare a base link
+	 *
 	 * @noBaseURL Indicator for building
 	 * @src       The source target
 	 */

--- a/system/remote/ColdboxProxy.cfc
+++ b/system/remote/ColdboxProxy.cfc
@@ -29,9 +29,9 @@ component serializable="false" accessors="true" {
 	/**
 	 * Process a remote call into ColdBox's event model and return data/objects back.
 	 *
-	 * @throws NoEventDetected - When no passed even is incoming via arguments[ "event" ]
-	 *
 	 * @return If no results where found, this method returns null/void
+	 *
+	 * @throws NoEventDetected - When no passed even is incoming via arguments[ "event" ]
 	 */
 	private any function process(){
 		var refLocal = {};
@@ -252,10 +252,10 @@ component serializable="false" accessors="true" {
 	 * @targetObject  The object requesting the dependency, usually only used by DSL lookups
 	 * @injector      The child injector to use when retrieving the instance
 	 *
+	 * @return The requested instance
+	 *
 	 * @throws InstanceNotFoundException - When the requested instance cannot be found
 	 * @throws InvalidChildInjector      - When you request an instance from an invalid child injector name
-	 *
-	 * @return The requested instance
 	 **/
 	private function getInstance(
 		name,

--- a/system/remote/RemotingUtil.cfc
+++ b/system/remote/RemotingUtil.cfc
@@ -2,8 +2,9 @@
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * @author Luis Majano <lmajano@ortussolutions.com>
  * Remoting Utility
+ *
+ * @author Luis Majano <lmajano@ortussolutions.com>
  */
 component {
 

--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -52,6 +52,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 
 	/**
 	 * Inspect test case for annotations
+	 *
 	 * @return BaseTestCase
 	 */
 	function metadataInspection(){
@@ -242,6 +243,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 
 	/**
 	 * I will return a mock controller object
+	 *
 	 * @return coldbox.system.testing.mock.web.MockController
 	 */
 	function getMockController(){
@@ -250,6 +252,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 
 	/**
 	 * Builds an empty functioning request context mocked with methods via MockBox.  You can also optionally wipe all methods on it
+	 *
 	 * @clearMethods Clear methods on the object
 	 * @decorator    The class path to the decorator to build into the mock request context
 	 *
@@ -297,6 +300,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 
 	/**
 	 * ColdBox must be loaded for this to work. Get a mock model object by convention. You can optional clear all the methods on the model object if you wanted to. The object is created but not initiated, that would be your job.
+	 *
 	 * @name         The name of the model to mock and return back
 	 * @clearMethods Clear methods on the object
 	 */
@@ -317,6 +321,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 
 	/**
 	 * Get the WireBox reference from the running application
+	 *
 	 * @return coldbox.system.ioc.Injector
 	 */
 	function getWireBox(){
@@ -325,6 +330,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 
 	/**
 	 * Get the CacheBox reference from the running application
+	 *
 	 * @return coldbox.system.cache.CacheFactory
 	 */
 	function getCacheBox(){
@@ -333,6 +339,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 
 	/**
 	 * Get the CacheBox reference from the running application
+	 *
 	 * @cacheName The cache name to retrieve or returns the 'default' cache by default.
 	 *
 	 * @return coldbox.system.cache.providers.ICacheProvider
@@ -343,6 +350,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 
 	/**
 	 * Get the LogBox reference from the running application
+	 *
 	 * @return coldbox.system.logging.LogBox
 	 */
 	function getLogBox(){
@@ -373,6 +381,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 
 	/**
 	 * Setup an initial request capture.  I basically look at the FORM/URL scopes and create the request collection out of them.
+	 *
 	 * @event The event to setup the request context with, simulates the URL/FORM.event
 	 *
 	 * @return BaseTestCase
@@ -401,7 +410,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 	 * @withExceptionHandling If true, then ColdBox will process any errors through the exception handling framework instead of just throwing the error. Default: false.
 	 * @domain                Override the domain of execution of the request. Default is to use the cgi.server_name variable.
 	 *
-	 * @return                coldbox.system.context.RequestContext
+	 * @return coldbox.system.context.RequestContext
 	 */
 	function execute(
 		string event                  = "",
@@ -866,10 +875,10 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 	 * @targetObject  The object requesting the dependency, usually only used by DSL lookups
 	 * @injector      The child injector to use when retrieving the instance
 	 *
+	 * @return The requested instance
+	 *
 	 * @throws InstanceNotFoundException - When the requested instance cannot be found
 	 * @throws InvalidChildInjector      - When you request an instance from an invalid child injector name
-	 *
-	 * @return The requested instance
 	 **/
 	function getInstance(
 		name,
@@ -883,6 +892,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 
 	/**
 	 * Get the ColdBox global utility class
+	 *
 	 * @return coldbox.system.core.util.Util
 	 */
 	function getUtil(){
@@ -931,6 +941,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 
 	/**
 	 * Process an exception and returns a rendered bug report
+	 *
 	 * @controller The ColdBox Controller
 	 * @exception  The ColdFusion exception
 	 */

--- a/system/testing/mock/web/context/MockRequestContext.cfc
+++ b/system/testing/mock/web/context/MockRequestContext.cfc
@@ -12,13 +12,14 @@ component
 
 	/**
 	 * Set an HTTP Header
+	 *
+	 * return RequestContext
+	 *
 	 * @statusCode.hint the status code
 	 * @statusText.hint the status text
 	 * @name.hint       The header name
 	 * @value.hint      The header value
 	 * @charset.hint    The charset to use, defaults to UTF-8
-	 *
-	 * return RequestContext
 	 */
 	function setHTTPHeader( statusCode, statusText = "", name, value = "" ){
 		// status code?

--- a/system/web/Controller.cfc
+++ b/system/web/Controller.cfc
@@ -259,9 +259,9 @@ component serializable="false" accessors="true" {
 	 * @name         The name of the setting
 	 * @defaultValue The default value to use if setting does not exist
 	 *
-	 * @throws SettingNotFoundException
-	 *
 	 * @return The application setting value
+	 *
+	 * @throws SettingNotFoundException
 	 */
 	function getSetting( required name, defaultValue ){
 		if ( variables.configSettings.keyExists( arguments.name ) ) {
@@ -286,9 +286,9 @@ component serializable="false" accessors="true" {
 	 * @name         The key to get
 	 * @defaultValue The default value if it doesn't exist
 	 *
-	 * @throws SettingNotFoundException
-	 *
 	 * @return The framework setting value
+	 *
+	 * @throws SettingNotFoundException
 	 */
 	function getColdBoxSetting( required name, defaultValue ){
 		if ( variables.coldboxSettings.keyExists( arguments.name ) ) {
@@ -715,9 +715,9 @@ component serializable="false" accessors="true" {
 	 * @defaultEvent   The flag that let's this service now if it is the default event running or not. USED BY THE FRAMEWORK ONLY
 	 * @eventArguments A collection of arguments to passthrough to the calling event handler method
 	 *
-	 * @throws InvalidHTTPMethod
-	 *
 	 * @return struct { data:event handler returned data (null), ehBean:event handler bean representation that was fired }
+	 *
+	 * @throws InvalidHTTPMethod
 	 */
 	private function _runEvent(
 		event                 = "",
@@ -1056,6 +1056,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Locate the real path location of a file in a coldbox application. 3 checks: 1) inside of coldbox app, 2) expand the path, 3) Absolute location. If path not found, it returns an empty path
+	 *
 	 * @pathToCheck The relative or absolute file path to verify and locate
 	 */
 	function locateFilePath( required pathToCheck ){
@@ -1080,6 +1081,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Locate the real path location of a directory in a coldbox application. 3 checks: 1) inside of coldbox app, 2) expand the path, 3) Absolute location. If path not found, it returns an empty path
+	 *
 	 * @pathToCheck The relative or absolute directory path to verify and locate
 	 */
 	function locateDirectoryPath( required pathToCheck ){
@@ -1130,6 +1132,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Internal helper to flash persist elements
+	 *
 	 * @return Controller
 	 */
 	private function persistVariables( persist = "", struct persistStruct = {} ){
@@ -1150,6 +1153,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Checks if an action can be executed according to inclusion/exclusion lists
+	 *
 	 * @action    The action to validate
 	 * @inclusion The list of inclusions
 	 * @exclusion The list of exclusions

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -3,6 +3,7 @@
  * www.ortussolutions.com
  * ---
  * The system web renderer
+ *
  * @author Luis Majano <lmajano@ortussolutions.com>
  */
 component
@@ -483,6 +484,7 @@ component
 
 	/**
 	 * Renders an external view anywhere that cfinclude works.
+	 *
 	 * @view                   The the view to render
 	 * @args                   A struct of arguments to pass into the view for rendering, will be available as 'args' in the view.
 	 * @cache                  Cached the view output or not, defaults to false
@@ -699,6 +701,7 @@ component
 
 	/**
 	 * Locate a layout in the conventions system
+	 *
 	 * @layout The layout name
 	 */
 	function locateLayout( required layout ){
@@ -727,6 +730,7 @@ component
 
 	/**
 	 * Locate a layout in the conventions system
+	 *
 	 * @layout         The layout name
 	 * @module         The name of the module we are searching for
 	 * @explicitModule Are we locating explicitly or implicitly for a module layout
@@ -789,6 +793,7 @@ component
 
 	/**
 	 * Locate a view in the conventions or external paths
+	 *
 	 * @view The view to locate
 	 */
 	function locateView( required view ){
@@ -806,6 +811,7 @@ component
 
 	/**
 	 * Locate a view in the conventions system
+	 *
 	 * @view           The view name
 	 * @module         The name of the module we are searching for
 	 * @explicitModule Are we locating explicitly or implicitly for a module layout

--- a/system/web/context/ExceptionBean.cfc
+++ b/system/web/context/ExceptionBean.cfc
@@ -25,6 +25,7 @@ component accessors="true" {
 
 	/**
 	 * Constructor
+	 *
 	 * @errorStruct  The CFML error structure
 	 * @extraMessage Custom error messages
 	 * @extraInfo    Extra info to store in the error
@@ -59,6 +60,7 @@ component accessors="true" {
 
 	/**
 	 * Set Memento
+	 *
 	 * @memento The mento to set
 	 */
 	ExceptionBean function setMemento( required memento ){

--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -277,6 +277,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * I Get a reference or deep copy of the public or private request Collection
+	 *
 	 * @deepCopy Default is false, gives a reference to the collection. True, creates a deep copy of the collection.
 	 * @private  Use public or private request collection
 	 */
@@ -297,6 +298,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * I get a private collection
+	 *
 	 * @deepCopy Default is false, gives a reference to the collection. True, creates a deep copy of the collection.
 	 * @private  Use public or private request collection
 	 */
@@ -307,6 +309,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Clears the entire collection
+	 *
 	 * @private Use public or private request collection
 	 */
 	function clearCollection( boolean private = false ){
@@ -327,6 +330,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Append a structure to the collection, with overwrite or not. Overwrite = false by default
+	 *
 	 * @collection The collection to incorporate
 	 * @overwrite  Overwrite elements, defaults to false
 	 * @private    Private or public, defaults public.
@@ -354,6 +358,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Append a structure to the collection, with overwrite or not. Overwrite = false by default
+	 *
 	 * @collection The collection to incorporate
 	 * @overwrite  Overwrite elements, defaults to false
 	 */
@@ -364,6 +369,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Get the collection Size
+	 *
 	 * @private Private or public, defaults public.
 	 */
 	numeric function getSize( boolean private = false ){
@@ -384,6 +390,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Get a value from the public or private request collection.
+	 *
 	 * @name         The key name
 	 * @defaultValue default value
 	 * @private      Private or public, defaults public.
@@ -419,6 +426,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Get a value from the private request collection.
+	 *
 	 * @name         The key name
 	 * @defaultValue default value
 	 */
@@ -429,6 +437,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Get a value from the request collection and if simple value, I will trim it.
+	 *
 	 * @name         The key name
 	 * @defaultValue default value
 	 * @private      Private or public, defaults public.
@@ -450,6 +459,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Get a trim value from the private request collection.
+	 *
 	 * @name         The key name
 	 * @defaultValue default value
 	 */
@@ -460,6 +470,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Set a value in the request collection
+	 *
 	 * @name    The key name
 	 * @value   The value
 	 * @private Private or public, defaults public.
@@ -482,6 +493,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Set a value in the private request collection
+	 *
 	 * @name  The key name
 	 * @value The value
 	 *
@@ -494,6 +506,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * remove a value in the request collection
+	 *
 	 * @name    The key name
 	 * @private Private or public, defaults public.
 	 *
@@ -512,6 +525,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * remove a value in the private request collection
+	 *
 	 * @name The key name
 	 *
 	 * @return RequestContext
@@ -523,6 +537,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Check if a value exists in the request collection
+	 *
 	 * @name    The key name
 	 * @private Private or public, defaults public.
 	 */
@@ -536,6 +551,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Check if a value exists in the private request collection
+	 *
 	 * @name The key name
 	 */
 	boolean function privateValueExists( required name ){
@@ -545,6 +561,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Just like cfparam, but for the request collection
+	 *
 	 * @name    The key name
 	 * @value   The value
 	 * @private Private or public, defaults public.
@@ -568,6 +585,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Just like cfparam, but for the private request collection
+	 *
 	 * @name  The key name
 	 * @value The value
 	 *
@@ -674,7 +692,7 @@ component serializable="false" accessors="true" {
 	 * @path  The path to match in the currently routed URL.
 	 * @exact Flag to do an exact match instead of a partial match
 	 *
-	 * @return  Boolean
+	 * @return Boolean
 	 */
 	boolean function urlMatches( required string path, boolean exact = false ){
 		var currentRoutedURL = getCurrentRoutedURL();
@@ -693,9 +711,9 @@ component serializable="false" accessors="true" {
 	/**
 	 * Tests that a given path matches exactly to the currently routed URL.
 	 *
-	 * @path    The path to match exactly to the currently routed URL.
+	 * @path The path to match exactly to the currently routed URL.
 	 *
-	 * @return  Boolean
+	 * @return Boolean
 	 */
 	boolean function urlMatchesExact( required string path ){
 		arguments.exact = true;
@@ -817,6 +835,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Set the view to render in this request. Private Request Collection Name: currentView, currentLayout
+	 *
 	 * @view                   The name of the view to set. If a layout has been defined it will assign it, else if will assign the default layout. No extension please
 	 * @args                   An optional set of arguments that will be available when the view is rendered
 	 * @layout                 You can override the rendering layout of this setView() call if you want to. Else it defaults to implicit resolution or another override.
@@ -930,6 +949,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Mark this request to not use a layout for rendering
+	 *
 	 * @return RequestContext
 	 */
 	function noLayout(){
@@ -942,6 +962,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Set the layout to override and render. Layouts are pre-defined in the config file. However I can override these settings if needed. Do not append a the cfm extension. Private Request Collection name
+	 *
 	 * @name   The name of the layout to set
 	 * @module The module to use
 	 */
@@ -962,6 +983,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Override the default layout for a request
+	 *
 	 * @return RequestContext
 	 */
 	function setDefaultLayout( required defaultLayout ){
@@ -971,6 +993,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Override the default view for a request
+	 *
 	 * @return RequestContext
 	 */
 	function setDefaultView( required defaultView ){
@@ -982,6 +1005,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Override the current event in the request collection. This method does not execute the event, it just replaces the event to be executed by the framework's RunEvent() method. This method is usually called from an onRequestStart or onApplicationStart method
+	 *
 	 * @event The event to override with
 	 *
 	 * @return RequestContext
@@ -993,6 +1017,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Set that this is a proxy request
+	 *
 	 * @return RequestContext
 	 */
 	function setProxyRequest(){
@@ -1008,6 +1033,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Set the flag that tells the framework not to render, just execute
+	 *
 	 * @remove Remove the flag completely
 	 *
 	 * @return RequestContext
@@ -1066,6 +1092,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Set the ses base URL for this request
+	 *
 	 * @return RequestContext
 	 */
 	function setSESBaseURL( required string sesBaseURL ){
@@ -1284,6 +1311,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Check wether the incoming event has been flagged for caching
+	 *
 	 * @cacheEntry The md entry for caching
 	 *
 	 * @return RequestContext
@@ -1301,6 +1329,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Check wether the incoming event has been flagged for caching
+	 *
 	 * @return RequestContext
 	 */
 	function removeEventCacheableEntry(){
@@ -1316,6 +1345,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Set the view cacheable entry
+	 *
 	 * @cacheEntry The md entry for caching
 	 *
 	 * @return RequestContext
@@ -1349,6 +1379,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Get the routed structure of key-value pairs. What the ses interceptor could match.
+	 *
 	 * @return RequestContext
 	 */
 	function setRoutedStruct( required struct routedStruct ){
@@ -1450,6 +1481,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Use this method to tell the framework to render data for you. The framework will take care of marshalling the data for you
+	 *
 	 * @type             The type of data to render. Valid types are JSON, JSONP, JSONT, XML, WDDX, PLAIN/HTML, TEXT, PDF. The default is HTML or PLAIN. If an invalid type is sent in, this method will throw an error
 	 * @data             The data you would like to marshall and return by the framework
 	 * @contentType      The content type of the data. This will be used in the cfcontent tag: text/html, text/plain, text/xml, text/json, etc. The default value is text/html. However, if you choose JSON this method will choose application/json, if you choose WDDX or XML this method will choose text/xml for you.
@@ -1708,6 +1740,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Filters the collection or private collection down to only the provided keys.
+	 *
 	 * @keys    A list or array of keys to bring back from the collection or private collection.
 	 * @private Private or public, defaults public request collection
 	 */
@@ -1730,6 +1763,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Filters the private collection down to only the provided keys.
+	 *
 	 * @keys A list or array of keys to bring back from the private collection.
 	 */
 	struct function getPrivateOnly( required keys ){
@@ -1738,6 +1772,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Filters the collection or private collection down to all keys except the provided keys.
+	 *
 	 * @keys    A list or array of keys to exclude from the results of the collection or private collection.
 	 * @private Private or public, defaults public request collection
 	 */
@@ -1760,6 +1795,7 @@ component serializable="false" accessors="true" {
 
 	/**
 	 * Filters the private collection down to all keys except the provided keys.
+	 *
 	 * @keys A list or array of keys to exclude from the results of the private collection.
 	 */
 	struct function getPrivateExcept( required keys ){
@@ -1834,6 +1870,7 @@ component serializable="false" accessors="true" {
 	/**
 	 * Get's the file mime type for a given file extension, this is mostly used for file delivery.
 	 * If not in the most common, we deliver as a binary octet-stream.
+	 *
 	 * @extension The extension to assume.
 	 */
 	private function getFileMimeType( required string extension ){

--- a/system/web/flash/AbstractFlashScope.cfc
+++ b/system/web/flash/AbstractFlashScope.cfc
@@ -12,6 +12,7 @@
  *
  * All these methds can use any of the concrete methods below. The most important one is the getScope()
  * method which will most likely be called by the saveFlash() method in order to persist the flashed map.
+ *
  * @author Luis Majano <lmajano@ortussolutions.com>
  */
 component accessors="true" {
@@ -33,6 +34,7 @@ component accessors="true" {
 
 	/**
 	 * Constructor
+	 *
 	 * @controller ColdBox Controller
 	 * @defaults   Default flash data packet for the flash RAM object=[scope,properties,inflateToRC,inflateToPRC,autoPurge,autoSave]
 	 */
@@ -65,6 +67,7 @@ component accessors="true" {
 
 	/**
 	 * Save the flash storage in preparing to go to the next request
+	 *
 	 * @return SessionFlash
 	 */
 	function saveFlash(){

--- a/system/web/flash/ClientFlash.cfc
+++ b/system/web/flash/ClientFlash.cfc
@@ -4,6 +4,7 @@
  * ---
  * This flash scope is smart enought to not create unnecessary client variables
  * unless data is put in it.  Else, it does not abuse session.
+ *
  * @author Luis Majano <lmajano@ortussolutions.com>
  */
 component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true" {
@@ -13,6 +14,7 @@ component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true"
 
 	/**
 	 * Constructor
+	 *
 	 * @controller.hint ColdBox Controller
 	 * @defaults.hint   Default flash data packet for the flash RAM object=[scope,properties,inflateToRC,inflateToPRC,autoPurge,autoSave]
 	 */
@@ -27,6 +29,7 @@ component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true"
 
 	/**
 	 * Save the flash storage in preparing to go to the next request
+	 *
 	 * @return ClientFlash
 	 */
 	function saveFlash(){
@@ -55,6 +58,7 @@ component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true"
 
 	/**
 	 * Remove the entire flash storage
+	 *
 	 * @return ClientFlash
 	 */
 	function removeFlash(){

--- a/system/web/flash/ColdboxCacheFlash.cfc
+++ b/system/web/flash/ColdboxCacheFlash.cfc
@@ -3,6 +3,7 @@
  * www.ortussolutions.com
  * ---
  * This flash uses CacheBox
+ *
  * @author Luis Majano <lmajano@ortussolutions.com>
  */
 component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true" {
@@ -14,6 +15,7 @@ component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true"
 
 	/**
 	 * Constructor
+	 *
 	 * @controller.hint ColdBox Controller
 	 * @defaults.hint   Default flash data packet for the flash RAM object=[scope,properties,inflateToRC,inflateToPRC,autoPurge,autoSave]
 	 */
@@ -45,6 +47,7 @@ component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true"
 
 	/**
 	 * Save the flash storage in preparing to go to the next request
+	 *
 	 * @return SessionFlash
 	 */
 	function saveFlash(){
@@ -70,6 +73,7 @@ component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true"
 
 	/**
 	 * Remove the entire flash storage
+	 *
 	 * @return SessionFlash
 	 */
 	function removeFlash(){

--- a/system/web/flash/MockFlash.cfc
+++ b/system/web/flash/MockFlash.cfc
@@ -3,6 +3,7 @@
  * www.ortussolutions.com
  * ---
  * A flash scope that is used for unit testing.
+ *
  * @author Luis Majano <lmajano@ortussolutions.com>
  */
 component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true" {
@@ -12,6 +13,7 @@ component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true"
 
 	/**
 	 * Constructor
+	 *
 	 * @controller.hint ColdBox Controller
 	 * @defaults.hint   Default flash data packet for the flash RAM object=[scope,properties,inflateToRC,inflateToPRC,autoPurge,autoSave]
 	 */
@@ -25,6 +27,7 @@ component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true"
 
 	/**
 	 * Save the flash storage in preparing to go to the next request
+	 *
 	 * @return MockFlash
 	 */
 	function saveFlash(){
@@ -48,6 +51,7 @@ component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true"
 
 	/**
 	 * Remove the entire flash storage
+	 *
 	 * @return MockFlash
 	 */
 	function removeFlash(){

--- a/system/web/flash/SessionFlash.cfc
+++ b/system/web/flash/SessionFlash.cfc
@@ -4,6 +4,7 @@
  * ---
  * This flash scope is smart enough to not create unnecessary session variables
  * unless data is put in it.  Else, it does not abuse session.
+ *
  * @author Luis Majano <lmajano@ortussolutions.com>
  */
 component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true" {
@@ -13,6 +14,7 @@ component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true"
 
 	/**
 	 * Constructor
+	 *
 	 * @controller.hint ColdBox Controller
 	 * @defaults.hint   Default flash data packet for the flash RAM object=[scope,properties,inflateToRC,inflateToPRC,autoPurge,autoSave]
 	 */
@@ -26,6 +28,7 @@ component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true"
 
 	/**
 	 * Save the flash storage in preparing to go to the next request
+	 *
 	 * @return SessionFlash
 	 */
 	function saveFlash(){
@@ -71,6 +74,7 @@ component extends="coldbox.system.web.flash.AbstractFlashScope" accessors="true"
 
 	/**
 	 * Remove the entire flash storage
+	 *
 	 * @return SessionFlash
 	 */
 	function removeFlash(){

--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -223,6 +223,7 @@ component
 
 	/**
 	 * Verifies if an extension is valid in the Router
+	 *
 	 * @extension The extension to validate
 	 */
 	boolean function isValidExtension( required extension ){
@@ -230,8 +231,9 @@ component
 	}
 
 	/**
-	 * @deprecated Please use `getModuleRoutingTable()` instead.
 	 * A quick ColdBox4 compatibility wrapper
+	 *
+	 * @deprecated Please use `getModuleRoutingTable()` instead.
 	 */
 	struct function getModulesRoutingTable(){
 		return getModuleRoutingTable();
@@ -241,11 +243,11 @@ component
 	// DEPRECATED FUNCTIONALITY: Remove in later release
 
 	/**
-	 * @deprecated Please use the Routes.cfc approach instead
 	 *
 	 * Includes a routes configuration file as an added import and returns itself after import
 	 *
-	 * @location The include location of the routes configuration template. Do not add '.cfm'
+	 * @deprecated Please use the Routes.cfc approach instead
+	 * @location   The include location of the routes configuration template. Do not add '.cfm'
 	 *
 	 * @return Router
 	 */
@@ -314,6 +316,7 @@ component
 
 	/**
 	 * Register modules routes in the specified position in the main routing table, and returns itself
+	 *
 	 * @pattern The pattern to match against the URL
 	 * @module  The module to load routes for
 	 * @append  Whether the module entry point route should be appended or pre-pended to the main routes array. By default we append to the end of the array
@@ -380,6 +383,7 @@ component
 
 	/**
 	 * Remove a module's routing table and registration points and return itself
+	 *
 	 * @module The module to remove
 	 *
 	 * @return Router
@@ -397,6 +401,7 @@ component
 
 	/**
 	 * Get a module's routes array
+	 *
 	 * @module The module to get
 	 */
 	array function getModuleRoutes( required module ){
@@ -412,6 +417,7 @@ component
 
 	/**
 	 * Register a namespace in the specified position in the main routing table, and returns itself
+	 *
 	 * @pattern   The pattern to match against the URL.
 	 * @namespace The name of the namespace to register
 	 * @append    Whether the route should be appended or pre-pended to the array. By default we append to the end of the array
@@ -440,6 +446,7 @@ component
 
 	/**
 	 * Get a namespace routes array
+	 *
 	 * @namespace The namespace to get
 	 */
 	array function getNamespaceRoutes( required namespace ){
@@ -456,6 +463,7 @@ component
 
 	/**
 	 * Remove a namespace's routing table and registration points and return itself
+	 *
 	 * @namespace The namespace to remove
 	 *
 	 * @return Router
@@ -477,10 +485,10 @@ component
 	/****************************************************************************************************************************/
 
 	/**
-	 * @deprecated This has been deprecated in favor of the <code>group()</code> function.
 	 *
 	 * Starts a with closure, where all arguments will be prefixed for the next concatenated addRoute() methods until an endWith() is called
 	 *
+	 * @deprecated            This has been deprecated in favor of the <code>group()</code> function.
 	 * @pattern               The pattern to match against the URL.
 	 * @handler               The handler to execute if pattern matched.
 	 * @action                The action in a handler to execute if a pattern is matched.  This can also be a structure based on the HTTP method(GET,POST,PUT,DELETE). ex: {GET:'show', PUT:'update', DELETE:'delete', POST:'save'}
@@ -524,9 +532,10 @@ component
 	}
 
 	/**
-	 * @deprecated This has been deprecated in favor of the <code>group()</code> function.
 	 *
 	 * End a with closure and returns itself
+	 *
+	 * @deprecated This has been deprecated in favor of the <code>group()</code> function.
 	 *
 	 * @return Router
 	 */
@@ -2028,6 +2037,7 @@ component
 
 	/**
 	 * Get the correct route actions based on only and except lists
+	 *
 	 * @initial The initial set of route actions
 	 * @only    Limit actions with only
 	 * @except  Exclude actions with except

--- a/system/web/services/HandlerService.cfc
+++ b/system/web/services/HandlerService.cfc
@@ -420,9 +420,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 * @event  The event that was found to be invalid
 	 * @ehBean The event handler bean representing the invalid event
 	 *
-	 * @throws EventHandlerNotRegisteredException,InvalidEventHandlerException
-	 *
 	 * @return The string event that should be executed as the invalid event handler or throws an EventHandlerNotRegisteredException
+	 *
+	 * @throws EventHandlerNotRegisteredException ,InvalidEventHandlerException
 	 */
 	string function invalidEvent( required string event, required ehBean ){
 		// Announce it
@@ -509,9 +509,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	/**
 	 * Register's application event handlers according to convention and external paths
 	 *
-	 * @throws HandlersDirectoryNotFoundException
-	 *
 	 * @return HandlerService
+	 *
+	 * @throws HandlersDirectoryNotFoundException
 	 */
 	function registerHandlers(){
 		var handlersPath                 = controller.getSetting( "handlersPath" );

--- a/system/web/services/InterceptorService.cfc
+++ b/system/web/services/InterceptorService.cfc
@@ -166,8 +166,8 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 * Announce an interception to the system. If you use the asynchronous facilities, you will get a thread structure report as a result.
 	 *
 	 * This is needed so interceptors can write to the page output buffer
-	 * @output true
 	 *
+	 * @output           true
 	 * @state            An interception state to process
 	 * @data             A data structure used to pass intercepted information.
 	 * @async            If true, the entire interception chain will be ran in a separate thread.
@@ -432,7 +432,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 *
 	 * @customPoints A comma delimited list or array of custom interception points to append. If they already exists, then they will not be added again.
 	 *
-	 * @return  The current interception points
+	 * @return The current interception points
 	 */
 	array function appendInterceptionPoints( required customPoints ){
 		// Inflate custom points
@@ -464,6 +464,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 
 	/**
 	 * Unregister an interceptor from an interception state or all states. If the state does not exists, it returns false
+	 *
 	 * @interceptorName The interceptor to unregister
 	 * @state           The state to unregister from, if not, passed, then from all states
 	 */

--- a/system/web/services/LoaderService.cfc
+++ b/system/web/services/LoaderService.cfc
@@ -26,13 +26,19 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 *
 	 * @return The LoaderService
 	 */
-	LoaderService function loadApplication( overrideConfigFile = "", overrideAppMapping = "", overrideWebMapping="" ){
+	LoaderService function loadApplication(
+		overrideConfigFile = "",
+		overrideAppMapping = "",
+		overrideWebMapping = ""
+	){
 		var coldBoxSettings = variables.controller.getColdBoxSettings();
 		var services        = variables.controller.getServices();
 
 		// Load application configuration file
-		createAppLoader( arguments.overrideConfigFile )
-			.loadConfiguration( arguments.overrideAppMapping, arguments.overrideWebMapping );
+		createAppLoader( arguments.overrideConfigFile ).loadConfiguration(
+			arguments.overrideAppMapping,
+			arguments.overrideWebMapping
+		);
 
 		// Do we need to create a controller decorator?
 		if ( len( variables.controller.getSetting( "ControllerDecorator" ) ) ) {

--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -149,6 +149,7 @@ component extends="coldbox.system.web.services.BaseService" {
 
 	/**
 	 * Register and activate a new module
+	 *
 	 * @moduleName     The name of the module to load.
 	 * @invocationPath The module's invocation path to its root from the webroot (the instantiation path,ex:myapp.myCustomModules), if empty we use registry location, if not we are doing a explicit name+path registration. Do not include the module name, you passed that in the first argument right
 	 */
@@ -165,9 +166,9 @@ component extends="coldbox.system.web.services.BaseService" {
 	 * @parent         The name of the parent module
 	 * @force          Force a registration
 	 *
-	 * @throws InvalidModuleName - When a module is not on disk
-	 *
 	 * @return If the module registered or not
+	 *
+	 * @throws InvalidModuleName - When a module is not on disk
 	 */
 	boolean function registerModule(
 		required moduleName,
@@ -500,9 +501,9 @@ component extends="coldbox.system.web.services.BaseService" {
 	 *
 	 * @moduleName The name of the module to load. It must exist and be valid. Else we ignore it by logging a warning
 	 *
-	 * @throws IllegalModuleState - When the requested module to active is not registered
-	 *
 	 * @return The Service
+	 *
+	 * @throws IllegalModuleState - When the requested module to active is not registered
 	 */
 	ModuleService function activateModule( required moduleName ){
 		var sTime   = getTickCount();
@@ -760,6 +761,7 @@ component extends="coldbox.system.web.services.BaseService" {
 
 	/**
 	 * Reload a targeted module
+	 *
 	 * @moduleName The module
 	 */
 	ModuleService function reload( required moduleName ){
@@ -788,6 +790,7 @@ component extends="coldbox.system.web.services.BaseService" {
 
 	/**
 	 * Check and see if a module has been registered
+	 *
 	 * @moduleName The module
 	 */
 	function isModuleRegistered( required moduleName ){
@@ -796,6 +799,7 @@ component extends="coldbox.system.web.services.BaseService" {
 
 	/**
 	 * Check and see if a module has been activated
+	 *
 	 * @moduleName The module
 	 */
 	boolean function isModuleActive( required moduleName ){
@@ -1179,6 +1183,7 @@ component extends="coldbox.system.web.services.BaseService" {
 
 	/**
 	 * Checks if the module can be loaded or registered
+	 *
 	 * @moduleName The module to check
 	 */
 	private boolean function canLoad( required moduleName ){

--- a/system/web/services/RequestService.cfc
+++ b/system/web/services/RequestService.cfc
@@ -8,6 +8,7 @@ component extends="coldbox.system.web.services.BaseService" {
 
 	/**
 	 * Constructor
+	 *
 	 * @controller The ColdBox Controller.
 	 */
 	function init( required controller ){
@@ -195,8 +196,7 @@ component extends="coldbox.system.web.services.BaseService" {
 	/**
 	 * Set the request context into the request scope
 	 *
-	 * @context Request Context object
-	 *
+	 * @context        Request Context object
 	 * @RequestService
 	 */
 	RequestService function setContext( required context ){
@@ -289,6 +289,7 @@ component extends="coldbox.system.web.services.BaseService" {
 
 	/**
 	 * Creates a new request context object
+	 *
 	 * @return coldbox.system.web.context.RequestContext
 	 */
 	function createContext( string classPath = "coldbox.system.web.context.RequestContext" ){

--- a/system/web/services/RoutingService.cfc
+++ b/system/web/services/RoutingService.cfc
@@ -8,6 +8,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 
 	/**
 	 * A ColdBox Router this routing service configures with.
+	 *
 	 * @doc_generic coldbox.system.web.routing.Router
 	 */
 	property name="router";
@@ -410,8 +411,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 * @module    Incoming module
 	 * @namespace Incoming namespace
 	 * @domain    Incoming domain
-	 *
-	 * @result Struct: { route: found route or empty struct, params: translated params }
+	 * @result    Struct: { route: found route or empty struct, params: translated params }
 	 */
 	struct function findRoute(
 		required action,
@@ -686,6 +686,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 
 	/**
 	 * Detect extensions from the incoming request
+	 *
 	 * @requestString The incoming request string
 	 * @event         The event object
 	 */
@@ -754,6 +755,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 
 	/**
 	 * Render a RESTFul response
+	 *
 	 * @route The route response
 	 * @event The event object
 	 */
@@ -914,6 +916,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 
 	/**
 	 * Check for invalid URL's
+	 *
 	 * @route       The incoming route
 	 * @script_name The cgi script name
 	 * @event       The event object
@@ -982,6 +985,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 
 	/**
 	 * Serialize a URL when invalid
+	 *
 	 * @formVars The incoming form variables
 	 * @event    The event object
 	 */

--- a/system/web/tasks/ColdBoxScheduler.cfc
+++ b/system/web/tasks/ColdBoxScheduler.cfc
@@ -154,10 +154,10 @@ component
 	 * @targetObject  The object requesting the dependency, usually only used by DSL lookups
 	 * @injector      The child injector to use when retrieving the instance
 	 *
+	 * @return The requested instance
+	 *
 	 * @throws InstanceNotFoundException - When the requested instance cannot be found
 	 * @throws InvalidChildInjector      - When you request an instance from an invalid child injector name
-	 *
-	 * @return The requested instance
 	 **/
 	function getInstance(
 		name,
@@ -341,9 +341,9 @@ component
 	 * @cacheProvider          The provider to cache this event rendering in, defaults to 'template'
 	 * @prePostExempt          If true, pre/post handlers will not be fired. Defaults to false
 	 *
-	 * @throws InvalidArgumentException
-	 *
 	 * @return null or anything produced from the route
+	 *
+	 * @throws InvalidArgumentException
 	 */
 	any function runRoute(
 		required name,
@@ -375,9 +375,9 @@ component
 	 * @name         The key of the setting
 	 * @defaultValue If not found in config, default return value
 	 *
-	 * @throws SettingNotFoundException
-	 *
 	 * @return The requested setting
+	 *
+	 * @throws SettingNotFoundException
 	 */
 	function getSetting( required name, defaultValue ){
 		return variables.controller.getSetting( argumentCollection = arguments );
@@ -389,9 +389,9 @@ component
 	 * @name         The key to get
 	 * @defaultValue The default value if it doesn't exist
 	 *
-	 * @throws SettingNotFoundException
-	 *
 	 * @return The framework setting value
+	 *
+	 * @throws SettingNotFoundException
 	 */
 	function getColdBoxSetting( required name, defaultValue ){
 		return variables.controller.getColdBoxSetting( argumentCollection = arguments );
@@ -444,9 +444,9 @@ component
 	 *
 	 * @module The module to retrieve the configuration structure from
 	 *
-	 * @throws InvalidModuleException - The module passed is invalid
-	 *
 	 * @return The struct requested
+	 *
+	 * @throws InvalidModuleException - The module passed is invalid
 	 */
 	struct function getModuleConfig( required module ){
 		var mConfig = variables.controller.getSetting( "modules" );

--- a/tests/specs/logging/appenders/SocketAppenderTest.cfc
+++ b/tests/specs/logging/appenders/SocketAppenderTest.cfc
@@ -47,6 +47,7 @@
 
 	/**
 	 * Get a random port for the specified host
+	 *
 	 * @host.hint host to get port on, defaults 127.0.0.1
 	 **/
 	function getRandomPort( host = "127.0.0.1" ){


### PR DESCRIPTION
This error prevents ColdBox apps from initializing on any CF engine which views trailing commas as a syntax error.