### PR TITLE
COLDBOX-1039 - Add unlisten( closure, point ) method to InterceptorService

### DIFF
--- a/system/async/proxies/Consumer.cfc
+++ b/system/async/proxies/Consumer.cfc
@@ -24,14 +24,12 @@ component extends="BaseProxy" {
 			lock name="#getConcurrentEngineLockName()#" type="exclusive" timeout="60" {
 				variables.target( arguments.t );
 			}
-		}
-		catch( any e ){
+		} catch ( any e ) {
 			// Log it, so it doesn't go to ether
 			err( "Error running Consumer: #e.message & e.detail#" );
 			err( "Stacktrace for Consumer: #e.stackTrace#" );
 			rethrow;
-		}
-		finally {
+		} finally {
 			unLoadContext();
 		}
 	}

--- a/system/async/proxies/Supplier.cfc
+++ b/system/async/proxies/Supplier.cfc
@@ -37,14 +37,12 @@ component extends="BaseProxy" {
 					return invoke( variables.target, variables.method );
 				}
 			}
-		}
-		catch( any e ){
+		} catch ( any e ) {
 			// Log it, so it doesn't go to ether
 			err( "Error running Supplier: #e.message & e.detail#" );
 			err( "Stacktrace for Supplier: #e.stackTrace#" );
 			rethrow;
-		}
-		finally {
+		} finally {
 			unLoadContext();
 		}
 	}

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -493,7 +493,9 @@ component accessors="true" {
 				}
 			} catch ( any afterException ) {
 				// Log it, so it doesn't go to ether and executor doesn't die.
-				err( "Error running task (#getname()#) after/error handlers : #afterException.message & afterException.detail#" );
+				err(
+					"Error running task (#getname()#) after/error handlers : #afterException.message & afterException.detail#"
+				);
 				err( "Stacktrace for task (#getname()#) after/error handlers : #afterException.stackTrace#" );
 			}
 		} finally {

--- a/system/testing/VirtualApp.cfc
+++ b/system/testing/VirtualApp.cfc
@@ -55,7 +55,7 @@ component accessors="true" {
 	 */
 	function startup( boolean force = false ){
 		// Return back if it's already running and not forcing
-		if( isRunning() && !arguments.force ){
+		if ( isRunning() && !arguments.force ) {
 			return application.cbController;
 		}
 
@@ -99,7 +99,7 @@ component accessors="true" {
 	 *
 	 */
 	function getController(){
-		return isRunning() ? application.cbController : javaCast( "null", "" );
+		return isRunning() ? application.cbController : javacast( "null", "" );
 	}
 
 	/**

--- a/system/web/services/InterceptorService.cfc
+++ b/system/web/services/InterceptorService.cfc
@@ -264,9 +264,11 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 *
 	 * @target The closure/lambda to unregister
 	 * @point  The interception point from which to unregister the listener
+	 * 
+	 * @returns True if interception point found and unregistered; else false.
 	 */
-	void function unlisten( required target, required point ){
-		unregister( "closure-#arguments.point#-#hash( target.toString() )#" );
+	boolean function unlisten( required target, required point ){
+		return unregister( "closure-#arguments.point#-#hash( arguments.target.toString() )#" );
 	}
 
 	/**

--- a/system/web/services/InterceptorService.cfc
+++ b/system/web/services/InterceptorService.cfc
@@ -260,6 +260,16 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	}
 
 	/**
+	 * Unregister the given closure from a specific interception point
+	 *
+	 * @target The closure/lambda to unregister
+	 * @point  The interception point from which to unregister the listener
+	 */
+	void function unlisten( required target, required point ){
+		unregister( "closure-#arguments.point#-#hash( target.toString() )#" );
+	}
+
+	/**
 	 * Register a closure listener as an interceptor on a specific point
 	 *
 	 * @target The closure/lambda to register

--- a/system/web/services/InterceptorService.cfc
+++ b/system/web/services/InterceptorService.cfc
@@ -264,8 +264,8 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 *
 	 * @target The closure/lambda to unregister
 	 * @point  The interception point from which to unregister the listener
-	 * 
-	 * @returns True if interception point found and unregistered; else false.
+	 *
+	 * @return True if interception point found and unregistered; else false.
 	 */
 	boolean function unlisten( required target, required point ){
 		return unregister( "closure-#arguments.point#-#hash( arguments.target.toString() )#" );

--- a/tests/specs/web/services/interceptorserviceTest.cfc
+++ b/tests/specs/web/services/interceptorserviceTest.cfc
@@ -69,14 +69,14 @@
 
 	function testListen(){
 		var called = false;
-		iService.listen( function() { called = true }, "onCall" );
+		iService.listen( function() { called = true; }, "onCall" );
 		iService.announce( "onCall" );
 		assertTrue( called );
 	}
 
 	function testUnlisten(){
 		var called = false;
-		var listener = function() { called = true };
+		var listener = function() { called = true; };
 		iService.listen( listener, "onCall" );
 		iService.unlisten( listener, "onCall" );
 

--- a/tests/specs/web/services/interceptorserviceTest.cfc
+++ b/tests/specs/web/services/interceptorserviceTest.cfc
@@ -11,7 +11,9 @@
 			.createEmptyMock( "coldbox.system.web.services.RequestService" )
 			.$( "getContext", mockRequestContext );
 		mockLogBox   = mockBox.createEmptyMock( "coldbox.system.logging.LogBox" );
-		mockLogger   = mockBox.createEmptyMock( "coldbox.system.logging.Logger" );
+		mockLogger   = mockBox
+			.createEmptyMock( "coldbox.system.logging.Logger" )
+			.$( "canDebug", false );
 		mockFlash    = mockBox.createMock( "coldbox.system.web.flash.MockFlash" ).init( mockController );
 		mockCacheBox = mockBox.createEmptyMock( "coldbox.system.cache.CacheFactory" );
 		mockCache    = mockBox.createEmptyMock( "coldbox.system.cache.providers.CacheBoxColdBoxProvider" );
@@ -63,6 +65,23 @@
 		iService.registerInterceptors();
 
 		assertTrue( iService.$count( 1, "registerInterceptor" ) );
+	}
+
+	function testListen(){
+		var called = false;
+		iService.listen( function() { called = true }, "onCall" );
+		iService.announce( "onCall" );
+		assertTrue( called );
+	}
+
+	function testUnlisten(){
+		var called = false;
+		var listener = function() { called = true };
+		iService.listen( listener, "onCall" );
+		iService.unlisten( listener, "onCall" );
+
+		iService.announce( "onCall" );
+		assertFalse( called );
 	}
 
 	function testInterceptionPoints(){

--- a/tests/specs/web/services/interceptorserviceTest.cfc
+++ b/tests/specs/web/services/interceptorserviceTest.cfc
@@ -11,9 +11,7 @@
 			.createEmptyMock( "coldbox.system.web.services.RequestService" )
 			.$( "getContext", mockRequestContext );
 		mockLogBox   = mockBox.createEmptyMock( "coldbox.system.logging.LogBox" );
-		mockLogger   = mockBox
-			.createEmptyMock( "coldbox.system.logging.Logger" )
-			.$( "canDebug", false );
+		mockLogger   = mockBox.createEmptyMock( "coldbox.system.logging.Logger" ).$( "canDebug", false );
 		mockFlash    = mockBox.createMock( "coldbox.system.web.flash.MockFlash" ).init( mockController );
 		mockCacheBox = mockBox.createEmptyMock( "coldbox.system.cache.CacheFactory" );
 		mockCache    = mockBox.createEmptyMock( "coldbox.system.cache.providers.CacheBoxColdBoxProvider" );
@@ -69,14 +67,18 @@
 
 	function testListen(){
 		var called = false;
-		iService.listen( function() { called = true; }, "onCall" );
+		iService.listen( function(){
+			called = true;
+		}, "onCall" );
 		iService.announce( "onCall" );
 		assertTrue( called );
 	}
 
 	function testUnlisten(){
-		var called = false;
-		var listener = function() { called = true; };
+		var called   = false;
+		var listener = function(){
+			called = true;
+		};
 		iService.listen( listener, "onCall" );
 		iService.unlisten( listener, "onCall" );
 


### PR DESCRIPTION
This allows simpler removal of closure listeners:

```js
var listener = function() {
  // DO STUFF...
};
iService.listen( listener, "onCall" );

// later, when we no longer need the listener:
iService.unlisten( listener, "onCall" );
```