### PR TITLE
🐛 FIX: Ignore lazy ORM properties

### DIFF
--- a/system/ioc/config/Mapping.cfc
+++ b/system/ioc/config/Mapping.cfc
@@ -935,7 +935,9 @@ component accessors="true" {
 		// Lazy processes
 		var isLazy         = arguments.metadata.keyExists( "lazy" );
 		var isLazyUnlocked = arguments.metadata.keyExists( "lazyNoLock" );
-		var isORMProperty  = ( arguments.metadata.keyExists( "persistent" ) && arguments.metadata.persistent ) || arguments.metadata.keyExists( "fieldtype" );
+		var isORMProperty  = ( arguments.metadata.keyExists( "persistent" ) && arguments.metadata.persistent ) || arguments.metadata.keyExists(
+			"fieldtype"
+		);
 		if ( ( isLazy || isLazyUnlocked ) && !isORMProperty ) {
 			// Detect Builder Name
 			var builderName = "";

--- a/system/ioc/config/Mapping.cfc
+++ b/system/ioc/config/Mapping.cfc
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
@@ -934,8 +934,9 @@ component accessors="true" {
 
 		// Lazy processes
 		var isLazy         = arguments.metadata.keyExists( "lazy" );
-		var isLazyUnlocked = arguments.metadata.keyExists( "lazyNoLock" )
-		if ( isLazy || isLazyUnlocked ) {
+		var isLazyUnlocked = arguments.metadata.keyExists( "lazyNoLock" );
+		var isORMProperty  = ( arguments.metadata.keyExists( "persistent" ) && arguments.metadata.persistent ) || arguments.metadata.keyExists( "fieldtype" );
+		if ( ( isLazy || isLazyUnlocked ) && !isORMProperty ) {
 			// Detect Builder Name
 			var builderName = "";
 			if ( isLazy && len( arguments.metadata.lazy ) ) {

--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -19,7 +19,7 @@ component
 	 ****************************************************************/
 
 	property name="templateCache" inject="cachebox:template";
-	property name="htmlHelper" inject="provider:@HTMLHelper";
+	property name="htmlHelper"    inject="provider:@HTMLHelper";
 
 	/****************************************************************
 	 * Rendering Properties *


### PR DESCRIPTION
Resolves lazy property evaluation errors on lazy-loaded Hibernate ORM properties, such as the following:

```js
property name="createdBy" 
            fieldtype="many-to-one" 
            cfc="User" 
            fkcolumn="FK_creationUser"
            insert="true"
            update="false"
            lazy="true"
            persistent=true;
```