### PR TITLE
Fix rev-manifest references in submodules

### DIFF
--- a/system/FrameworkSupertype.cfc
+++ b/system/FrameworkSupertype.cfc
@@ -692,7 +692,9 @@ component serializable="false" accessors="true" {
 	 */
 	DateTimeHelper function getDateTimeHelper(){
 		if ( isNull( variables.cbDateTimeHelper ) ) {
-			variables.cbDateTimeHelper = variables.wirebox.getInstance( "coldbox.system.async.time.DateTimeHelper" );
+			variables.cbDateTimeHelper = variables.wirebox.getInstance(
+				"coldbox.system.async.time.DateTimeHelper"
+			);
 		}
 		return cbDateTimeHelper;
 	}

--- a/system/modules/HTMLHelper/models/HTMLHelper.cfc
+++ b/system/modules/HTMLHelper/models/HTMLHelper.cfc
@@ -2561,7 +2561,8 @@ component
 		);
 
 		// Calculate href for asset delivery via Browser
-		var href = "/#includesLocation#/#arguments.fileName#";
+		// if the filename begins with modules_app they want an asset from a module, not the includes dir
+		var href = "/" & ( left( arguments.fileName , 12 ) != 'modules_app/' ? includesLocation & '/' : '' ) & arguments.fileName;
 		var key  = reReplace( href, "^//?", "" );
 		if ( mapping.len() ) {
 			var href = "/#mapping#/#includesLocation#/#arguments.fileName#";

--- a/system/modules/HTMLHelper/models/HTMLHelper.cfc
+++ b/system/modules/HTMLHelper/models/HTMLHelper.cfc
@@ -2562,7 +2562,7 @@ component
 
 		// Calculate href for asset delivery via Browser
 		// if the filename begins with modules_app they want an asset from a module, not the includes dir
-		var href = "/" & ( left( arguments.fileName , 12 ) != 'modules_app/' ? includesLocation & '/' : '' ) & arguments.fileName;
+		var href = "/" & ( left( arguments.fileName, 12 ) != "modules_app/" ? includesLocation & "/" : "" ) & arguments.fileName;
 		var key  = reReplace( href, "^//?", "" );
 		if ( mapping.len() ) {
 			var href = "/#mapping#/#includesLocation#/#arguments.fileName#";


### PR DESCRIPTION
Forcing the "includes" location to the beginning of the asset path will break links to assets in sub modules. See issue for details