### PR TITLE
cf-2021 ehcache keys are case sensitive

### DIFF
--- a/system/cache/util/EventURLFacade.cfc
+++ b/system/cache/util/EventURLFacade.cfc
@@ -135,7 +135,7 @@ component accessors="true" {
 	 * @targetEvent The targeted ColdBox event string
 	 */
 	string function buildBasicCacheKey( required keySuffix, required targetEvent ){
-		return lcase(variables.cacheProvider.getEventCacheKeyPrefix() & arguments.targetEvent & "-" & arguments.keySuffix & "-");
+		return lCase( variables.cacheProvider.getEventCacheKeyPrefix() & arguments.targetEvent & "-" & arguments.keySuffix & "-" );
 	}
 
 }

--- a/system/cache/util/EventURLFacade.cfc
+++ b/system/cache/util/EventURLFacade.cfc
@@ -135,7 +135,7 @@ component accessors="true" {
 	 * @targetEvent The targeted ColdBox event string
 	 */
 	string function buildBasicCacheKey( required keySuffix, required targetEvent ){
-		return variables.cacheProvider.getEventCacheKeyPrefix() & arguments.targetEvent & "-" & arguments.keySuffix & "-";
+		return lcase(variables.cacheProvider.getEventCacheKeyPrefix() & arguments.targetEvent & "-" & arguments.keySuffix & "-");
 	}
 
 }


### PR DESCRIPTION
CF-2021 ehCache keys are case sensitive, cache set/get should not be affected by Router.cfc lower or uppercase event-action declaration.