### PR TITLE
📖 DOC: Add testbox to apidocs build for full coldbox documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,11 +20,16 @@ logs/*
 build-coldbox
 build/build.number
 artifacts/*
+apidocs/CacheBox-APIDocs
+apidocs/ColdBox-APIDocs
+apidocs/logbox-APIDocs
+apidocs/wirebox-APIDocs
 
 # Dependencies
 .engine/**
 testbox/*
-apidocs/docbox/*
+apidocs/testbox
+apidocs/docbox
 ApplicationTemplates/*
 tests/suites/loadtests/logs
 test-harness/**/route-visualizer

--- a/apidocs/Application.cfc
+++ b/apidocs/Application.cfc
@@ -12,6 +12,7 @@ component{
 
 	// Core Mappings
 	this.mappings[ "/docbox" ] 	= API_ROOT & "docbox";
+	this.mappings[ "/testbox" ]  = API_ROOT & "testbox";
 
 	// Standlone mappings
 	this.mappings[ "/coldbox" ]  = ( structKeyExists( url, "coldbox_root" )  ? url.coldbox_root  : COLDBOX_ROOT );

--- a/apidocs/box.json
+++ b/apidocs/box.json
@@ -5,8 +5,11 @@
     "dependencies":{
         "docbox":"^2.0.7"
     },
-    "devDependencies":{},
+    "devDependencies":{
+        "testbox":"^4.5.0+5"
+    },
     "installPaths":{
-        "docbox":"docbox/"
+        "docbox":"docbox/",
+        "testbox":"testbox/"
     }
 }

--- a/system/async/proxies/BaseProxy.cfc
+++ b/system/async/proxies/BaseProxy.cfc
@@ -141,10 +141,10 @@ component accessors="true" {
 		} catch ( any e ) {
 			err( "Error loading context #e.toString()#" );
 			writeDump(
-				var=[ createObject( "java", "coldfusion.filter.FusionContext" ).getCurrent() ],
-				output="console",
-				label="FusionContext Exception - Get Current",
-				top = 5
+				var    = [ createObject( "java", "coldfusion.filter.FusionContext" ).getCurrent() ],
+				output = "console",
+				label  = "FusionContext Exception - Get Current",
+				top    = 5
 			);
 		}
 	}

--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -440,12 +440,12 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 		try {
 			// Make sure our routing service can be manipulated
 			prepareMock( routingService )
-					.$( "getCGIElement" )
-					.$args( "script_name", requestContext )
-					.$results( "" )
-					.$( "getCGIElement" )
-					.$args( "server_name", requestContext )
-					.$results( arguments.domain );
+				.$( "getCGIElement" )
+				.$args( "script_name", requestContext )
+				.$results( "" )
+				.$( "getCGIElement" )
+				.$args( "server_name", requestContext )
+				.$results( arguments.domain );
 
 			// If the route is for the home page, use the default event in the config/ColdBox.cfc
 			if ( arguments.route == "/" ) {
@@ -465,7 +465,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 			// if we were passed a route, parse it and prepare the SES interceptor for routing.
 			else if ( arguments.route.len() ) {
 				// enable the SES interceptor
-				//getInstance( "router@coldbox" ).setEnabled( true );
+				// getInstance( "router@coldbox" ).setEnabled( true );
 				// separate the route into the route and the query string
 				var routeParts = explodeRoute( arguments.route );
 				// add the query string parameters from the route to the request context
@@ -479,7 +479,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 				controller.getRequestService().requestCapture();
 			} else {
 				// If we were passed just an event, remove routing since we don't need it
-				//getInstance( "router@coldbox" ).setEnabled( false );
+				// getInstance( "router@coldbox" ).setEnabled( false );
 				// Capture the request using our passed in event to execute
 				controller.getRequestService().requestCapture( arguments.event );
 				routingService

--- a/tests/specs/async/AsyncManagerSpec.cfc
+++ b/tests/specs/async/AsyncManagerSpec.cfc
@@ -12,7 +12,6 @@ component extends="BaseAsyncSpec" {
 
 		// all your suites go here.
 		describe( "ColdBox Async Programming", function(){
-
 			it( "can produce durations", function(){
 				expect(
 					asyncManager


### PR DESCRIPTION
Ensure all coldbox.system.testing cfcs are able to reference testbox when building documentation. Resolves an issue where the `BaseInterceptorTest`, `BaseModelTest`, etc. files were excluded from the documentation output due to a missing `testbox` dependency.