### PR TITLE
🤖 TEST: Reuse existing controller in getMockRequestContext()

### DIFF
--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -237,10 +237,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 
 		// Create functioning request context
 		mockRC         = getMockBox().createMock( "coldbox.system.web.context.RequestContext" );
-		mockController = createObject( "component", "coldbox.system.testing.mock.web.MockController" ).init(
-			"/unittest",
-			"unitTest"
-		);
+		mockController = !isSimpleValue( variables.controller ) ? variables.controller : getMockController();
 
 		// Create mock properties
 		rcProps.defaultLayout     = "";

--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -237,7 +237,7 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 
 		// Create functioning request context
 		mockRC         = getMockBox().createMock( "coldbox.system.web.context.RequestContext" );
-		mockController = !isSimpleValue( variables.controller ) ? variables.controller : getMockController();
+		mockController = !isSimpleValue( variables.controller ) ? prepareMock( variables.controller ) : getMockController();
 
 		// Create mock properties
 		rcProps.defaultLayout     = "";


### PR DESCRIPTION
This PR improves testing performance by not creating a brand new Controller object each time `getMockRequestContext()` is called if `variables.controller` already exists.