### PR TITLE
COLDBOX-1137 - Feat/allow point first listen method

### DIFF
--- a/system/async/proxies/Consumer.cfc
+++ b/system/async/proxies/Consumer.cfc
@@ -24,14 +24,12 @@ component extends="BaseProxy" {
 			lock name="#getConcurrentEngineLockName()#" type="exclusive" timeout="60" {
 				variables.target( arguments.t );
 			}
-		}
-		catch( any e ){
+		} catch ( any e ) {
 			// Log it, so it doesn't go to ether
 			err( "Error running Consumer: #e.message & e.detail#" );
 			err( "Stacktrace for Consumer: #e.stackTrace#" );
 			rethrow;
-		}
-		finally {
+		} finally {
 			unLoadContext();
 		}
 	}

--- a/system/async/proxies/Supplier.cfc
+++ b/system/async/proxies/Supplier.cfc
@@ -37,14 +37,12 @@ component extends="BaseProxy" {
 					return invoke( variables.target, variables.method );
 				}
 			}
-		}
-		catch( any e ){
+		} catch ( any e ) {
 			// Log it, so it doesn't go to ether
 			err( "Error running Supplier: #e.message & e.detail#" );
 			err( "Stacktrace for Supplier: #e.stackTrace#" );
 			rethrow;
-		}
-		finally {
+		} finally {
 			unLoadContext();
 		}
 	}

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -493,7 +493,9 @@ component accessors="true" {
 				}
 			} catch ( any afterException ) {
 				// Log it, so it doesn't go to ether and executor doesn't die.
-				err( "Error running task (#getname()#) after/error handlers : #afterException.message & afterException.detail#" );
+				err(
+					"Error running task (#getname()#) after/error handlers : #afterException.message & afterException.detail#"
+				);
 				err( "Stacktrace for task (#getname()#) after/error handlers : #afterException.stackTrace#" );
 			}
 		} finally {

--- a/system/testing/VirtualApp.cfc
+++ b/system/testing/VirtualApp.cfc
@@ -55,7 +55,7 @@ component accessors="true" {
 	 */
 	function startup( boolean force = false ){
 		// Return back if it's already running and not forcing
-		if( isRunning() && !arguments.force ){
+		if ( isRunning() && !arguments.force ) {
 			return application.cbController;
 		}
 
@@ -99,7 +99,7 @@ component accessors="true" {
 	 *
 	 */
 	function getController(){
-		return isRunning() ? application.cbController : javaCast( "null", "" );
+		return isRunning() ? application.cbController : javacast( "null", "" );
 	}
 
 	/**

--- a/system/web/services/InterceptorService.cfc
+++ b/system/web/services/InterceptorService.cfc
@@ -266,6 +266,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 * @point  The interception point from which to unregister the listener
 	 */
 	void function unlisten( required target, required point ){
+		arguments = normalizeListenArguments( argumentCollection = arguments );
 		unregister( "closure-#arguments.point#-#hash( target.toString() )#" );
 	}
 
@@ -276,6 +277,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 * @point  The interception point to register the listener to
 	 */
 	void function listen( required target, required point ){
+		arguments = normalizeListenArguments( argumentCollection = arguments );
 		// Append Custom Points
 		appendInterceptionPoints( arguments.point );
 		// Register the listener
@@ -652,4 +654,21 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 		return pointsFound;
 	}
 
+
+	/**
+	 * Allow point-first arguments when calling listen() or unlisten().
+	 * 
+	 * Basically flips the `target` and `point` arguments if the former is found to be a string instead of closure.
+	 *
+	 * @target Could be the target closure... could be the listen point.
+	 * @point Could be the interception point... could be the target closure
+	 */
+	private struct function normalizeListenArguments( required target, required point ){
+		if ( isValid( "string", arguments.target ) ){
+			var closure = arguments.point;
+			arguments.point = arguments.target;
+			arguments.target = closure;
+		}
+		return arguments;
+	}
 }

--- a/system/web/services/InterceptorService.cfc
+++ b/system/web/services/InterceptorService.cfc
@@ -260,6 +260,16 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	}
 
 	/**
+	 * Unregister the given closure from a specific interception point
+	 *
+	 * @target The closure/lambda to unregister
+	 * @point  The interception point from which to unregister the listener
+	 */
+	void function unlisten( required target, required point ){
+		unregister( "closure-#arguments.point#-#hash( target.toString() )#" );
+	}
+
+	/**
 	 * Register a closure listener as an interceptor on a specific point
 	 *
 	 * @target The closure/lambda to register

--- a/tests/specs/web/services/interceptorserviceTest.cfc
+++ b/tests/specs/web/services/interceptorserviceTest.cfc
@@ -74,11 +74,28 @@
 		assertTrue( called );
 	}
 
+	function testListenArgumentOrder(){
+		var called = false;
+		iService.listen( "onCall", function() { called = true } );
+		iService.announce( "onCall" );
+		assertTrue( called );
+	}
+
 	function testUnlisten(){
 		var called = false;
 		var listener = function() { called = true };
 		iService.listen( listener, "onCall" );
 		iService.unlisten( listener, "onCall" );
+
+		iService.announce( "onCall" );
+		assertFalse( called );
+	}
+
+	function testUnlistenArgumentOrder(){
+		var called = false;
+		var listener = function() { called = true };
+		iService.listen( "onCall", listener );
+		iService.unlisten( "onCall", listener );
 
 		iService.announce( "onCall" );
 		assertFalse( called );

--- a/tests/specs/web/services/interceptorserviceTest.cfc
+++ b/tests/specs/web/services/interceptorserviceTest.cfc
@@ -11,7 +11,9 @@
 			.createEmptyMock( "coldbox.system.web.services.RequestService" )
 			.$( "getContext", mockRequestContext );
 		mockLogBox   = mockBox.createEmptyMock( "coldbox.system.logging.LogBox" );
-		mockLogger   = mockBox.createEmptyMock( "coldbox.system.logging.Logger" );
+		mockLogger   = mockBox
+			.createEmptyMock( "coldbox.system.logging.Logger" )
+			.$( "canDebug", false );
 		mockFlash    = mockBox.createMock( "coldbox.system.web.flash.MockFlash" ).init( mockController );
 		mockCacheBox = mockBox.createEmptyMock( "coldbox.system.cache.CacheFactory" );
 		mockCache    = mockBox.createEmptyMock( "coldbox.system.cache.providers.CacheBoxColdBoxProvider" );
@@ -63,6 +65,23 @@
 		iService.registerInterceptors();
 
 		assertTrue( iService.$count( 1, "registerInterceptor" ) );
+	}
+
+	function testListen(){
+		var called = false;
+		iService.listen( function() { called = true }, "onCall" );
+		iService.announce( "onCall" );
+		assertTrue( called );
+	}
+
+	function testUnlisten(){
+		var called = false;
+		var listener = function() { called = true };
+		iService.listen( listener, "onCall" );
+		iService.unlisten( listener, "onCall" );
+
+		iService.announce( "onCall" );
+		assertFalse( called );
 	}
 
 	function testInterceptionPoints(){

--- a/tests/specs/web/services/interceptorserviceTest.cfc
+++ b/tests/specs/web/services/interceptorserviceTest.cfc
@@ -11,9 +11,7 @@
 			.createEmptyMock( "coldbox.system.web.services.RequestService" )
 			.$( "getContext", mockRequestContext );
 		mockLogBox   = mockBox.createEmptyMock( "coldbox.system.logging.LogBox" );
-		mockLogger   = mockBox
-			.createEmptyMock( "coldbox.system.logging.Logger" )
-			.$( "canDebug", false );
+		mockLogger   = mockBox.createEmptyMock( "coldbox.system.logging.Logger" ).$( "canDebug", false );
 		mockFlash    = mockBox.createMock( "coldbox.system.web.flash.MockFlash" ).init( mockController );
 		mockCacheBox = mockBox.createEmptyMock( "coldbox.system.cache.CacheFactory" );
 		mockCache    = mockBox.createEmptyMock( "coldbox.system.cache.providers.CacheBoxColdBoxProvider" );
@@ -69,7 +67,9 @@
 
 	function testListen(){
 		var called = false;
-		iService.listen( function() { called = true; }, "onCall" );
+		iService.listen( function(){
+			called = true;
+		}, "onCall" );
 		iService.announce( "onCall" );
 		assertTrue( called );
 	}
@@ -82,8 +82,10 @@
 	}
 
 	function testUnlisten(){
-		var called = false;
-		var listener = function() { called = true; };
+		var called   = false;
+		var listener = function(){
+			called = true;
+		};
 		iService.listen( listener, "onCall" );
 		iService.unlisten( listener, "onCall" );
 

--- a/tests/specs/web/services/interceptorserviceTest.cfc
+++ b/tests/specs/web/services/interceptorserviceTest.cfc
@@ -69,7 +69,7 @@
 
 	function testListen(){
 		var called = false;
-		iService.listen( function() { called = true }, "onCall" );
+		iService.listen( function() { called = true; }, "onCall" );
 		iService.announce( "onCall" );
 		assertTrue( called );
 	}
@@ -83,7 +83,7 @@
 
 	function testUnlisten(){
 		var called = false;
-		var listener = function() { called = true };
+		var listener = function() { called = true; };
 		iService.listen( listener, "onCall" );
 		iService.unlisten( listener, "onCall" );
 


### PR DESCRIPTION
I propose we add support for passing the point first and closure second. I think it's weird to pass the event name after the function:

```js
variables.interceptorService.listen( function( interceptData ){
    // do magic...
}, "ORMPreLoad" );
```

IMHO, this is more legible:

```js
variables.interceptorService.listen( "ORMPreLoad", function( interceptData ){
    // do magic...
} );
```

Note: This PR extends #530 . Please address that PR prior to this one.