### PR TITLE
Dynamically generate QueryExecute options based on config data

### DIFF
--- a/system/cache/store/indexers/JDBCMetadataIndexer.cfc
+++ b/system/cache/store/indexers/JDBCMetadataIndexer.cfc
@@ -57,7 +57,7 @@ component extends="coldbox.system.cache.store.indexers.MetadataIndexer" accessor
 		variables.store = arguments.store;
 
 		variables.isLucee = server.keyExists( "lucee" );
-		
+
 		// Check credentials
 		if ( isNull( variables.config.dsnUsername ) ) {
 			variables.config.dsnUsername = "";
@@ -129,11 +129,7 @@ component extends="coldbox.system.cache.store.indexers.MetadataIndexer" accessor
 			params = [];
 		}
 
-		queryExecute(
-			sql,
-			params,
-			variables.queryOptions
-		).each( function( row ){
+		queryExecute( sql, params, variables.queryOptions ).each( function( row ){
 			results[ row.objectKey ] = {
 				"hits"              : row.hits,
 				"timeout"           : row.timeout,

--- a/system/cache/store/indexers/JDBCMetadataIndexer.cfc
+++ b/system/cache/store/indexers/JDBCMetadataIndexer.cfc
@@ -57,6 +57,33 @@ component extends="coldbox.system.cache.store.indexers.MetadataIndexer" accessor
 		variables.store = arguments.store;
 
 		variables.isLucee = server.keyExists( "lucee" );
+		
+		// Check credentials
+		if ( isNull( variables.config.dsnUsername ) ) {
+			variables.config.dsnUsername = "";
+		}
+		if ( isNull( variables.config.dsnPassword ) ) {
+			variables.config.dsnPassword = "";
+		}
+
+		// this struct will contain the dsn and credentials if passed into the config. Otherwise queryExecute will default
+		// to the datasource set in application.cfc
+		variables.queryOptions = {};
+
+		// if DSN username or password were passed, include them in the query options
+		if ( len( variables.config.dsnUsername ) || len( variables.config.dsnPassword ) ) {
+			variables.queryOptions[ "dsnUsername" ] = variables.config.dsnUsername;
+			variables.queryOptions[ "dsnPassword" ] = variables.config.dsnPassword;
+		}
+
+		if ( isNull( variables.config.queryIncludeDsn ) ) {
+			variables.config.queryIncludeDsn = true;
+		}
+
+		// if we should include the dsn in the query options, add it
+		if ( variables.config.queryIncludeDsn ) {
+			variables.queryOptions[ "dsn" ] = variables.config.dsn;
+		}
 
 		return this;
 	}
@@ -72,11 +99,7 @@ component extends="coldbox.system.cache.store.indexers.MetadataIndexer" accessor
 			  FROM #variables.config.table#
 			 WHERE id = ?",
 			[ variables.store.getNormalizedID( arguments.objectKey ) ],
-			{
-				datasource : variables.config.dsn,
-				username   : variables.config.dsnUsername,
-				password   : variables.config.dsnPassword
-			}
+			variables.queryOptions
 		).recordCount eq 1;
 	}
 
@@ -109,11 +132,7 @@ component extends="coldbox.system.cache.store.indexers.MetadataIndexer" accessor
 		queryExecute(
 			sql,
 			params,
-			{
-				datasource : variables.config.dsn,
-				username   : variables.config.dsnUsername,
-				password   : variables.config.dsnPassword
-			}
+			variables.queryOptions
 		).each( function( row ){
 			results[ row.objectKey ] = {
 				"hits"              : row.hits,
@@ -140,11 +159,7 @@ component extends="coldbox.system.cache.store.indexers.MetadataIndexer" accessor
 			  FROM #variables.config.table#
 			 WHERE id = ?",
 			[ variables.store.getNormalizedID( arguments.objectKey ) ],
-			{
-				datasource : variables.config.dsn,
-				username   : variables.config.dsnUsername,
-				password   : variables.config.dsnPassword
-			}
+			variables.queryOptions
 		);
 
 		return variables.fields.listReduce( function( accumulator, target ){
@@ -170,11 +185,7 @@ component extends="coldbox.system.cache.store.indexers.MetadataIndexer" accessor
 			  FROM #variables.config.table#
 			 WHERE id = ?",
 			[ variables.store.getNormalizedID( arguments.objectKey ) ],
-			{
-				datasource : variables.config.dsn,
-				username   : variables.config.dsnUsername,
-				password   : variables.config.dsnPassword
-			}
+			variables.queryOptions
 		);
 
 		if ( structKeyExists( metadata, arguments.property ) ) {
@@ -219,11 +230,7 @@ component extends="coldbox.system.cache.store.indexers.MetadataIndexer" accessor
 			FROM #variables.config.table#
 		    ORDER BY #arguments.property# #arguments.sortOrder#",
 			[],
-			{
-				datasource : variables.config.dsn,
-				username   : variables.config.dsnUsername,
-				password   : variables.config.dsnPassword
-			}
+			variables.queryOptions
 		);
 
 		return (


### PR DESCRIPTION
A similar solution as https://ortussolutions.atlassian.net/browse/CACHEBOX-80.
This change dynamically generates the options for each queryExecute() statement based on the configuration data so it remains consistent with the JDBCStore.