### PR TITLE
ACF2023 Compat Update

### DIFF
--- a/system/cache/providers/CFProvider.cfc
+++ b/system/cache/providers/CFProvider.cfc
@@ -180,6 +180,7 @@ component
 
 	/**
 	 * Clear the cache statistics
+	 * NOT IMPLEMENTED FOR ACF 2016+
 	 *
 	 * @return ICacheProvider
 	 */
@@ -297,7 +298,7 @@ component
 	 * @objectKey The key to retrieve
 	 */
 	function getQuiet( required objectKey ){
-		return getObjectStore().getQuiet( uCase( arguments.objectKey ) );
+		return getObjectStore().getQuiet( arguments.objectKey );
 	}
 
 	/**
@@ -482,7 +483,7 @@ component
 	 * @objectKey The object cache key
 	 */
 	boolean function clearQuiet( required objectKey ){
-		if ( listFind( "2018,2021", server.coldfusion.productVersion.listFirst() ) ) {
+		if ( listFind( "2018,2021,2023", server.coldfusion.productVersion.listFirst() ) ) {
 			return getObjectStore().removeQuiet( arguments.objectKey );
 		} else {
 			return getObjectStore().removeQuiet( uCase( arguments.objectKey ) );
@@ -537,3 +538,4 @@ component
 	}
 
 }
+

--- a/system/cache/providers/CFProvider.cfc
+++ b/system/cache/providers/CFProvider.cfc
@@ -180,7 +180,6 @@ component
 
 	/**
 	 * Clear the cache statistics
-	 * NOT IMPLEMENTED FOR ACF 2016+
 	 *
 	 * @return ICacheProvider
 	 */

--- a/system/cache/providers/CFProvider.cfc
+++ b/system/cache/providers/CFProvider.cfc
@@ -297,16 +297,7 @@ component
 	 * @objectKey The key to retrieve
 	 */
 	function getQuiet( required objectKey ){
-		// Don't touch the casing on 2018+
-		if ( listFind( "2018,2021", server.coldfusion.productVersion.listFirst() ) ) {
-			var element = getObjectStore().getQuiet( arguments.objectKey );
-		} else {
-			var element = getObjectStore().getQuiet( uCase( arguments.objectKey ) );
-		}
-
-		if ( !isNull( local.element ) ) {
-			return element.getValue();
-		}
+		return getObjectStore().getQuiet( uCase( arguments.objectKey ) );
 	}
 
 	/**

--- a/system/cache/providers/CFProvider.cfc
+++ b/system/cache/providers/CFProvider.cfc
@@ -483,11 +483,7 @@ component
 	 * @objectKey The object cache key
 	 */
 	boolean function clearQuiet( required objectKey ){
-		if ( listFind( "2018,2021,2023", server.coldfusion.productVersion.listFirst() ) ) {
-			return getObjectStore().removeQuiet( arguments.objectKey );
-		} else {
-			return getObjectStore().removeQuiet( uCase( arguments.objectKey ) );
-		}
+		return getObjectStore().removeQuiet( arguments.objectKey );
 	}
 
 	/**


### PR DESCRIPTION
Remove ACF version checks in CFProvider as 2023 was not listed and we no longer support anything less than 2018.