### PR TITLE
Fix for implicitViewChecks() changing global RequestContext

### DIFF
--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -577,8 +577,6 @@ component
 		boolean prePostExempt = false
 	){
 		var event                  = getRequestContext();
-		var cbox_implicitLayout    = implicitViewChecks();
-		var cbox_currentLayout     = cbox_implicitLayout;
 		var cbox_locateUDF         = variables.locateLayout;
 		var cbox_explicitModule    = false;
 		var cbox_layoutLocationKey = "";
@@ -608,6 +606,9 @@ component
 
 		// If no passed layout, then get it from implicit values
 		if ( isNull( arguments.layout ) ) {
+			var cbox_implicitLayout = implicitViewChecks(
+				arguments.view != "" ? arguments.view : event.getCurrentView()
+			);
 			// Strip off the .cfm extension if it is set
 			if ( len( cbox_implicitLayout ) GT 4 AND right( cbox_implicitLayout, 4 ) eq ".cfm" ) {
 				cbox_implicitLayout = left( cbox_implicitLayout, len( cbox_implicitLayout ) - 4 );
@@ -627,6 +628,7 @@ component
 			announce( "preLayoutRender", iData );
 		}
 
+		cbox_currentLayout = arguments.layout;
 		// Check explicit layout rendering
 		if ( !isNull( arguments.layout ) ) {
 			// Check if any length on incoming layout
@@ -946,7 +948,7 @@ component
 	/**
 	 * Checks if implicit views are turned on and if so, calculate view according to event.
 	 */
-	private function implicitViewChecks(){
+	private function implicitViewChecks( required string view ){
 		var event  = getRequestContext();
 		var layout = event.getCurrentLayout();
 		var cEvent = event.getCurrentEvent();
@@ -960,16 +962,13 @@ component
 		cEvent = reReplaceNoCase( cEvent, "^([^:.]*):", "" );
 
 		// Check if no view set?
-		if ( NOT len( event.getCurrentView() ) ) {
+		if ( NOT len( arguments.view ) ) {
 			// Implicit views
 			if ( controller.getSetting( name = "caseSensitiveImplicitViews", defaultValue = true ) ) {
-				event.setView( replace( cEvent, ".", "/", "all" ) );
+				return event.discoverLayout( replace( cEvent, ".", "/", "all" ) );
 			} else {
-				event.setView( lCase( replace( cEvent, ".", "/", "all" ) ) );
+				return event.discoverLayout( lCase( replace( cEvent, ".", "/", "all" ) ) );
 			}
-
-			// reset layout according to newly set views;
-			layout = event.getCurrentLayout();
 		}
 
 		return layout;

--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -878,34 +878,9 @@ component serializable="false" accessors="true" {
 		}
 		// Discover layout
 		else if ( NOT arguments.nolayout AND NOT getPrivateValue( name = "layoutoverride", defaultValue = false ) ) {
-			// Verify that the view has a layout in the viewLayouts structure, static lookups
-			if ( structKeyExists( variables.viewLayouts, lCase( arguments.view ) ) ) {
-				setPrivateValue( "currentLayout", variables.viewLayouts[ lCase( arguments.view ) ] );
-			} else {
-				// Check the folders structure
-				for ( var key in variables.folderLayouts ) {
-					if ( reFindNoCase( "^#key#", lCase( arguments.view ) ) ) {
-						setPrivateValue( "currentLayout", variables.folderLayouts[ key ] );
-						break;
-					}
-				}
-				// end for loop
-			}
-			// end else
-
-			// If not layout, then set default from main application
-			if ( not privateValueExists( "currentLayout", true ) ) {
-				setPrivateValue( "currentLayout", variables.defaultLayout );
-			}
-
-			// If in current module, check for a module default layout\
-			var cModule = getCurrentModule();
-			if (
-				len( cModule )
-				AND structKeyExists( variables.modules, cModule )
-				AND len( variables.modules[ cModule ].layoutSettings.defaultLayout )
-			) {
-				setPrivateValue( "currentLayout", variables.modules[ cModule ].layoutSettings.defaultLayout );
+			var discoveredLayout = discoverLayout( arguments.view );
+			if ( discoveredLayout != "" ) {
+				setPrivateValue( "currentLayout", discoveredLayout );
 			}
 		}
 		// end layout discover
@@ -945,6 +920,39 @@ component serializable="false" accessors="true" {
 		setPrivateValue( "currentViewArgs", arguments.args, true );
 
 		return this;
+	}
+
+	function discoverLayout( required string view ){
+		// Verify that the view has a layout in the viewLayouts structure, static lookups
+		if ( structKeyExists( variables.viewLayouts, lCase( arguments.view ) ) ) {
+			return variables.viewLayouts[ lCase( arguments.view ) ];
+		} else {
+			// Check the folders structure
+			for ( var key in variables.folderLayouts ) {
+				if ( reFindNoCase( "^#key#", lCase( arguments.view ) ) ) {
+					return variables.folderLayouts[ key ];
+				}
+			}
+			// end for loop
+		}
+		// end else
+
+		// If not layout, then set default from main application
+		if ( not privateValueExists( "currentLayout" ) ) {
+			return variables.defaultLayout;
+		}
+
+		// If in current module, check for a module default layout\
+		var cModule = getCurrentModule();
+		if (
+			len( cModule )
+			AND structKeyExists( variables.modules, cModule )
+			AND len( variables.modules[ cModule ].layoutSettings.defaultLayout )
+		) {
+			return variables.modules[ cModule ].layoutSettings.defaultLayout;
+		}
+
+		return "";
 	}
 
 	/**

--- a/tests/specs/web/RendererTest.cfc
+++ b/tests/specs/web/RendererTest.cfc
@@ -134,6 +134,16 @@ component extends="tests.resources.BaseIntegrationTest" {
 				var results    = r.layout( layout = "Simple", view = "simpleview" );
 				expect( event.getCurrentView() ).toBe( beforeView );
 			} );
+
+			it( "can render implicit views", function(){
+				var event = getRequestContext();
+				event.overrideEvent( "Main.index" );
+				event.setPrivateValue( "welcomeMessage", "Welcome to ColdBox!" );
+				var beforeView = event.getCurrentView();
+				expect( beforeView ).toBe( "" );
+				var results = r.layout();
+				expect( event.getCurrentView() ).toBe( "Main/index" );
+			} );
 		} );
 	}
 

--- a/tests/specs/web/RendererTest.cfc
+++ b/tests/specs/web/RendererTest.cfc
@@ -126,6 +126,14 @@ component extends="tests.resources.BaseIntegrationTest" {
 				);
 				expect( results ).notToBe( results2 );
 			} );
+
+			it( "can render a layout without changing the request context", function(){
+				var event = getRequestContext();
+				event.overrideEvent( "Main.index" );
+				var beforeView = event.getCurrentView();
+				var results    = r.layout( layout = "Simple", view = "simpleview" );
+				expect( event.getCurrentView() ).toBe( beforeView );
+			} );
 		} );
 	}
 

--- a/tests/specs/web/RendererTest.cfc
+++ b/tests/specs/web/RendererTest.cfc
@@ -137,12 +137,12 @@ component extends="tests.resources.BaseIntegrationTest" {
 
 			it( "can render implicit views", function(){
 				var event = getRequestContext();
-				event.overrideEvent( "Main.index" );
+				event.overrideEvent( "main.index" );
 				event.setPrivateValue( "welcomeMessage", "Welcome to ColdBox!" );
 				var beforeView = event.getCurrentView();
 				expect( beforeView ).toBe( "" );
 				var results = r.layout();
-				expect( event.getCurrentView() ).toBe( "Main/index" );
+				expect( event.getCurrentView() ).toBe( "main/index" );
 			} );
 		} );
 	}


### PR DESCRIPTION
When getting default layout values for implicit views, ColdBox would use the `event.setView` method in order to discover the required layout file.  This would cause problems is the `layout`/`renderLayout` call was not called from ColdBox's event lifecycle but was called manually, as is the case when using `cbmailservices.newMail().setView()` method.

This PR adds a test showing the global scope pollution.  It extracts a new `discoverLayout` method on the `RequestContext` that can be used in the `Renderer` to get the correct layout path without changing `RequestContext` values.