### PR TITLE
Update RestHandler - Implement abort logic onAuthenticationFailure

### DIFF
--- a/system/RestHandler.cfc
+++ b/system/RestHandler.cfc
@@ -171,7 +171,9 @@ component extends="EventHandler" {
 		eventArguments = {}
 	){
 		// Try to discover exception, if not, hard error
-		if ( !isNull( arguments.prc.exception ) && ( isNull( arguments.exception ) || isEmpty( arguments.exception ) ) ) {
+		if (
+			!isNull( arguments.prc.exception ) && ( isNull( arguments.exception ) || isEmpty( arguments.exception ) )
+		) {
 			arguments.exception = arguments.prc.exception.getExceptionStruct();
 		}
 

--- a/system/RestHandler.cfc
+++ b/system/RestHandler.cfc
@@ -391,9 +391,10 @@ component extends="EventHandler" {
 	 * @event     The request context
 	 * @rc        The rc reference
 	 * @prc       The prc reference
+	 * @abort     Hard abort the request if passed, defaults to false
 	 * @exception The thrown exception
 	 *
-	 * @return 403
+	 * @return 401
 	 */
 	function onAuthenticationFailure(
 		event     = getRequestContext(),
@@ -425,6 +426,22 @@ component extends="EventHandler" {
 			.setStatusCode( arguments.event.STATUS.NOT_AUTHENTICATED )
 			.setStatusText( "Invalid or Missing Credentials" )
 			.addMessage( "Invalid or Missing Authentication Credentials" );
+
+		/**
+		 * When you need a really hard stop to prevent further execution ( use as last resort )
+		 */
+		if ( arguments.abort ) {
+			event.setHTTPHeader( name = "Content-Type", value = "application/json" );
+			event.setHTTPHeader(
+				statusCode = "#arguments.event.STATUS.NOT_AUTHENTICATED#",
+				statusText = "Invalid or Missing Credentials"
+			);
+
+			writeOutput( serializeJSON( prc.response.getDataPacket( reset = this.resetDataOnError ) ) );
+
+			flush;
+			abort;
+		}
 	}
 
 	/**


### PR DESCRIPTION
The Method signature had support for the abort, but it did not actually do anything with it. Add param to javadocs, and used the appropriate code from the onAuthorizationFailure Also updated the comment to say it returns a 401.  Confirmed the http status codes struct has the 401 for NOT_AUTHENTICATED not a 403.


Note: should we implement this abort option on all of the rest handler methods? I think its nice, I assumed it did it automatically since some did do it.
I realize module need the flexibility to abort or not. 
I think cbsecurity might expect that behavior to not abort and continue processing.