### PR TITLE
Update Response Pagination Properties for Case-Sensitive Engines

### DIFF
--- a/system/web/context/Response.cfc
+++ b/system/web/context/Response.cfc
@@ -261,11 +261,11 @@ component accessors="true" {
 		numeric totalPages   = 1
 	){
 		variables.pagination = {
-			"offset": arguments.offset,
-			"maxRows": arguments.maxRows,
-			"page": arguments.page,
-			"totalRecords": arguments.totalRecords,
-			"totalPages": arguments.totalPages
+			"offset"       : arguments.offset,
+			"maxRows"      : arguments.maxRows,
+			"page"         : arguments.page,
+			"totalRecords" : arguments.totalRecords,
+			"totalPages"   : arguments.totalPages
 		};
 		return this;
 	}

--- a/system/web/context/Response.cfc
+++ b/system/web/context/Response.cfc
@@ -260,7 +260,13 @@ component accessors="true" {
 		numeric totalRecords = 0,
 		numeric totalPages   = 1
 	){
-		variables.pagination = arguments;
+		variables.pagination = {
+			"offset": arguments.offset,
+			"maxRows": arguments.maxRows,
+			"page": arguments.page,
+			"totalRecords": arguments.totalRecords,
+			"totalPages": arguments.totalPages
+		};
 		return this;
 	}
 


### PR DESCRIPTION
Depending on what engine you are using, the `Response` object's `pagination` struct will either be in camel case or all in caps.  For example in ACF, it will convert all of the variables `offset`, `maxRows`, etc... to `OFFSET`, `MAXROWS`, etc...   Since the `Response` object could be consumed by JavaScript which is case-sensitive, it's important to deliver consistent output between CFML engines.

This update addresses the problem by explicitly forcing the case of the `pagination` struct to be in camel case.