### PR TITLE
Updated Missing Action Response Code to 404 instead of 405

### DIFF
--- a/system/RestHandler.cfc
+++ b/system/RestHandler.cfc
@@ -363,7 +363,7 @@ component extends="EventHandler" {
 			.getResponse()
 			.setError( true )
 			.addMessage( "Action '#arguments.missingAction#' could not be found" )
-			.setStatusCode( arguments.event.STATUS.NOT_ALLOWED )
+			.setStatusCode( arguments.event.STATUS.NOT_FOUND )
 			.setStatusText( "Invalid Action" );
 
 		// Render Error Out

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -1250,7 +1250,9 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function startOn( required date, string time = "00:00" ){
-		variables.startOnDateTime = variables.chronoUnitHelper.parse( "#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#" );
+		variables.startOnDateTime = variables.chronoUnitHelper.parse(
+			"#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#"
+		);
 		return this;
 	}
 
@@ -1261,7 +1263,9 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function endOn( required date, string time = "00:00" ){
-		variables.endOnDateTime = variables.chronoUnitHelper.parse( "#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#" );
+		variables.endOnDateTime = variables.chronoUnitHelper.parse(
+			"#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#"
+		);
 		return this;
 	}
 

--- a/system/async/time/ChronoUnit.cfc
+++ b/system/async/time/ChronoUnit.cfc
@@ -14,41 +14,41 @@ component singleton {
 	this.ChronoField = createObject( "java", "java.time.temporal.ChronoField" );
 
 	// The java chrono unit we model
-	variables.jChronoUnit = createObject( "java", "java.time.temporal.ChronoUnit" );
+	variables.jChronoUnit    = createObject( "java", "java.time.temporal.ChronoUnit" );
 	// Java LocalDateTime class
 	variables.jLocalDateTime = createObject( "java", "java.time.LocalDateTime" );
 	// Unit that represents the concept of a century.
-	this.CENTURIES        = variables.jChronoUnit.CENTURIES;
+	this.CENTURIES           = variables.jChronoUnit.CENTURIES;
 	// Unit that represents the concept of a day.
-	this.DAYS             = variables.jChronoUnit.DAYS;
+	this.DAYS                = variables.jChronoUnit.DAYS;
 	// Unit that represents the concept of a decade.
-	this.DECADES          = variables.jChronoUnit.DECADES;
+	this.DECADES             = variables.jChronoUnit.DECADES;
 	// Unit that represents the concept of an era.
-	this.ERAS             = variables.jChronoUnit.ERAS;
+	this.ERAS                = variables.jChronoUnit.ERAS;
 	// Artificial unit that represents the concept of forever.
-	this.FOREVER          = variables.jChronoUnit.FOREVER;
+	this.FOREVER             = variables.jChronoUnit.FOREVER;
 	// Unit that represents the concept of half a day, as used in AM/PM.
-	this.HALF_DAYS        = variables.jChronoUnit.HALF_DAYS;
+	this.HALF_DAYS           = variables.jChronoUnit.HALF_DAYS;
 	// Unit that represents the concept of an hour.
-	this.HOURS            = variables.jChronoUnit.HOURS;
+	this.HOURS               = variables.jChronoUnit.HOURS;
 	// Unit that represents the concept of a microsecond.
-	this.MICROS           = variables.jChronoUnit.MICROS;
+	this.MICROS              = variables.jChronoUnit.MICROS;
 	// Unit that represents the concept of a millennium.
-	this.MILLENNIA        = variables.jChronoUnit.MILLENNIA;
+	this.MILLENNIA           = variables.jChronoUnit.MILLENNIA;
 	// Unit that represents the concept of a millisecond.
-	this.MILLIS           = variables.jChronoUnit.MILLIS;
+	this.MILLIS              = variables.jChronoUnit.MILLIS;
 	// Unit that represents the concept of a minute.
-	this.MINUTES          = variables.jChronoUnit.MINUTES;
+	this.MINUTES             = variables.jChronoUnit.MINUTES;
 	// Unit that represents the concept of a month.
-	this.MONTHS           = variables.jChronoUnit.MONTHS;
+	this.MONTHS              = variables.jChronoUnit.MONTHS;
 	// Unit that represents the concept of a nanosecond, the smallest supported unit of time.
-	this.NANOS            = variables.jChronoUnit.NANOS;
+	this.NANOS               = variables.jChronoUnit.NANOS;
 	// Unit that represents the concept of a second.
-	this.SECONDS          = variables.jChronoUnit.SECONDS;
+	this.SECONDS             = variables.jChronoUnit.SECONDS;
 	// Unit that represents the concept of a week.
-	this.WEEKS            = variables.jChronoUnit.WEEKS;
+	this.WEEKS               = variables.jChronoUnit.WEEKS;
 	// Unit that represents the concept of a year.
-	this.YEARS            = variables.jChronoUnit.YEARS;
+	this.YEARS               = variables.jChronoUnit.YEARS;
 
 	/**
 	 * Convert any ColdFusion date/time or string date/time object to a Java instant temporal object


### PR DESCRIPTION
I believe the intent of this method is to show that a particular handler action is missing which feels more like a 404 not found error.  405 (NOT_ALLOWED) is more appropriate for invalid HTTP actions.