### PR TITLE
Patch/lucee 6 hibernate jaxb context classloader

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup CommandBox CLI
         uses: Ortus-Solutions/setup-commandbox@v2.0.1
         with:
-          version: 5.7.0
+          version: 5.6.1
 
       - name: Setup .env For Runner
         run: |

--- a/system/core/util/Util.cfc
+++ b/system/core/util/Util.cfc
@@ -432,6 +432,8 @@ component {
 
 		// Override ourselves into parent
 		for ( var thisKey in arguments.md ) {
+			// https://luceeserver.atlassian.net/browse/LDEV-4421
+			if ( arrayContains( ["sub", "subname" ], thisKey ) ){ continue; }
 			// Functions and properties are an array of structs keyed on name, so I can treat them the same
 			if ( listFindNoCase( "functions,properties", thisKey ) ) {
 				if ( !structKeyExists( loc.parent, thisKey ) ) {

--- a/test-harness/config/ApplicationMixins.cfm
+++ b/test-harness/config/ApplicationMixins.cfm
@@ -1,5 +1,18 @@
 <cfscript>
 
+	/**
+	 * Fixes JAXBContext classloader issue with Lucee running the Hibernate 5.4 extension on CommandBox.
+	 * 
+	 * Can remove this If and Only If:
+	 * a) Lucee gets their act together, or 
+	 * b) everyone upgrades to CommandBox 5.8.x or newer.
+	 */
+	createObject( "java", "java.lang.System" )
+			.setProperty(
+				"javax.xml.bind.context.factory", 
+				"com.sun.xml.bind.v2.ContextFactory"
+			);
+
 	// Lucee 5 Cache Definition
 	this.cache.connections[ "default" ] = {
 		  "class" = 'lucee.runtime.cache.ram.RamCache'

--- a/tests/resources/BaseIntegrationTest.cfc
+++ b/tests/resources/BaseIntegrationTest.cfc
@@ -72,6 +72,14 @@ component
 		return server.keyExists( "lucee" );
 	}
 
+	function isLucee6(){
+		return server.keyExists( "lucee" ) && left( server.lucee.version, 1 ) == 6;
+	}
+
+	function noWSDLSupport(){
+		return isAdobe() || isLucee6();
+	}
+
 	function shutdownColdBox(){
 		getColdBoxVirtualApp().shutdown();
 	}

--- a/tests/specs/core/collections/ScopeStorageTest.cfc
+++ b/tests/specs/core/collections/ScopeStorageTest.cfc
@@ -20,6 +20,11 @@
 		server.luis = "cool";
 		assertTrue( scope.delete( "luis", "server" ) );
 
+		// https://luceeserver.atlassian.net/browse/LDEV-4423
+		if ( isLucee6() ){
+			writeOutput( "--- SKIPPED for Lucee 6 --- " );
+			return;
+		}
 		assertFalse( scope.delete( "luis", "server" ) );
 		</cfscript>
 	</cffunction>
@@ -61,6 +66,12 @@
 		scope.getScope( "server" );
 		scope.getScope( "client" );
 		scope.getScope( "cookie" );
+		</cfscript>
+	</cffunction>
+
+	<cffunction name="isLucee6">
+		<cfscript>
+			return server.keyExists( "lucee" ) && left( server.lucee.version, 1 ) == 6;
 		</cfscript>
 	</cffunction>
 </cfcomponent>

--- a/tests/specs/core/collections/ScopeStorageTest.cfc
+++ b/tests/specs/core/collections/ScopeStorageTest.cfc
@@ -21,7 +21,7 @@
 		assertTrue( scope.delete( "luis", "server" ) );
 
 		// https://luceeserver.atlassian.net/browse/LDEV-4423
-		if ( isLucee6() ){
+		if ( isLucee6() ) {
 			writeOutput( "--- SKIPPED for Lucee 6 --- " );
 			return;
 		}
@@ -71,7 +71,7 @@
 
 	<cffunction name="isLucee6">
 		<cfscript>
-			return server.keyExists( "lucee" ) && left( server.lucee.version, 1 ) == 6;
+		return server.keyExists( "lucee" ) && left( server.lucee.version, 1 ) == 6;
 		</cfscript>
 	</cffunction>
 </cfcomponent>

--- a/tests/specs/ioc/BuilderTest.cfc
+++ b/tests/specs/ioc/BuilderTest.cfc
@@ -60,7 +60,7 @@
 		// debug(r);
 	}
 
-	function testbuildWebservice() skip="isAdobe"{
+	function testbuildWebservice() skip="noWSDLSupport"{
 		mapping = createMock( "coldbox.system.ioc.config.Mapping" ).init( "Buffer" );
 		mapping.setPath( "http://localhost:8599/test-harness/remote/Echo.cfc?wsdl" );
 		r = builder.buildwebservice( mapping );

--- a/tests/specs/ioc/InjectorCreationTest.cfc
+++ b/tests/specs/ioc/InjectorCreationTest.cfc
@@ -139,7 +139,7 @@
 		assertTrue( len( prop ) );
 	}
 
-	function testWebService() skip="isAdobe"{
+	function testWebService() skip="noWSDLSupport"{
 		ws = injector.getInstance( "coldboxWS" );
 
 		//


### PR DESCRIPTION
## Description

Updates test suite for Lucee 6 compatibility.

Fixes:

* Webservice (WSDL) tests break in Lucee 6
* Metadata looping breaks in Lucee 6 - [LDEV-4421](https://luceeserver.atlassian.net/browse/LDEV-4421)

## Type of change

Please delete options that are not relevant.

- [x] Improvement

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] New and existing unit tests pass locally with my changes
