### PR TITLE
Patch/2021-Test-Failures

### DIFF
--- a/box.json
+++ b/box.json
@@ -50,7 +50,6 @@
         "format:watch":"cfformat watch system/**/*.cfc,tests/specs/**/*.cfc ./.cfformat.json",
         "format:check":"cfformat check system/**/*.cfc,tests/specs/**/*.cfc",
         "log":"server log --follow",
-        "onServerInstall":"cfpm install zip,orm,mysql,postgresql,sqlserver,document,feed,mail,debugger",
         "start:lucee":"server start serverConfigFile='server-lucee@5.json' --force",
         "start:2018":"server start serverConfigFile='server-adobe@2018.json' --force",
         "start:2021":"server start serverConfigFile='server-adobe@2021.json' --force",

--- a/server-adobe@2021.json
+++ b/server-adobe@2021.json
@@ -23,5 +23,8 @@
     },
 	"cfconfig": {
 		"file" : ".cfconfig.json"
+	},
+	"scripts" : {
+		"onServerInstall":"cfpm install zip,orm,mysql,postgresql,sqlserver,document,feed,mail,debugger"
 	}
 }


### PR DESCRIPTION
- moves `onServerInstall` to ACF 2021 server.json as it is now supported there
Fixes failing null support tests on ACF 2021