### PR TITLE
👌 IMPROVE: Split CFFormat job into standalone PR workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Direct Commits
+
+on:
+  push:
+    branches-ignore:
+      - "main"
+      - "master"
+      - "development"
+      - "releases/**"
+
+jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - uses: Ortus-Solutions/commandbox-action@v1.0.2
+        with:
+          cmd: run-script format
+
+      - name: Commit Format Changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Apply cfformat changes
+
+  tests:
+    uses: ./.github/workflows/tests.yml
+    secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,35 +1,38 @@
-name: Coldbox Pull Requests
+### ❗ WARNING ❗ ##
+# This workflow runs on the original repo with a a read/write repo token and ALL SECRET ACCESS.
+# AND, it checks out the untrusted PR in order to format it.
+# It is imperative that this workflow only run passive code checks and formats.
+# Any execution of the PR code can potentially access the github api for this repo, send secrets to a pastebin, etc.
+###
+name: Pull Requests
 
 on:
-  push:
-    branches-ignore:
-      - "main"
-      - "master"
-      - "development"
-      - "releases/**"
-  pull_request:
+  pull_request_target:
     branches:
       - development
       - "releases/**"
 
 jobs:
-  tests:
-    uses: ./.github/workflows/tests.yml
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
   format:
     name: Format
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - uses: Ortus-Solutions/commandbox-action@v1.0.2
         with:
-          cmd: run-script format
+          # For security reasons, we use our OWN cfformat command - not trusting the one in the PR
+          cmd: cfformat run system/**/*.cfc,tests/specs/**/*.cfc --overwrite
 
       - name: Commit Format Changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Apply cfformat changes
+
+  tests:
+    uses: ./.github/workflows/tests.yml
+    secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,13 +1,7 @@
-### ❗ WARNING ❗ ##
-# This workflow runs on the original repo with a a read/write repo token and ALL SECRET ACCESS.
-# AND, it checks out the untrusted PR in order to format it.
-# It is imperative that this workflow only run passive code checks and formats.
-# Any execution of the PR code can potentially access the github api for this repo, send secrets to a pastebin, etc.
-###
 name: Pull Requests
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - development
       - "releases/**"
@@ -17,12 +11,11 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-20.04
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-        with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - uses: Ortus-Solutions/commandbox-action@v1.0.2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - development
       - "releases/**"
-      - pr-cfformat-workflow # TESTING!!
+      - patch/pr-cfformat-workflow # TESTING!!
 
 jobs:
   format:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - development
       - "releases/**"
+      - pr-cfformat-workflow # TESTING!!
 
 jobs:
   format:

--- a/system/web/context/ExceptionBean.cfc
+++ b/system/web/context/ExceptionBean.cfc
@@ -282,7 +282,9 @@ component accessors="true" {
 		if ( isSimpleValue( getExtraInfo() ) ) {
 			buffer.append( "CFExtraInfo=" & getExtraInfo() & chr( 13 ) );
 		} else {
-			buffer.append( "CFExtraInfo=" & new coldbox.system.core.util.Util().toJson( getExtraInfo() ) & chr( 13 ) );
+			buffer.append(
+				"CFExtraInfo=" & new coldbox.system.core.util.Util().toJson( getExtraInfo() ) & chr( 13 )
+			);
 		}
 		return buffer.toString();
 	}

--- a/tests/specs/FrameworkSuperTypeTest.cfc
+++ b/tests/specs/FrameworkSuperTypeTest.cfc
@@ -17,28 +17,28 @@ component extends="tests.resources.BaseIntegrationTest" {
 			story( "it can use the back() function to return to the previous URI", function(){
 				given( "no previous referer", function(){
 					then( "it should use the fallback", function(){
-						var fallback = "main.dashboard";
-						var mockContext = getMockRequestContext();
+						var fallback              = "main.dashboard";
+						var mockContext           = getMockRequestContext();
 						mockContext.getHTTPHeader = function( header, defaultValue ){
 							return defaultValue;
 						};
 						target.$( "relocate" ).$( "getRequestContext", mockContext );
 						target.back( fallback );
 						expect( target.$callLog().relocate[ 1 ].url ).toInclude( "dashboard" );
-					});
-				});
+					} );
+				} );
 				given( "a previous referer", function(){
 					then( "it should use the referer", function(){
-						var mockContext = getMockRequestContext();
+						var mockContext           = getMockRequestContext();
 						mockContext.getHTTPHeader = function( header, defaultValue ){
 							return "http://localhost/luis/majano";
 						};
 						target.$( "relocate" ).$( "getRequestContext", mockContext );
 						target.back();
 						expect( target.$callLog().relocate[ 1 ].url ).toInclude( "majano" );
-					});
-				});
-			});
+					} );
+				} );
+			} );
 
 			story( "should encode data for binding to html attributes", function(){
 				given( "a simple value", function(){


### PR DESCRIPTION
This PR fixes the broken CFFormat workflow when running on pull requests.

Using the `pull_request_target` event runs the workflow under the target repo with a read/write repo token and secret access. This is a security concern if we execute any of the untrusted code... but with careful attention this is an acceptable solution to formatting the code. ([Github suggests it in their blog on preventing PWN requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).)