### PR TITLE
Fix instance of bad route merging

### DIFF
--- a/system/async/proxies/BaseProxy.cfc
+++ b/system/async/proxies/BaseProxy.cfc
@@ -141,10 +141,10 @@ component accessors="true" {
 		} catch ( any e ) {
 			err( "Error loading context #e.toString()#" );
 			writeDump(
-				var=[ createObject( "java", "coldfusion.filter.FusionContext" ).getCurrent() ],
-				output="console",
-				label="FusionContext Exception - Get Current",
-				top = 5
+				var    = [ createObject( "java", "coldfusion.filter.FusionContext" ).getCurrent() ],
+				output = "console",
+				label  = "FusionContext Exception - Get Current",
+				top    = 5
 			);
 		}
 	}

--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -440,12 +440,12 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 		try {
 			// Make sure our routing service can be manipulated
 			prepareMock( routingService )
-					.$( "getCGIElement" )
-					.$args( "script_name", requestContext )
-					.$results( "" )
-					.$( "getCGIElement" )
-					.$args( "server_name", requestContext )
-					.$results( arguments.domain );
+				.$( "getCGIElement" )
+				.$args( "script_name", requestContext )
+				.$results( "" )
+				.$( "getCGIElement" )
+				.$args( "server_name", requestContext )
+				.$results( arguments.domain );
 
 			// If the route is for the home page, use the default event in the config/ColdBox.cfc
 			if ( arguments.route == "/" ) {
@@ -465,7 +465,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 			// if we were passed a route, parse it and prepare the SES interceptor for routing.
 			else if ( arguments.route.len() ) {
 				// enable the SES interceptor
-				//getInstance( "router@coldbox" ).setEnabled( true );
+				// getInstance( "router@coldbox" ).setEnabled( true );
 				// separate the route into the route and the query string
 				var routeParts = explodeRoute( arguments.route );
 				// add the query string parameters from the route to the request context
@@ -479,7 +479,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 				controller.getRequestService().requestCapture();
 			} else {
 				// If we were passed just an event, remove routing since we don't need it
-				//getInstance( "router@coldbox" ).setEnabled( false );
+				// getInstance( "router@coldbox" ).setEnabled( false );
 				// Capture the request using our passed in event to execute
 				controller.getRequestService().requestCapture( arguments.event );
 				routingService

--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -907,6 +907,12 @@ component
 				if ( thisRoute.handler != "" ) {
 					newEvent = thisRoute.handler & "." & newEvent;
 				}
+				if ( actions.keyExists( newActionVerb ) && variables.log.canWarn() ) {
+					variables.log.warn(
+						"Duplicate HTTP verb found when merging routing for pattern: [#thisRoute.pattern#]. Changing #uCase( newActionVerb )# action from [#actions[ newActionVerb ]#] to [#newEvent#]",
+						{ existingRoute: matchingRoute, newRoute: thisRoute }
+					);
+				}
 				actions[ newActionVerb ] = newEvent;
 			}
 			if ( thisRoute.event != "" ) {

--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -910,7 +910,7 @@ component
 				if ( actions.keyExists( newActionVerb ) && variables.log.canWarn() ) {
 					variables.log.warn(
 						"Duplicate HTTP verb found when merging routing for pattern: [#thisRoute.pattern#]. Changing #uCase( newActionVerb )# action from [#actions[ newActionVerb ]#] to [#newEvent#]",
-						{ existingRoute: matchingRoute, newRoute: thisRoute }
+						{ existingRoute : matchingRoute, newRoute : thisRoute }
 					);
 				}
 				actions[ newActionVerb ] = newEvent;

--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -902,7 +902,13 @@ component
 				}
 			}
 			var thisRouteActions = isStruct( thisRoute.action ) ? thisRoute.action : {};
-			structAppend( actions, thisRouteActions, true );
+			for ( var newActionVerb in thisRouteActions ) {
+				var newEvent = thisRouteActions[ newActionVerb ];
+				if ( thisRoute.handler != "" ) {
+					newEvent = thisRoute.handler & "." & newEvent;
+				}
+				actions[ newActionVerb ] = newEvent;
+			}
 			if ( thisRoute.event != "" ) {
 				for ( var verb in thisRoute.verbs ) {
 					structInsert( actions, verb, thisRoute.event );

--- a/tests/specs/async/AsyncManagerSpec.cfc
+++ b/tests/specs/async/AsyncManagerSpec.cfc
@@ -12,7 +12,6 @@ component extends="BaseAsyncSpec" {
 
 		// all your suites go here.
 		describe( "ColdBox Async Programming", function(){
-
 			it( "can produce durations", function(){
 				expect(
 					asyncManager

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -578,6 +578,30 @@ component extends="coldbox.system.testing.BaseModelTest" {
 					} );
 				} );
 			} );
+
+			describe( "merging routes", function() {
+				it( "can merge a route with event and a route with handler", function() {
+					router.post( "/notifications/read", "Notifications.ReadNotifications.create" );
+					router.route( "/notifications/read" )
+						.withHandler( "Notifications.ReadNotifications" )
+						.toAction( { "POST": "create", "DELETE": "delete" } );
+
+					var routes = router.getRoutes();
+					expect( routes ).toBeArray();
+					expect( routes ).toHaveLength( 1 );
+					var route = routes[ 1 ];
+					expect( route ).toHaveKey( "event" );
+					expect( route.event ).toBe( "" );
+					expect( route ).toHaveKey( "handler" );
+					expect( route.handler ).toBe( "" );
+					expect( route ).toHaveKey( "action" );
+					expect( route.action ).toBeStruct();
+					expect( route.action ).toHaveKey( "POST" );
+					expect( route.action.POST ).toBe( "Notifications.ReadNotifications.create" );
+					expect( route.action ).toHaveKey( "DELETE" );
+					expect( route.action.DELETE ).toBe( "Notifications.ReadNotifications.delete" );
+				} );
+			} );
 		} );
 	}
 

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -579,12 +579,13 @@ component extends="coldbox.system.testing.BaseModelTest" {
 				} );
 			} );
 
-			describe( "merging routes", function() {
-				it( "can merge a route with event and a route with handler", function() {
+			describe( "merging routes", function(){
+				it( "can merge a route with event and a route with handler", function(){
 					router.post( "/notifications/read", "Notifications.ReadNotifications.create" );
-					router.route( "/notifications/read" )
+					router
+						.route( "/notifications/read" )
 						.withHandler( "Notifications.ReadNotifications" )
-						.toAction( { "POST": "create", "DELETE": "delete" } );
+						.toAction( { "POST" : "create", "DELETE" : "delete" } );
 
 					var routes = router.getRoutes();
 					expect( routes ).toBeArray();


### PR DESCRIPTION
The following now merges the routes correctly:
```cfc
router.post( "/notifications/read", "Notifications.ReadNotifications.create" );
router.route( "/notifications/read" )
	.withHandler( "Notifications.ReadNotifications" )
	.toAction( { "POST": "create", "DELETE": "delete" } );
```

It will also log a warning if any verbs are overwritten (since that is likely just a mistake).