### PR TITLE
🐛 FIX: Fix JAXBContext classloader error on CommandBox < 5.8

### DIFF
--- a/test-harness/config/ApplicationMixins.cfm
+++ b/test-harness/config/ApplicationMixins.cfm
@@ -1,5 +1,18 @@
 <cfscript>
 
+	/**
+	 * Fixes JAXBContext classloader issue with Lucee running the Hibernate 5.4 extension on CommandBox.
+	 * 
+	 * Can remove this If and Only If:
+	 * a) Lucee gets their act together, or 
+	 * b) everyone upgrades to CommandBox 5.8.x or newer.
+	 */
+	createObject( "java", "java.lang.System" )
+			.setProperty(
+				"javax.xml.bind.context.factory", 
+				"com.sun.xml.bind.v2.ContextFactory"
+			);
+
 	// Lucee 5 Cache Definition
 	this.cache.connections[ "default" ] = {
 		  "class" = 'lucee.runtime.cache.ram.RamCache'


### PR DESCRIPTION
## Description

This PR adds a workaround for the Lucee Hibernate ORM startup error: "Could not parse mapping document: null (INPUT_STREAM)".

It is not possible to start up the ColdBox test app or any ColdBox app with ORM enabled, if both of the following are true:

1. The Lucee Hibernate extension v5.4+ is installed
2. The user is on CommandBox pre-5.8.0.

Note this PR solves the issue in the tests, NOT in the main app.

See https://luceeserver.atlassian.net/browse/LDEV-4276

## Jira Issues

* Lucee bug tracker: https://luceeserver.atlassian.net/browse/LDEV-4276

## Type of change

This is a workaround for a Lucee (or, possibly, CommandBox) bug.

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
