### PR TITLE
Support Event.NoRender() in Integration Tests 1151

### DIFF
--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -512,6 +512,10 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 							renderedContent = serializeJSON( handlerResults );
 						}
 					}
+					// Skip rendering if event.noRender is set
+					else if ( requestContext.getPrivateValue( "coldbox_norender", false ) ){
+						renderedContent = "";
+					}
 					// render layout/view pair
 					else {
 						requestContext.setValue( "cbox_statusCode", getNativeStatusCode() );


### PR DESCRIPTION
https://ortussolutions.atlassian.net/browse/COLDBOX-1151

The integration test will fail if you use event.noRender() as it looks for the view file. If you return "" or relocate it works as expected.