### PR TITLE
Remove use of deprecated methods internally

### DIFF
--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -215,7 +215,7 @@ component serializable="false" accessors="true" {
 	 */
 	function processColdBoxRequest() output="true"{
 		// Get Controller Reference
-		var cbController = application[ locateAppKey() ];
+		var cbController       = application[ locateAppKey() ];
 		// Local references
 		var interceptorService = cbController.getInterceptorService();
 		var cacheBox           = cbController.getCacheBox();

--- a/system/FrameworkSupertype.cfc
+++ b/system/FrameworkSupertype.cfc
@@ -226,7 +226,7 @@ component serializable="false" accessors="true" {
 		viewModule            = "",
 		boolean prePostExempt = false
 	) cbMethod{
-		return variables.controller.getRenderer().renderLayout( argumentCollection = arguments );
+		return variables.controller.getRenderer().layout( argumentCollection = arguments );
 	}
 
 	/****************************************************************

--- a/system/web/services/LoaderService.cfc
+++ b/system/web/services/LoaderService.cfc
@@ -39,7 +39,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 		// Prep services
 		var coldBoxSettings = variables.controller.getColdBoxSettings();
 		var services        = variables.controller.getServices();
-		var configSettings = variables.controller.getConfigSettings();
+		var configSettings  = variables.controller.getConfigSettings();
 
 		// Do we need to create a controller decorator?
 		if ( len( configSettings.controllerDecorator ) ) {
@@ -73,9 +73,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 		}
 
 		// Auto Map Root Models
-		if (
-			configSettings.autoMapModels && directoryExists( configSettings.modelsPath )
-		) {
+		if ( configSettings.autoMapModels && directoryExists( configSettings.modelsPath ) ) {
 			variables.controller
 				.getWireBox()
 				.getBinder()

--- a/tests/suites/loadtests/6load/layouts/Main.cfm
+++ b/tests/suites/loadtests/6load/layouts/Main.cfm
@@ -157,7 +157,7 @@
 
 		<!---Container And Views --->
 		<main class="flex-shrink-0">
-			#renderView()#
+			#view()#
 		</main>
 
 		<!--- Footer --->


### PR DESCRIPTION
Remove the use of `renderLayout` by `layout` which was logging errors