### PR TITLE
Add a helper method to encapsulate requesttimeout to improve testing …

### DIFF
--- a/system/FrameworkSupertype.cfc
+++ b/system/FrameworkSupertype.cfc
@@ -692,7 +692,9 @@ component serializable="false" accessors="true" {
 	 */
 	DateTimeHelper function getDateTimeHelper(){
 		if ( isNull( variables.cbDateTimeHelper ) ) {
-			variables.cbDateTimeHelper = variables.wirebox.getInstance( "coldbox.system.async.time.DateTimeHelper" );
+			variables.cbDateTimeHelper = variables.wirebox.getInstance(
+				"coldbox.system.async.time.DateTimeHelper"
+			);
 		}
 		return cbDateTimeHelper;
 	}

--- a/system/testing/mock/web/MockController.cfc
+++ b/system/testing/mock/web/MockController.cfc
@@ -66,4 +66,5 @@ component extends="coldbox.system.web.Controller" accessors="true" {
 	function setRequestTimeout( numberOfSeconds ){
 		// Ignore timeouts while running tests
 	}
+
 }

--- a/system/testing/mock/web/MockController.cfc
+++ b/system/testing/mock/web/MockController.cfc
@@ -62,4 +62,8 @@ component extends="coldbox.system.web.Controller" accessors="true" {
 		throw( message = "Relocating via relocate", type = "TestController.relocate" );
 	}
 
+	// Encapsulate a cfsettings requesttimeout. Encapsulated so we can ignore it for tests so it does not change the timeout of the test runner
+	function setRequestTimeout( numberOfSeconds ){
+		// Ignore timeouts while running tests
+	}
 }

--- a/system/web/Controller.cfc
+++ b/system/web/Controller.cfc
@@ -1260,6 +1260,11 @@ component serializable="false" accessors="true" {
 		return this;
 	}
 
+	// Encapsulate a cfsettings requesttimeout. Encapsulated so we can ignore it for tests so it does not change the timeout of the test runner
+	function setRequestTimeout( numberOfSeconds ){
+		setting requesttimeout=numberOfSeconds;
+	}
+
 	/**
 	 * Update SSL or not on a request string
 	 */


### PR DESCRIPTION
What do you think about adding a helper method to encapsulate requesttimeout to improve testing consistency.

Sometimes we're adding `setting requesttimeout=300` etc and it of course overrides the test runners timeout.
Resetting it in the beforeall() or beforeEach seems too hacky, thinking it might be a nice framework helper.

Thoughts?