### PR TITLE
🤖 TEST: Add experimental builds with the latest Lucee 5.3 beta

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,11 +15,16 @@ jobs:
     env:
       DB_USER: root
       DB_PASSWORD: root
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         cfengine: [ "lucee@5", "adobe@2018", "adobe@2021" ]
         fullNull: [ "true", "false" ]
+        experimental: [false]
+        include:
+          - cfengine: "lucee@5.3-rc"
+            experimental: true
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR will allow us to test ColdBox against the latest Lucee RC or SNAPSHOT without halting the current ColdBox release. This will give us (and Lucee!) early warning against Lucee 5.3.x compatibility issues.