### PR TITLE
COLDBOX-1137 - Allow passing closure as second arg to listen() and unlisten() methods

### DIFF
--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -266,7 +266,9 @@ component serializable="false" accessors="true" {
 				} );
 
 				// Cached Status Code
-				if ( isNumeric( local.refResults.eventCaching.statusCode ) && local.refResults.eventCaching.statusCode > 0 ) {
+				if (
+					isNumeric( local.refResults.eventCaching.statusCode ) && local.refResults.eventCaching.statusCode > 0
+				) {
 					event.setHTTPHeader( statusCode = local.refResults.eventCaching.statusCode );
 				}
 

--- a/system/cache/util/EventURLFacade.cfc
+++ b/system/cache/util/EventURLFacade.cfc
@@ -135,7 +135,9 @@ component accessors="true" {
 	 * @targetEvent The targeted ColdBox event string
 	 */
 	string function buildBasicCacheKey( required keySuffix, required targetEvent ){
-		return lCase( variables.cacheProvider.getEventCacheKeyPrefix() & arguments.targetEvent & "-" & arguments.keySuffix & "-" );
+		return lCase(
+			variables.cacheProvider.getEventCacheKeyPrefix() & arguments.targetEvent & "-" & arguments.keySuffix & "-"
+		);
 	}
 
 }

--- a/system/ioc/Injector.cfc
+++ b/system/ioc/Injector.cfc
@@ -1215,11 +1215,14 @@ component serializable="false" accessors="true" {
 			.each( function( thisMethod ){
 				var delegationMethod = "#delegatePrefix##arguments.thisMethod##delegateSuffix#";
 				// Only add delegate if not overriden
-				if( !structKeyExists( target, delegationMethod ) ){
+				if ( !structKeyExists( target, delegationMethod ) ) {
 					// Lookup targets
-					target.$wbDelegateMap[ delegationMethod ] = { delegate : delegate, method : arguments.thisMethod };
+					target.$wbDelegateMap[ delegationMethod ] = {
+						delegate : delegate,
+						method   : arguments.thisMethod
+					};
 					// inject delegation method to our core
-					target[ delegationMethod ]                = variables.mixerUtil.getByDelegate;
+					target[ delegationMethod ] = variables.mixerUtil.getByDelegate;
 				}
 			} )
 		;

--- a/system/web/services/InterceptorService.cfc
+++ b/system/web/services/InterceptorService.cfc
@@ -268,6 +268,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 * @return True if interception point found and unregistered; else false.
 	 */
 	boolean function unlisten( required target, required point ){
+		arguments = normalizeListenArguments( argumentCollection = arguments );
 		return unregister( "closure-#arguments.point#-#hash( arguments.target.toString() )#" );
 	}
 
@@ -278,6 +279,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 * @point  The interception point to register the listener to
 	 */
 	void function listen( required target, required point ){
+		arguments = normalizeListenArguments( argumentCollection = arguments );
 		// Append Custom Points
 		appendInterceptionPoints( arguments.point );
 		// Register the listener
@@ -286,6 +288,23 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 			state          = arguments.point,
 			oInterceptor   = arguments.target
 		);
+	}
+
+	/**
+	 * Allow point-first arguments when calling listen() or unlisten().
+	 * 
+	 * Basically flips the `target` and `point` arguments if the former is found to be a string instead of closure.
+	 *
+	 * @target Could be the target closure... could be the listen point.
+	 * @point Could be the interception point... could be the target closure
+	 */
+	private struct function normalizeListenArguments( required target, required point ){
+	        if ( isValid( "string", arguments.target ) ){
+	                var closure = arguments.point;
+	                arguments.point = arguments.target;
+	                arguments.target = closure;
+	        }
+	        return arguments;
 	}
 
 	/**

--- a/system/web/services/InterceptorService.cfc
+++ b/system/web/services/InterceptorService.cfc
@@ -292,19 +292,19 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 
 	/**
 	 * Allow point-first arguments when calling listen() or unlisten().
-	 * 
+	 *
 	 * Basically flips the `target` and `point` arguments if the former is found to be a string instead of closure.
 	 *
 	 * @target Could be the target closure... could be the listen point.
-	 * @point Could be the interception point... could be the target closure
+	 * @point  Could be the interception point... could be the target closure
 	 */
 	private struct function normalizeListenArguments( required target, required point ){
-	        if ( isSimpleValue( arguments.target ) ){
-	                var closure = arguments.point;
-	                arguments.point = arguments.target;
-	                arguments.target = closure;
-	        }
-	        return arguments;
+		if ( isSimpleValue( arguments.target ) ) {
+			var closure      = arguments.point;
+			arguments.point  = arguments.target;
+			arguments.target = closure;
+		}
+		return arguments;
 	}
 
 	/**

--- a/system/web/services/InterceptorService.cfc
+++ b/system/web/services/InterceptorService.cfc
@@ -299,7 +299,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	 * @point Could be the interception point... could be the target closure
 	 */
 	private struct function normalizeListenArguments( required target, required point ){
-	        if ( isValid( "string", arguments.target ) ){
+	        if ( isSimpleValue( arguments.target ) ){
 	                var closure = arguments.point;
 	                arguments.point = arguments.target;
 	                arguments.target = closure;

--- a/tests/specs/web/services/interceptorserviceTest.cfc
+++ b/tests/specs/web/services/interceptorserviceTest.cfc
@@ -86,6 +86,27 @@
 		assertFalse( called );
 	}
 
+	function testListenReverseArgumentOrder(){
+		var called = false;
+		iService.listen( "onCall", function(){
+			called = true;
+		} );
+		iService.announce( "onCall" );
+		assertTrue( called );
+	}
+
+	function testUnlistenReverseArgumentOrder(){
+		var called   = false;
+		var listener = function(){
+			called = true;
+		};
+		iService.listen( "onCall", listener );
+		iService.unlisten( "onCall", listener );
+
+		iService.announce( "onCall" );
+		assertFalse( called );
+	}
+
 	function testInterceptionPoints(){
 		// test registration again
 		assertTrue( arrayLen( iService.getInterceptionPoints() ) gt 0 );


### PR DESCRIPTION
I propose we add support for passing the point first and closure second. I think it's weird to pass the event name after the function:

```js
variables.interceptorService.listen( function( interceptData ){
    // do magic...
}, "ORMPreLoad" );
```
IMHO, this is more legible:

```js
variables.interceptorService.listen( "ORMPreLoad", function( interceptData ){
    // do magic...
} );
```

Resolves [COLDBOX-1137](https://ortussolutions.atlassian.net/browse/COLDBOX-1137).