### PR TITLE
error wrappers for rest handlers missing exception

### DIFF
--- a/system/RestHandler.cfc
+++ b/system/RestHandler.cfc
@@ -59,10 +59,12 @@ component extends="EventHandler" {
 		}
 		// Auth Issues
 		catch ( "InvalidCredentials" e ) {
+			arguments.exception = e;
 			this.onAuthenticationFailure( argumentCollection = arguments );
 		}
 		// Token Decoding Issues
 		catch ( "TokenInvalidException" e ) {
+			arguments.exception = e;
 			this.onAuthenticationFailure( argumentCollection = arguments );
 		}
 		// Validation Exceptions


### PR DESCRIPTION
RestHandler.cfc missing exception information on InvalidCredentials & TokenInvalidException