### PR TITLE
Enhance EntityNotFound Exception Message

### DIFF
--- a/system/RestHandler.cfc
+++ b/system/RestHandler.cfc
@@ -288,7 +288,7 @@ component extends="EventHandler" {
 			.getResponse()
 			.setError( true )
 			.setData( rc.id ?: "" )
-			.addMessage( "The record you requested cannot be found in this system" )
+			.addMessage( len( exception.message ) ? exception.message : "The record you requested cannot be found in this system" )
 			.setStatusCode( arguments.event.STATUS.NOT_FOUND )
 			.setStatusText( "Not Found" );
 

--- a/system/RestHandler.cfc
+++ b/system/RestHandler.cfc
@@ -288,7 +288,9 @@ component extends="EventHandler" {
 			.getResponse()
 			.setError( true )
 			.setData( rc.id ?: "" )
-			.addMessage( len( exception.message ) ? exception.message : "The record you requested cannot be found in this system" )
+			.addMessage(
+				len( exception.message ) ? exception.message : "The record you requested cannot be found in this system"
+			)
 			.setStatusCode( arguments.event.STATUS.NOT_FOUND )
 			.setStatusText( "Not Found" );
 


### PR DESCRIPTION
This change allows for more customizable 404 entity not found exception responses. This should benefit everyone using Quick since methods like `findOrFail()` provide a default exception message and it can be customized via arguments.  Passing the message through to the client will help create more friendly (and detailed) error messages.  Users can also default to the generic message by providing an empty string as `exception.message` as well.