### PR TITLE
WIREBOX-132 - Remove throwing instances from scopes

### DIFF
--- a/system/ioc/scopes/CFScopes.cfc
+++ b/system/ioc/scopes/CFScopes.cfc
@@ -67,8 +67,13 @@ component accessors="true" {
 						variables.injector.getScopeStorage().put( cacheKey, target, CFScope );
 					}
 
-					// wire it
-					variables.injector.autowire( target = target, mapping = arguments.mapping );
+					try {
+						// wire it
+						variables.injector.autowire( target = target, mapping = arguments.mapping );
+					} catch ( any e ) {
+						variables.injector.getScopeStorage().delete( cacheKey, CFScope );
+						rethrow;
+					}
 
 					// If thread safe, then now store it in the scope, as all dependencies are now safely wired
 					if ( arguments.mapping.getThreadSafe() ) {

--- a/system/ioc/scopes/CacheBox.cfc
+++ b/system/ioc/scopes/CacheBox.cfc
@@ -91,8 +91,13 @@ component accessors="true" {
 					);
 				}
 
-				// wire up dependencies on the object
-				variables.injector.autowire( target = local.refLocal.target, mapping = arguments.mapping );
+				try {
+					// wire up dependencies on the object
+					variables.injector.autowire( target = local.refLocal.target, mapping = arguments.mapping );
+				} catch ( any e ) {
+					cacheProvider.clear( cacheKey );
+					rethrow;
+				}
 
 				// If thread safe, then now store it in the cache, as all dependencies are now safely wired
 				if ( arguments.mapping.getThreadSafe() ) {

--- a/system/ioc/scopes/RequestScope.cfc
+++ b/system/ioc/scopes/RequestScope.cfc
@@ -55,8 +55,13 @@ component accessors="true" {
 			var target          = variables.injector.buildInstance( arguments.mapping, arguments.initArguments );
 			request[ cacheKey ] = target;
 
-			// wire it
-			variables.injector.autowire( target = target, mapping = arguments.mapping );
+			try {
+				// wire it
+				variables.injector.autowire( target = target, mapping = arguments.mapping );
+			} catch ( any e ) {
+				structDelete( request, cacheKey );
+				rethrow;
+			}
 
 			// log it
 			if ( variables.log.canDebug() ) {

--- a/system/ioc/scopes/Singleton.cfc
+++ b/system/ioc/scopes/Singleton.cfc
@@ -76,8 +76,13 @@ component accessors="true" {
 						variables.singletons.put( cacheKey, tmpSingleton );
 					}
 
-					// wire up dependencies on the singleton object
-					variables.injector.autowire( target = tmpSingleton, mapping = arguments.mapping );
+					try {
+						// wire up dependencies on the singleton object
+						variables.injector.autowire( target = tmpSingleton, mapping = arguments.mapping );
+					} catch ( any e ) {
+						variables.singletons.remove( cacheKey );
+						rethrow;
+					}
 
 					// If thread safe, then now store it in the singleton cache, as all dependencies are now safely wired
 					if ( arguments.mapping.getThreadSafe() ) {

--- a/tests/specs/ioc/scopes/CFScopesTest.cfc
+++ b/tests/specs/ioc/scopes/CFScopesTest.cfc
@@ -66,6 +66,27 @@
 						expect( o ).toBe( mockStub );
 					} );
 				} );
+
+				given( "An object that fails in autowiring", function(){
+					then( "it should not be stored in the scope", function(){
+						var mapping = createMock( "coldbox.system.ioc.config.Mapping" ).init(
+							name = "CFScopeTest"
+						);
+						mapping.setScope( "session" );
+						mapping.setThreadSafe( false );
+						mockInjector.$( "buildInstance", mockStub );
+						mockInjector
+							.$( "autowire" )
+							.$throws( type = "CustomAutowireError", message = "Error in autowire" );
+						structClear( session );
+
+						expect( function(){
+							scope.getFromScope( mapping, {} );
+						} ).toThrow( "CustomAutowireError" );
+
+						expect( session ).toBeEmpty();
+					} );
+				} );
 			} );
 		} );
 	}

--- a/tests/specs/ioc/scopes/CacheBoxTest.cfc
+++ b/tests/specs/ioc/scopes/CacheBoxTest.cfc
@@ -59,7 +59,7 @@
 		o = scope.getFromScope( mapping, {} );
 	}
 
-	function testSingletonsThatErrorInAutowireAreRemoved(){
+	function testInstancesThatErrorInAutowireAreRemoved(){
 		var mapping = createMock( "coldbox.system.ioc.config.Mapping" ).init( name = "CacheTest" );
 
 		mapping.setCacheProperties(

--- a/tests/specs/ioc/scopes/CacheBoxTest.cfc
+++ b/tests/specs/ioc/scopes/CacheBoxTest.cfc
@@ -58,5 +58,28 @@
 		mockInjector.$( "buildInstance", mockStub ).$( "autowire", mockStub );
 		o = scope.getFromScope( mapping, {} );
 	}
+
+	function testSingletonsThatErrorInAutowireAreRemoved(){
+		var mapping = createMock( "coldbox.system.ioc.config.Mapping" ).init( name = "CacheTest" );
+
+		mapping.setCacheProperties(
+			key      = "CacheTest",
+			timeout  = "",
+			provider = "default"
+		);
+		mapping.setThreadSafe( false );
+		mockCache
+			.$( "get" )
+			.$( "set", true )
+			.$( "clear", true );
+		mockInjector.$( "buildInstance", mockStub );
+		mockInjector.$( "autowire" ).$throws( type = "CustomAutowireError", message = "Error in autowire" );
+
+		expect( function(){
+			scope.getFromScope( mapping, {} );
+		} ).toThrow( "CustomAutowireError" );
+
+		expect( mockCache.$once( "clear" ) ).toBeTrue();
+	}
 	</cfscript>
 </cfcomponent>

--- a/tests/specs/ioc/scopes/RequestScopeTest.cfc
+++ b/tests/specs/ioc/scopes/RequestScopeTest.cfc
@@ -37,6 +37,7 @@
 		mapping.setThreadSafe( true );
 		mockInjector.$( "buildInstance", mockStub );
 		mockInjector.$( "autowire" ).$throws( type = "CustomAutowireError", message = "Error in autowire" );
+		structDelete( request, "wirebox:RequestTest" );
 
 		expect( function(){
 			scope.getFromScope( mapping, {} );

--- a/tests/specs/ioc/scopes/RequestScopeTest.cfc
+++ b/tests/specs/ioc/scopes/RequestScopeTest.cfc
@@ -31,5 +31,18 @@
 		var o = scope.getFromScope( mapping, {} );
 		assertEquals( request[ "wirebox:RequestTest" ], o );
 	}
+
+	function testInstancesThatErrorInAutowireAreRemoved(){
+		var mapping = createMock( "coldbox.system.ioc.config.Mapping" ).init( name = "RequestTest" );
+		mapping.setThreadSafe( true );
+		mockInjector.$( "buildInstance", mockStub );
+		mockInjector.$( "autowire" ).$throws( type = "CustomAutowireError", message = "Error in autowire" );
+
+		expect( function(){
+			scope.getFromScope( mapping, {} );
+		} ).toThrow( "CustomAutowireError" );
+
+		expect( request ).notToHaveKey( "wirebox:RequestTest" );
+	}
 	</cfscript>
 </cfcomponent>

--- a/tests/specs/ioc/scopes/SingletonTest.cfc
+++ b/tests/specs/ioc/scopes/SingletonTest.cfc
@@ -28,7 +28,7 @@
 	function testGetFromScope(){
 		// 1: Default construction
 		var mapping = createMock( "coldbox.system.ioc.config.Mapping" ).init( name = "singletontest" );
-		mapping.setThreadSafe( true );
+		mapping.setThreadSafe( false );
 		mockInjector.$( "buildInstance", mockStub ).$( "autowire", mockStub );
 		var o = scope.getFromScope( mapping, {} );
 
@@ -51,6 +51,17 @@
 		assertTrue( structCount( scope.getSingletons() ) eq 1 );
 		scope.clear();
 		assertTrue( structCount( scope.getSingletons() ) eq 0 );
+	}
+
+	function testSingletonsThatErrorInAutowireAreRemoved(){
+		var mapping = createMock( "coldbox.system.ioc.config.Mapping" ).init( name = "singletontest" );
+		mapping.setThreadSafe( false );
+		mockInjector.$( "buildInstance", mockStub );
+		mockInjector.$( "autowire" ).$throws( type = "CustomAutowireError", message = "Error in autowire" );
+		expect( function(){
+			scope.getFromScope( mapping, {} );
+		} ).toThrow( "CustomAutowireError" );
+		expect( scope.getSingletons() ).toBeEmpty();
 	}
 	</cfscript>
 </cfcomponent>

--- a/tests/specs/ioc/scopes/SingletonTest.cfc
+++ b/tests/specs/ioc/scopes/SingletonTest.cfc
@@ -53,7 +53,7 @@
 		assertTrue( structCount( scope.getSingletons() ) eq 0 );
 	}
 
-	function testSingletonsThatErrorInAutowireAreRemoved(){
+	function testInstancesThatErrorInAutowireAreRemoved(){
 		var mapping = createMock( "coldbox.system.ioc.config.Mapping" ).init( name = "singletontest" );
 		mapping.setThreadSafe( false );
 		mockInjector.$( "buildInstance", mockStub );


### PR DESCRIPTION
Instead of leaving an incorrectly built instance in a persistent scope, this PR removes any instance from it's scope if it throws during autowiring.