### PR TITLE
Announce onException on async interceptor error

### DIFF
--- a/system/core/util/Util.cfc
+++ b/system/core/util/Util.cfc
@@ -291,7 +291,7 @@ component {
 	 * Retrieve an instance of Java System
 	 */
 	function getJavaSystem(){
-		if( isNull( variables.javaSystem ) ){
+		if ( isNull( variables.javaSystem ) ) {
 			variables.javaSystem = createObject( "java", "java.lang.System" );
 		}
 		return variables.javaSystem;
@@ -303,7 +303,7 @@ component {
 	 * @return coldbox.system.core.dynamic.MixerUtil
 	 */
 	function getMixerUtil(){
-		if( isNull( variables.mixerUtil ) ){
+		if ( isNull( variables.mixerUtil ) ) {
 			variables.mixerUtil = new coldbox.system.core.dynamic.MixerUtil();
 		}
 		return variables.mixerUtil;

--- a/system/ioc/Injector.cfc
+++ b/system/ioc/Injector.cfc
@@ -1261,7 +1261,9 @@ component serializable="false" accessors="true" {
 
 		// Log info
 		if ( variables.log.canDebug() ) {
-			variables.log.debug( "Scope Registration enabled and Injector scoped to: #arguments.scopeInfo.toString()#" );
+			variables.log.debug(
+				"Scope Registration enabled and Injector scoped to: #arguments.scopeInfo.toString()#"
+			);
 		}
 
 		return this;

--- a/system/web/context/InterceptorState.cfc
+++ b/system/web/context/InterceptorState.cfc
@@ -186,18 +186,23 @@ component accessors="true" extends="coldbox.system.core.events.EventPool" {
 			priority  ="#arguments.asyncPriority#"
 			threadName="#threadName#"
 			buffer    ="#arguments.buffer#" {
-			// Process it
-			variables.processSync(
-				event  = variables.controller.getRequestService().getContext(),
-				data   = request[ attributes.threadName ],
-				buffer = attributes.buffer
-			);
-
-			if ( variables.log.canDebug() ) {
-				variables.log.debug(
-					"Finished threaded interceptor chain: #getState()# with thread name: #attributes.threadName#",
-					thread
+			try {
+				// Process it
+				variables.processSync(
+					event  = variables.controller.getRequestService().getContext(),
+					data   = request[ attributes.threadName ],
+					buffer = attributes.buffer
 				);
+
+				if ( variables.log.canDebug() ) {
+					variables.log.debug(
+						"Finished threaded interceptor chain: #getState()# with thread name: #attributes.threadName#",
+						thread
+					);
+				}
+			} catch ( any e ) {
+				variables.controller.getInterceptorService().announce( "onException", { exception : e } );
+				rethrow;
 			}
 		}
 

--- a/tests/specs/ioc/scopes/CFScopesTest.cfc
+++ b/tests/specs/ioc/scopes/CFScopesTest.cfc
@@ -1,4 +1,4 @@
-﻿component extends="coldbox.system.testing.BaseModelTest" model="coldbox.system.ioc.scopes.CFScopes"{
+﻿component extends="coldbox.system.testing.BaseModelTest" model="coldbox.system.ioc.scopes.CFScopes" {
 
 	/*********************************** LIFE CYCLE Methods ***********************************/
 
@@ -29,7 +29,6 @@
 	 * executes after all suites+specs in the run() method
 	 */
 	function afterAll(){
-
 	}
 
 	/*********************************** BDD SUITES ***********************************/
@@ -37,12 +36,13 @@
 	function run( testResults, testBox ){
 		// all your suites go here.
 		describe( "CF Scopes Suite", function(){
-
 			story( "Can store and get objects from a CF scope", function(){
 				given( "A new object request", function(){
 					then( "it should store it into the right scope", function(){
 						// 1: Default construction
-						var mapping = createMock( "coldbox.system.ioc.config.Mapping" ).init( name = "CFScopeTest" );
+						var mapping = createMock( "coldbox.system.ioc.config.Mapping" ).init(
+							name = "CFScopeTest"
+						);
 						mapping.setScope( "session" );
 						mapping.setThreadSafe( true );
 						mockInjector.$( "buildInstance", mockStub ).$( "autowire", mockStub );
@@ -51,20 +51,22 @@
 						var o = scope.getFromScope( mapping: mapping, initArguments: {} );
 						expect( o ).toBe( mockStub );
 						expect( mockStub ).toBe( session[ "wirebox:CFScopeTest" ] );
-					});
-				});
+					} );
+				} );
 
 				given( "a previously created object", function(){
 					then( "it should retrieve the same object", function(){
-						var mapping = createMock( "coldbox.system.ioc.config.Mapping" ).init( name = "CFScopeTest" );
+						var mapping = createMock( "coldbox.system.ioc.config.Mapping" ).init(
+							name = "CFScopeTest"
+						);
 						mapping.setScope( "session" );
 						mapping.setThreadSafe( true );
 						session[ "wirebox:CFScopeTest" ] = mockStub;
 						var o                            = scope.getFromScope( mapping, {} );
 						expect( o ).toBe( mockStub );
-					});
-				});
-			});
+					} );
+				} );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Adds `onException` interception support for allowing error handling on async interceptions. Previously, only the `processAsyncAll()` method supported this.