### PR TITLE
🐛 FIX: Update GHA dependencies to drop deprecated syntax

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: taiki-e/create-gh-release-action@v1.5.0
+      - uses: taiki-e/create-gh-release-action@v1.6.1
         with:
           # Produced by the build/Build.cfc
           changelog: changelog.md

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
           printf "DB_BUNDLENAME=com.mysql.cj\n" >> .env
 
       - name: Cache CommandBox Dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         if: ${{ true }}
         with:
           path: ~/.CommandBox/artifacts
@@ -88,7 +88,7 @@ jobs:
         run: echo "CFENGINE_VERSION=$(box echo ${serverInfo.engineName@coldbox-${{ matrix.cfengine }}}@${serverInfo.engineVersion@coldbox-${{ matrix.cfengine }}})" >> $GITHUB_ENV
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: tests/results/**/*.xml

--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -22,12 +22,12 @@ component
 	 ****************************************************************/
 
 	property
-		name    ="cachebox"
+		name    ="cachebox"  
 		inject  ="cachebox"
 		delegate="getCache";
 	property
 		name    ="controller"
-		inject  ="coldbox"
+		inject  ="coldbox" 
 		delegate="relocate,runEvent,runRoute";
 	property name="flash"  inject="coldbox:flash";
 	property name="logBox" inject="logbox";
@@ -2041,7 +2041,11 @@ component
 				.getContext()
 				.isSSL() ? "https://" : "http://"
 		) &
-		( headers.keyExists( "x-forwarded-host" ) && len( headers[ "x-forwarded-host" ] ) ? headers[ "x-forwarded-host" ] : CGI.HTTP_HOST ) & // multi-host
+		(
+			headers.keyExists( "x-forwarded-host" ) && len( headers[ "x-forwarded-host" ] ) ? headers[
+				"x-forwarded-host"
+			] : CGI.HTTP_HOST
+		) & // multi-host
 		composeRoutingPath(); // Routing Path
 	}
 

--- a/tests/specs/testing/BaseInterceptorTest.cfc
+++ b/tests/specs/testing/BaseInterceptorTest.cfc
@@ -1,22 +1,20 @@
 /**
  * Baser Interceptor Test
  */
-component extends="coldbox.system.testing.BaseInterceptorTest" interceptor="cbtestharness.interceptors.Test1"{
+component extends="coldbox.system.testing.BaseInterceptorTest" interceptor="cbtestharness.interceptors.Test1" {
 
-/*********************************** LIFE CYCLE Methods ***********************************/
+	/*********************************** LIFE CYCLE Methods ***********************************/
 
 	/**
 	 * executes before all suites+specs in the run() method
 	 */
 	function beforeAll(){
-
 	}
 
 	/**
 	 * executes after all suites+specs in the run() method
 	 */
 	function afterAll(){
-
 	}
 
 	/*********************************** BDD SUITES ***********************************/
@@ -24,15 +22,13 @@ component extends="coldbox.system.testing.BaseInterceptorTest" interceptor="cbte
 	function run( testResults, testBox ){
 		// all your suites go here.
 		describe( "Test 1 Interceptor Test", function(){
-
-			beforeEach(function( currentSpec ){
+			beforeEach( function( currentSpec ){
 				setup();
-			});
+			} );
 
 			it( "It can be created", function(){
 				expect( interceptor ).toBeComponent();
 			} );
-
 		} );
 	}
 


### PR DESCRIPTION
Updates for deprecated syntax in older versions of third-party actions:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/