### PR TITLE
ColdBox Scheduled Tasks Updates

### DIFF
--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -1869,8 +1869,8 @@ component accessors="true" {
 	 */
 	function debugLog( required string caller, struct args = {} ){
 		if ( variables.debug ) {
-			var message = dateTimeFormat(now(),"yyyy-mm-dd hh:nn:ss") &
-				" : ScheduledTask : " & variables.name & " : " & arguments.caller & "()" & (
+			var message = dateTimeFormat( now(), "yyyy-mm-dd hh:nn:ss" ) &
+			" : ScheduledTask : " & variables.name & " : " & arguments.caller & "()" & (
 				structIsEmpty( arguments.args ) ? "" : " : " & serializeJSON( arguments.args )
 			);
 			variables.executor.out( message );

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -506,9 +506,13 @@ component accessors="true" {
 	 * - when
 	 * - dayOfTheMonth
 	 * - dayOfTheWeek
+	 * - firstBusinessDay
 	 * - lastBusinessDay
-	 * - weekends
 	 * - weekdays
+	 * - weekends
+	 * - startOnDateTime
+	 * - endOnDateTime
+	 * - startTime and/or endTime
 	 *
 	 * This method is called by the `run()` method at runtime to determine if the task can be ran at that point in time
 	 */
@@ -537,6 +541,14 @@ component accessors="true" {
 			return true;
 		}
 
+		// Do we have day of the week?
+		if (
+			variables.dayOfTheWeek > 0 &&
+			now.getDayOfWeek().getValue() != variables.dayOfTheWeek
+		) {
+			return true;
+		}
+
 		// Do we have a first business day constraint
 		if (
 			variables.firstBusinessDay &&
@@ -553,14 +565,6 @@ component accessors="true" {
 			return true;
 		}
 
-		// Do we have weekends?
-		if (
-			variables.weekends &&
-			now.getDayOfWeek().getValue() <= 5
-		) {
-			return true;
-		}
-
 		// Do we have weekdays?
 		if (
 			variables.weekdays &&
@@ -569,10 +573,10 @@ component accessors="true" {
 			return true;
 		}
 
-		// Do we have day of the week?
+		// Do we have weekends?
 		if (
-			variables.dayOfTheWeek > 0 &&
-			now.getDayOfWeek().getValue() != variables.dayOfTheWeek
+			variables.weekends &&
+			now.getDayOfWeek().getValue() <= 5
 		) {
 			return true;
 		}
@@ -585,7 +589,7 @@ component accessors="true" {
 			return true;
 		}
 
-		// Do we have a end on constraint
+		// Do we have an end on constraint
 		if (
 			len( variables.endOnDateTime ) &&
 			now.isAfter( variables.endOnDateTime )
@@ -593,7 +597,7 @@ component accessors="true" {
 			return true;
 		}
 
-		// if we have a start time and / or end time constraint
+		// Do we have we have a start time and / or end time constraint
 		if (
 			len( variables.startTime ) ||
 			len( variables.endTime )

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -1713,7 +1713,9 @@ component accessors="true" {
 			true
 		);
 		// Set the period to be every hour in seconds
-		variables.period   = variables.timeUnitHelper.get( arguments.period ).toSeconds( arguments.periodMultiplier );
+		variables.period = variables.timeUnitHelper
+			.get( arguments.periodValue )
+			.toSeconds( arguments.periodMultiplier );
 		variables.timeUnit = "seconds";
 	}
 

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -1869,7 +1869,8 @@ component accessors="true" {
 	 */
 	function debugLog( required string caller, struct args = {} ){
 		if ( variables.debug ) {
-			var message = "ScheduledTask : " & variables.name & " : " & arguments.caller & "()" & (
+			var message = dateTimeFormat(now(),"yyyy-mm-dd hh:nn:ss") &
+				" : ScheduledTask : " & variables.name & " : " & arguments.caller & "()" & (
 				structIsEmpty( arguments.args ) ? "" : " : " & serializeJSON( arguments.args )
 			);
 			variables.executor.out( message );

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -7,9 +7,29 @@
 component accessors="true" {
 
 	/**
+	 * The human name of this task
+	 */
+	property name="name";
+
+	/**
+	 * The task closure or CFC to execute in the task
+	 */
+	property name="task";
+
+	/**
+	 * The method to execute if the task is a CFC
+	 */
+	property name="method";
+
+	/**
 	 * The delay or time to wait before we execute the task in the scheduler
 	 */
 	property name="delay" type="numeric";
+
+	/**
+	 * The time unit string used when there is a delay requested for the task
+	 */
+	property name="delayTimeUnit";
 
 	/**
 	 * A fixed time period of execution of the tasks in this schedule. It does not wait for tasks to finish,
@@ -25,22 +45,17 @@ component accessors="true" {
 	/**
 	 * The time unit string used to schedule the task
 	 */
-	property name="timeunit";
+	property name="timeUnit";
 
 	/**
-	 * The task closure or CFC to execute in the task
+	 * A handy boolean that is set when the task is annually scheduled
 	 */
-	property name="task";
+	property name="annually" type="boolean";
 
 	/**
-	 * The method to execute if the task is a CFC
+	 * The boolean value is used for debugging
 	 */
-	property name="method";
-
-	/**
-	 * The human name of this task
-	 */
-	property name="name";
+	property name="debugEnabled";
 
 	/**
 	 * A handy boolean that disables the scheduling of this task
@@ -54,9 +69,73 @@ component accessors="true" {
 	property name="whenClosure" type="any";
 
 	/**
-	 * The timezone this task runs under, by default we use the timezone defined in the schedulers
+	 * Constraint of what day of the month we need to run on: 1-31
 	 */
-	property name="timezone";
+	property name="dayOfTheMonth" type="numeric";
+
+	/**
+	 * Constraint of what day of the week this runs on: 1-7
+	 */
+	property name="dayOfTheWeek" type="numeric";
+
+	/**
+	 * Constraint to run only on weekends
+	 */
+	property name="weekends" type="boolean";
+
+	/**
+	 * Constraint to run only on weekdays
+	 */
+	property name="weekdays" type="boolean";
+
+	/**
+	 * Constraint to run only on the first business day of the month
+	 */
+	property name="firstBusinessDay" type="boolean";
+
+	/**
+	 * Constraint to run only on the last business day of the month
+	 */
+	property name="lastBusinessDay" type="boolean";
+
+	/**
+	 * By default tasks execute in an interval frequency which can cause tasks to
+	 * stack if they take longer than their periods ( fire immediately after completion ).
+	 * With this boolean flag turned on, the schedulers don't kick off the
+	 * intervals until the tasks finish executing. Meaning no stacking.
+	 */
+	property name="noOverlaps" type="boolean";
+
+	/**
+	 * Used by first and last business day constraints to
+	 * log the time of day for use in setNextRunTime()
+	 */
+	property name="taskTime" type="string";
+
+	/**
+	 * Constraint of when the task can start execution.
+	 */
+	property name="startOnDateTime";
+
+	/**
+	 * Constraint of when the task must not continue to execute
+	 */
+	property name="endOnDateTime";
+
+	/**
+	 * Constraint to limit the task to run after a specified time of day.
+	 */
+	property name="startTime";
+
+	/**
+	 * Constraint to limit the task to run before a specified time of day.
+	 */
+	property name="endTime";
+
+	/**
+	 * The boolean value that lets us know if this task has been scheduled
+	 */
+	property name="scheduled";
 
 	/**
 	 * This task can be assigned to a task scheduler or be executed on its own at runtime
@@ -64,9 +143,14 @@ component accessors="true" {
 	property name="scheduler";
 
 	/**
-	 * The collection of stats for the task: { created, lastRun, totalRuns, totalFailures, totalSuccess, lastResult, neverRun, lastExecutionTime }
+	 * The collection of stats for the task: { name, created, lastRun, nextRun, totalRuns, totalFailures, totalSuccess, lastResult, neverRun, lastExecutionTime }
 	 */
 	property name="stats" type="struct";
+
+	/**
+	 * The timezone this task runs under, by default we use the timezone defined in the schedulers
+	 */
+	property name="timezone";
 
 	/**
 	 * The before task closure
@@ -88,48 +172,6 @@ component accessors="true" {
 	 */
 	property name="onTaskFailure";
 
-	/**
-	 * The constraint of what day of the month we need to run on: 1-31
-	 */
-	property name="dayOfTheMonth" type="numeric";
-
-	/**
-	 * The constraint of what day of the week this runs on: 1-7
-	 */
-	property name="dayOfTheWeek" type="numeric";
-
-	/**
-	 * Constraint to run only on weekends
-	 */
-	property name="weekends" type="boolean";
-
-	/**
-	 * Constraint to run only on weekdays
-	 */
-	property name="weekdays" type="boolean";
-
-	/**
-	 * Constraint to run only on the last business day of the month
-	 */
-	property name="lastBusinessDay" type="boolean";
-
-	/**
-	 * By default tasks execute in an interval frequency which can cause overlaps if tasks
-	 * take longer than their periods. With this boolean flag turned on, the schedulers
-	 * don't kick off the intervals until the tasks finish executing. Meaning no overlaps.
-	 */
-	property name="noOverlaps" type="boolean";
-
-	/**
-	 * The constraint of when the task can start execution.
-	 */
-	property name="startOnDateTime";
-
-	/**
-	 * The constraint of when the task must not continue to execute
-	 */
-	property name="endOnDateTime";
-
 
 	/**
 	 * Constructor
@@ -138,51 +180,64 @@ component accessors="true" {
 	 * @executor The executor this task will run under and be linked to
 	 * @task     The closure or cfc that represents the task (optional)
 	 * @method   The method on the cfc to call, defaults to "run" (optional)
+	 * @debug    Add debugging logs to System out, disabled by default
 	 */
 	ScheduledTask function init(
 		required name,
 		required executor,
 		any task = "",
-		method   = "run"
+		method   = "run",
+		debug    = false
 	){
+		// used for debugging output
+		variables.System = createObject( "java", "java.lang.System" );
 		// Utility class
-		variables.util            = new coldbox.system.core.util.Util();
+		variables.util             = new coldbox.system.core.util.Util();
 		// Link up the executor and name
-		variables.executor        = arguments.executor;
-		variables.name            = arguments.name;
+		variables.executor         = arguments.executor;
+		variables.name             = arguments.name;
 		// time unit helper
-		variables.dateTimeHelper  = new coldbox.system.async.time.DateTimeHelper();
-		variables.timeUnitHelper  = new coldbox.system.async.time.TimeUnit();
+		variables.dateTimeHelper   = new coldbox.system.async.time.DateTimeHelper();
+		variables.timeUnitHelper   = new coldbox.system.async.time.TimeUnit();
 		// Init Properties
-		variables.task            = arguments.task;
-		variables.method          = arguments.method;
+		variables.task             = arguments.task;
+		variables.method           = arguments.method;
 		// Default Frequencies
-		variables.period          = 0;
-		variables.delay           = 0;
-		variables.spacedDelay     = 0;
-		variables.timeUnit        = "milliseconds";
-		variables.noOverlap       = false;
+		variables.delay            = 0;
+		variables.delayTimeUnit    = "";
+		variables.period           = 0;
+		variables.spacedDelay      = 0;
+		variables.timeUnit         = "milliseconds";
+		variables.noOverlaps       = false;
 		// Constraints
-		variables.disabled        = false;
-		variables.whenClosure     = "";
-		variables.dayOfTheMonth   = 0;
-		variables.dayOfTheWeek    = 0;
-		variables.weekends        = false;
-		variables.weekdays        = false;
-		variables.lastBusinessDay = false;
-		variables.noOverlaps      = false;
-		variables.startOnDateTime = "";
-		variables.endOnDateTime   = "";
+		variables.annually         = false;
+		variables.debugEnabled     = arguments.debug;
+		variables.disabled         = false;
+		variables.whenClosure      = "";
+		variables.dayOfTheMonth    = 0;
+		variables.dayOfTheWeek     = 0;
+		variables.weekends         = false;
+		variables.weekdays         = false;
+		variables.firstBusinessDay = false;
+		variables.lastBusinessDay  = false;
+		variables.taskTime         = "";
+		variables.startOnDateTime  = "";
+		variables.endOnDateTime    = "";
+		variables.startTime        = "";
+		variables.endTime          = "";
+		variables.scheduled        = false;
 		// Probable Scheduler or not
-		variables.scheduler       = "";
+		variables.scheduler        = "";
 		// Prepare execution tracking stats
-		variables.stats           = {
+		variables.stats            = {
 			// Save name just in case
 			"name"              : arguments.name,
 			// When task got created
 			"created"           : now(),
 			// The last execution run timestamp
 			"lastRun"           : "",
+			// The next execution run timestamp
+			"nextRun"           : "",
 			// Total runs
 			"totalRuns"         : 0,
 			// Total faiulres
@@ -206,6 +261,8 @@ component accessors="true" {
 		variables.onTaskSuccess = "";
 		variables.onTaskFailure = "";
 
+		doLog( "init" );
+
 		return this;
 	}
 
@@ -221,6 +278,8 @@ component accessors="true" {
 	 * @throws UserInterruptException - When the thread has been interrupted
 	 */
 	function checkInterrupted(){
+		doLog( "checkInterrupted" );
+
 		var thisThread = createObject( "java", "java.lang.Thread" ).currentThread();
 		// Has the user/system tried to interrupt this thread?
 		if ( thisThread.isInterrupted() ) {
@@ -261,6 +320,8 @@ component accessors="true" {
 	 * @timezone The timezone string identifier
 	 */
 	ScheduledTask function setTimezone( required timezone ){
+		doLog( "setTimezone", arguments );
+
 		variables.timezone = createObject( "java", "java.time.ZoneId" ).of( arguments.timezone );
 		return this;
 	}
@@ -269,6 +330,8 @@ component accessors="true" {
 	 * Has this task been assigned to a scheduler or not?
 	 */
 	boolean function hasScheduler(){
+		doLog( "hasScheduler" );
+
 		return isObject( variables.scheduler );
 	}
 
@@ -281,6 +344,8 @@ component accessors="true" {
 	 * @return The schedule with the task/method registered on it
 	 */
 	ScheduledTask function call( required task, method = "run" ){
+		doLog( "call" );
+
 		variables.task   = arguments.task;
 		variables.method = arguments.method;
 		return this;
@@ -297,6 +362,8 @@ component accessors="true" {
 	 * If the closure returns true we schedule, else we disable it.
 	 */
 	ScheduledTask function when( target ){
+		doLog( "when" );
+
 		variables.whenClosure = arguments.target;
 		return this;
 	}
@@ -305,7 +372,19 @@ component accessors="true" {
 	 * Disable the task when scheduled, meaning, don't run this sucker!
 	 */
 	ScheduledTask function disable(){
+		doLog( "disable" );
+
 		variables.disabled = true;
+		return this;
+	}
+
+	/**
+	 * Update the debug setting for this task!
+	 */
+	ScheduledTask function debug( required boolean value ){
+		doLog( "debug" );
+
+		variables.debugEnabled = arguments.value;
 		return this;
 	}
 
@@ -313,6 +392,8 @@ component accessors="true" {
 	 * Enable the task when disabled so we can run again
 	 */
 	ScheduledTask function enable(){
+		doLog( "enable" );
+
 		variables.disabled = false;
 		return this;
 	}
@@ -324,7 +405,58 @@ component accessors="true" {
 	 * - when closure
 	 */
 	boolean function isDisabled(){
+		doLog( "isDisabled" );
+
 		return variables.disabled;
+	}
+
+	/**
+	 *
+	 * @startTime The specific time using 24 hour format => HH:mm
+	 * @endTime The specific time using 24 hour format => HH:mm
+	 */
+	ScheduledTask function between( required string startTime, required string endTime ){
+		doLog( "between" );
+		startOnTime( arguments.startTime );
+		endOnTime( arguments.endTime );
+		return this;
+	}
+
+	/**
+	 *
+	 * @time The specific time using 24 hour format => HH:mm
+	 */
+	ScheduledTask function startOnTime( required string time ){
+		doLog( "startOnTime" );
+
+		// Check for minutes else add them
+		if ( !find( ":", arguments.time ) ) {
+			arguments.time &= ":00";
+		}
+		// Validate time format
+		validateTime( arguments.time );
+
+		variables.startTime = arguments.time;
+		return this;
+	}
+
+	/**
+	 *
+	 * @time The specific time using 24 hour format => HH:mm
+	 */
+	ScheduledTask function endOnTime( required string time ){
+		doLog( "endOnTime" );
+
+		// Check for minutes else add them
+		if ( !find( ":", arguments.time ) ) {
+			arguments.time &= ":00";
+		}
+		// Validate time format
+		validateTime( arguments.time );
+
+		variables.endTime = arguments.time;
+
+		return this;
 	}
 
 	/**
@@ -346,6 +478,8 @@ component accessors="true" {
 	 * This method is called by the `run()` method at runtime to determine if the task can be ran at that point in time
 	 */
 	boolean function isConstrained(){
+		doLog( "isConstrained" );
+
 		var now = getJavaNow();
 
 		// When Closure that dictates if the task can be scheduled/ran: true => yes, false => no
@@ -358,9 +492,20 @@ component accessors="true" {
 		}
 
 		// Do we have a day of the month constraint? and the same as the running date/time? Else skip it
+		// If the day day assigned is greater than the days in the month, then we let it thru
+		// as the user intended to run it at the end of the month
 		if (
 			variables.dayOfTheMonth > 0 &&
-			now.getDayOfMonth() != variables.dayOfTheMonth
+			now.getDayOfMonth() != variables.dayOfTheMonth &&
+			daysInMonth( now.toString() ) >	variables.dayOfTheMonth
+		) {
+			return true;
+		}
+
+		// Do we have a first business day constraint
+		if (
+			variables.firstBusinessDay &&
+			now.getDayOfMonth() != getFirstBusinessDayOfTheMonth().getDayOfMonth()
 		) {
 			return true;
 		}
@@ -368,7 +513,7 @@ component accessors="true" {
 		// Do we have a last business day constraint
 		if (
 			variables.lastBusinessDay &&
-			now.getDayOfMonth() != getLastDayOfTheMonth().getDayOfMonth()
+			now.getDayOfMonth() != getLastBusinessDayOfTheMonth().getDayOfMonth()
 		) {
 			return true;
 		}
@@ -413,26 +558,45 @@ component accessors="true" {
 			return true;
 		}
 
+		// if we have a start time constraint
+		if (
+			len( variables.startTime ) ||
+			len( variables.endTime )
+		) {
+			var _startTime =  variables.dateTimeHelper.parse(
+				dateFormat( now(), "yyyy-mm-dd" ) & "T" & ( len( variables.startTime ) ? variables.startTime : "00:00:00" )
+			);
+			var _endTime =  variables.dateTimeHelper.parse(
+				dateFormat( now(), "yyyy-mm-dd" ) & "T" & ( len( variables.endTime ) ? variables.endTime : "23:59:59" )
+			);
+			if ( now.isBefore( _startTime ) || now.isAfter( _endTime ) )
+				return true;
+		}
+
 		return false;
 	}
 
 	/**
 	 * This is the runnable proxy method that executes your code by the executors
 	 */
-	function run(){
+	function run( boolean force = false ){
+		doLog( "run - " & arguments.force );
+
 		var sTime = getTickCount();
 
 		// If disabled or paused
-		if ( isDisabled() ) {
+		if ( !arguments.force && isDisabled() ) {
+			setNextRunTime();
 			return;
 		}
 
 		// Check for constraints of execution
-		if ( isConstrained() ) {
+		if ( !arguments.force && isConstrained() ) {
+			setNextRunTime();
 			return;
 		}
 
-		// Mark the task as it wil run now for the first time
+		// Mark the task as it will run now for the first time
 		variables.stats.neverRun = false;
 
 		try {
@@ -493,9 +657,7 @@ component accessors="true" {
 				}
 			} catch ( any afterException ) {
 				// Log it, so it doesn't go to ether and executor doesn't die.
-				err(
-					"Error running task (#getname()#) after/error handlers : #afterException.message & afterException.detail#"
-				);
+				err( "Error running task (#getname()#) after/error handlers : #afterException.message & afterException.detail#" );
 				err( "Stacktrace for task (#getname()#) after/error handlers : #afterException.stackTrace#" );
 			}
 		} finally {
@@ -505,6 +667,8 @@ component accessors="true" {
 			variables.stats.lastExecutionTime = getTickCount() - sTime;
 			// Call internal cleanups event
 			cleanupTaskRun();
+			// set next run time based on timeUnit and period
+			setNextRunTime();
 		}
 	}
 
@@ -523,10 +687,63 @@ component accessors="true" {
 	 * @return A ScheduledFuture from where you can monitor the task, an empty ScheduledFuture if the task was not registered
 	 */
 	ScheduledFuture function start(){
+
 		// If we have overlaps and the spaced delay is 0 then grab it from the period
-		if ( variables.noOverlaps and variables.spacedDelay eq 0 ) {
+		if ( variables.noOverlaps && variables.spacedDelay == 0 ) {
 			variables.spacedDelay = variables.period;
 		}
+
+		// If we have a delay and a delayTimeUnit, then we need to compare to our
+		// current timeUnit and convert to support the delay
+		// ( only if our time unit is seconds , if not we disable the delay )
+		//
+		// TODO: We need to support other time units - this is a temporary fix
+		// for the previous issue where the delay and/or setting would replace
+		// the time setting of the task based on the order presented
+		if (
+			variables.delay > 0 &&
+			len(variables.delayTimeUnit) &&
+			compare( variables.delayTimeUnit, variables.timeUnit)
+		){
+			if ( variables.timeUnit != "seconds" ){
+				variables.delay = 0;
+				// reset the initial nextRunTime
+				variables.stats.nextRun = "";
+			} else {
+				// transform all to seconds
+				switch ( variables.delayTimeUnit ) {
+					case "days":
+						variables.delay = javacast( "int", variables.delay * 60 * 60 * 24 );
+						break;
+					case "hours":
+						variables.delay = javacast( "int", variables.delay * 60 * 60 );
+						break;
+					case "minutes":
+						variables.delay = javacast( "int", variables.delay * 60 );
+						break;
+					case "milliseconds":
+						variables.delay = javacast( "int", variables.delay / 1000 );
+						break;
+					case "microseconds":
+						variables.delay = javacast( "int", variables.delay / 1000000 );
+						break;
+					case "nanoseconds":
+						variables.delay = javacast( "int", variables.delay / 1000000000 );
+						break;
+				}
+			}
+		}
+
+		variables.scheduled = true;
+
+		doLog(
+			"start - " & variables.name & " - should execute initial next run call " &
+			serializeJSON({
+				"spacedDelay" : variables.spacedDelay,
+				"period"      : variables.period,
+				"delay"       : variables.delay
+			})
+		);
 
 		// Startup a spaced frequency task: no overlaps
 		if ( variables.spacedDelay > 0 ) {
@@ -571,6 +788,8 @@ component accessors="true" {
 	 * @target The closure to execute
 	 */
 	ScheduledTask function before( required target ){
+		doLog( "before" );
+
 		variables.beforeTask = arguments.target;
 		return this;
 	}
@@ -581,6 +800,8 @@ component accessors="true" {
 	 * @target The closure to execute
 	 */
 	ScheduledTask function after( required target ){
+		doLog( "after" );
+
 		variables.afterTask = arguments.target;
 		return this;
 	}
@@ -591,6 +812,8 @@ component accessors="true" {
 	 * @target The closure to execute
 	 */
 	ScheduledTask function onSuccess( required target ){
+		doLog( "onSuccess" );
+
 		variables.onTaskSuccess = arguments.target;
 		return this;
 	}
@@ -601,6 +824,8 @@ component accessors="true" {
 	 * @target The closure to execute
 	 */
 	ScheduledTask function onFailure( required target ){
+		doLog( "onFailure" );
+
 		variables.onTaskFailure = arguments.target;
 		return this;
 	}
@@ -614,22 +839,39 @@ component accessors="true" {
 	/**
 	 * Set a delay in the running of the task that will be registered with this schedule
 	 *
-	 * @delay    The delay that will be used before executing the task
-	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
+	 * @delay          The delay that will be used before executing the task
+	 * @timeUnit       The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
+	 * @overwrites     Boolean to overwrite delay and timeUnit even if value is already set, this is helpful if the delay is set later in the chain when creating the task - defaults to false
+	 * @setNextRunTime Boolean to execute setInitialNextRunTime() - defaults to true
 	 */
-	ScheduledTask function delay( numeric delay, timeUnit = "milliseconds" ){
-		variables.delay    = arguments.delay;
-		variables.timeUnit = arguments.timeUnit;
+	ScheduledTask function delay(
+		numeric delay,
+		timeUnit = "milliseconds",
+		boolean overwrites = false,
+		boolean setNextRunTime = true
+	){
+		doLog( "delay", arguments );
+
+		if ( arguments.overwrites || !variables.delay ){
+			variables.delay         = arguments.delay;
+			variables.delayTimeUnit = arguments.timeUnit;
+		}
+
+		if ( arguments.setNextRunTime )
+			setInitialNextRunTime( delay:arguments.delay, timeUnit:arguments.timeUnit );
+
 		return this;
 	}
 
 	/**
 	 * Run the task every custom spaced delay of execution, meaning no overlaps
 	 *
-	 * @delay    The delay that will be used before executing the task
+	 * @spacedDelay The delay that will be used before executing the task with no overlaps
 	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 */
 	ScheduledTask function spacedDelay( numeric spacedDelay, timeUnit = "milliseconds" ){
+		doLog( "spacedDelay", arguments );
+
 		variables.spacedDelay = arguments.spacedDelay;
 		variables.timeUnit    = arguments.timeUnit;
 		return this;
@@ -637,25 +879,28 @@ component accessors="true" {
 
 	/**
 	 * Calling this method prevents task frequencies to overlap.  By default all tasks are executed with an
-	 * interval but ccould potentially overlap if they take longer to execute than the period.
-	 *
-	 * @period  
-	 * @timeUnit
+	 * interval but could potentially overlap if they take longer to execute than the period.
 	 */
 	ScheduledTask function withNoOverlaps(){
+		doLog( "withNoOverlaps" );
+
 		variables.noOverlaps = true;
 		return this;
 	}
 
-	/**
-	 * Run the task every custom period of execution
+	/**	 * Run the task every custom period of execution
 	 *
 	 * @period   The period of execution
 	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 */
 	ScheduledTask function every( numeric period, timeUnit = "milliseconds" ){
+		doLog( "every", arguments );
+
 		variables.period   = arguments.period;
 		variables.timeUnit = arguments.timeUnit;
+
+		setInitialNextRunTime();
+
 		return this;
 	}
 
@@ -663,18 +908,18 @@ component accessors="true" {
 	 * Run the task every minute from the time it get's scheduled
 	 */
 	ScheduledTask function everyMinute(){
-		variables.period   = 1;
-		variables.timeUnit = "minutes";
-		return this;
+		doLog( "everyMinute", arguments );
+
+		return this.every( 1, "minutes" );
 	}
 
 	/**
 	 * Run the task every hour from the time it get's scheduled
 	 */
 	ScheduledTask function everyHour(){
-		variables.period   = 1;
-		variables.timeUnit = "hours";
-		return this;
+		doLog( "everyHour", arguments );
+
+		return this.every( 1, "hours" );
 	}
 
 	/**
@@ -683,6 +928,8 @@ component accessors="true" {
 	 * @minutes The minutes past the hour mark
 	 */
 	ScheduledTask function everyHourAt( required numeric minutes ){
+		doLog( "everyHourAt", arguments );
+
 		var now     = getJavaNow();
 		var nextRun = now.withMinute( javacast( "int", arguments.minutes ) ).withSecond( javacast( "int", 0 ) );
 		// If we passed it, then move the hour by 1
@@ -696,7 +943,8 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to be every hour
 		variables.period   = variables.timeUnitHelper.get( "hours" ).toSeconds( 1 );
@@ -709,6 +957,8 @@ component accessors="true" {
 	 * Run the task every day at midnight
 	 */
 	ScheduledTask function everyDay(){
+		doLog( "everyDay", arguments );
+
 		var now     = getJavaNow();
 		// Set at midnight
 		var nextRun = now
@@ -726,7 +976,8 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to every day in seconds
 		variables.period   = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
@@ -742,7 +993,9 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm
 	 */
 	ScheduledTask function everyDayAt( required string time ){
-		// Check for mintues else add them
+		doLog( "everyDayAt", arguments );
+
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
@@ -765,7 +1018,8 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to every day in seconds
 		variables.period   = variables.timeUnitHelper.get( "DAYS" ).toSeconds( 1 );
@@ -778,33 +1032,9 @@ component accessors="true" {
 	 * Run the task every Sunday at midnight
 	 */
 	ScheduledTask function everyWeek(){
-		var now     = getJavaNow();
-		// Set at midnight
-		var nextRun = now
-			// Sunday
-			.with( variables.dateTimeHelper.ChronoField.DAY_OF_WEEK, javacast( "int", 7 ) )
-			// Midnight
-			.withHour( javacast( "int", 0 ) )
-			.withMinute( javacast( "int", 0 ) )
-			.withSecond( javacast( "int", 0 ) );
-		// If we passed it, then move to the next week
-		if ( now.compareTo( nextRun ) > 0 ) {
-			nextRun = nextRun.plusWeeks( javacast( "int", 1 ) );
-		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.dateTimeHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds"
-		);
-		// Set the period to every week in seconds
-		variables.period       = variables.timeUnitHelper.get( "days" ).toSeconds( 7 );
-		variables.timeUnit     = "seconds";
-		variables.dayOfTheWeek = 7;
-		return this;
+		doLog( "everyWeek", arguments );
+
+		return this.everyWeekOn( 7 );
 	}
 
 	/**
@@ -814,8 +1044,10 @@ component accessors="true" {
 	 * @time      The specific time using 24 hour format => HH:mm, defaults to midnight
 	 */
 	ScheduledTask function everyWeekOn( required numeric dayOfWeek, string time = "00:00" ){
+		doLog( "everyWeekOn", arguments );
+
 		var now = getJavaNow();
-		// Check for mintues else add them
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
@@ -839,12 +1071,14 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to every week in seconds
 		variables.period       = variables.timeUnitHelper.get( "days" ).toSeconds( 7 );
 		variables.timeUnit     = "seconds";
 		variables.dayOfTheWeek = arguments.dayOfWeek;
+
 		return this;
 	}
 
@@ -852,34 +1086,9 @@ component accessors="true" {
 	 * Run the task on the first day of every month at midnight
 	 */
 	ScheduledTask function everyMonth(){
-		var now     = getJavaNow();
-		// Set at midnight
-		var nextRun = now
-			// First day of the month
-			.with( variables.dateTimeHelper.ChronoField.DAY_OF_MONTH, javacast( "int", 1 ) )
-			// Midnight
-			.withHour( javacast( "int", 0 ) )
-			.withMinute( javacast( "int", 0 ) )
-			.withSecond( javacast( "int", 0 ) );
+		doLog( "everyMonth", arguments );
 
-		if ( now.compareTo( nextRun ) > 0 ) {
-			nextRun = nextRun.plusMonths( javacast( "int", 1 ) );
-		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.dateTimeHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds"
-		);
-		// Set the period to one day. And make sure we add a constraint for it
-		// Mostly because every month is different
-		variables.period        = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
-		variables.timeUnit      = "seconds";
-		variables.dayOfTheMonth = 1;
-		return this;
+		return this.everyMonthOn( 1 );
 	}
 
 	/**
@@ -889,8 +1098,10 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to midnight
 	 */
 	ScheduledTask function everyMonthOn( required numeric day, string time = "00:00" ){
+		doLog( "everyMonthOn", arguments );
+
 		var now = getJavaNow();
-		// Check for mintues else add them
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
@@ -915,13 +1126,15 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to one day. And make sure we add a constraint for it
 		// Mostly because every month is different
 		variables.period        = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
 		variables.timeUnit      = "seconds";
 		variables.dayOfTheMonth = arguments.day;
+
 		return this;
 	}
 
@@ -931,28 +1144,20 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to midnight
 	 */
 	ScheduledTask function onFirstBusinessDayOfTheMonth( string time = "00:00" ){
+		doLog( "onFirstBusinessDayOfTheMonth", arguments );
+
 		var now = getJavaNow();
-		// Check for mintues else add them
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
 		// Validate time format
 		validateTime( arguments.time );
 		// Get new time
-		var nextRun = now
-			// First business day of the month
-			.with(
-				createObject( "java", "java.time.temporal.TemporalAdjusters" ).firstInMonth(
-					createObject( "java", "java.time.DayOfWeek" ).MONDAY
-				)
-			)
-			// Specific Time
-			.withHour( javacast( "int", getToken( arguments.time, 1, ":" ) ) )
-			.withMinute( javacast( "int", getToken( arguments.time, 2, ":" ) ) )
-			.withSecond( javacast( "int", 0 ) );
+		var nextRun = getFirstBusinessDayOfTheMonth( arguments.time );
 		// Have we passed it
 		if ( now.compareTo( nextRun ) > 0 ) {
-			nextRun = nextRun.plusMonths( javacast( "int", 1 ) );
+			nextRun = getFirstBusinessDayOfTheMonth( arguments.time, true );
 		}
 		// Get the duration time for the next run and delay accordingly
 		this.delay(
@@ -961,39 +1166,17 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to one day. And make sure we add a constraint for it
 		// Mostly because every month is different
-		variables.period        = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
-		variables.timeUnit      = "seconds";
-		variables.dayOfTheMonth = 1;
+		variables.period           = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
+		variables.timeUnit         = "seconds";
+		variables.firstBusinessDay = true;
+		variables.taskTime         = arguments.time;
+
 		return this;
-	}
-
-	/**
-	 * This utility method gives us the last day of the month in Java format
-	 */
-	private function getLastDayOfTheMonth(){
-		// Get the last day of the month
-		var lastDay = variables.dateTimeHelper
-			.toLocalDateTime( now(), this.getTimezone() )
-			.with( createObject( "java", "java.time.temporal.TemporalAdjusters" ).lastDayOfMonth() );
-		// Verify if on weekend
-		switch ( lastDay.getDayOfWeek().getValue() ) {
-			// Sunday - 2 days
-			case 7: {
-				lastDay = lastDay.minusDays( 2 );
-				break;
-			}
-			// Saturday - 1 day
-			case 6: {
-				lastDay = lastDay.minusDays( 1 );
-				break;
-			}
-		}
-
-		return lastDay;
 	}
 
 	/**
@@ -1002,22 +1185,20 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to midnight
 	 */
 	ScheduledTask function onLastBusinessDayOfTheMonth( string time = "00:00" ){
+		doLog( "onLastBusinessDayOfTheMonth", arguments );
+
 		var now = getJavaNow();
-		// Check for mintues else add them
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
 		// Validate time format
 		validateTime( arguments.time );
 		// Get the last day of the month
-		var nextRun = getLastDayOfTheMonth()
-			// Specific Time
-			.withHour( javacast( "int", getToken( arguments.time, 1, ":" ) ) )
-			.withMinute( javacast( "int", getToken( arguments.time, 2, ":" ) ) )
-			.withSecond( javacast( "int", 0 ) );
+		var nextRun = getLastBusinessDayOfTheMonth( arguments.time );
 		// Have we passed it
 		if ( now.compareTo( nextRun ) > 0 ) {
-			nextRun = nextRun.plusMonths( javacast( "int", 1 ) );
+			nextRun = getLastBusinessDayOfTheMonth( arguments.time, true );
 		}
 		// Get the duration time for the next run and delay accordingly
 		this.delay(
@@ -1026,13 +1207,16 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to one day. And make sure we add a constraint for it
 		// Mostly because every month is different
 		variables.period          = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
 		variables.timeUnit        = "seconds";
 		variables.lastBusinessDay = true;
+		variables.taskTime        = arguments.time;
+
 		return this;
 	}
 
@@ -1040,32 +1224,8 @@ component accessors="true" {
 	 * Run the task on the first day of the year at midnight
 	 */
 	ScheduledTask function everyYear(){
-		var now     = getJavaNow();
-		// Set at midnight
-		var nextRun = now
-			// First day of the month
-			.with( variables.dateTimeHelper.ChronoField.DAY_OF_YEAR, javacast( "int", 1 ) )
-			// Midnight
-			.withHour( javacast( "int", 0 ) )
-			.withMinute( javacast( "int", 0 ) )
-			.withSecond( javacast( "int", 0 ) );
-
-		if ( now.compareTo( nextRun ) > 0 ) {
-			nextRun = nextRun.plusYears( javacast( "int", 1 ) );
-		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.dateTimeHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds"
-		);
-		// Set the period to
-		variables.period   = variables.timeUnitHelper.get( "days" ).toSeconds( 365 );
-		variables.timeUnit = "seconds";
-		return this;
+		doLog( "everyYear" );
+		return this.everyYearOn( 1, 1 );
 	}
 
 	/**
@@ -1080,8 +1240,10 @@ component accessors="true" {
 		required numeric day,
 		required string time = "00:00"
 	){
+		doLog( "everyYearOn", arguments );
+
 		var now = getJavaNow();
-		// Check for mintues else add them
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
@@ -1107,11 +1269,14 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to
 		variables.period   = variables.timeUnitHelper.get( "days" ).toSeconds( 365 );
 		variables.timeUnit = "seconds";
+		variables.annually = true;
+
 		return this;
 	}
 
@@ -1121,7 +1286,9 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onWeekends( string time = "00:00" ){
-		// Check for mintues else add them
+		doLog( "onWeekends", arguments );
+
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
@@ -1144,7 +1311,8 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to every day in seconds
 		variables.period   = variables.timeUnitHelper.get( "DAYS" ).toSeconds( 1 );
@@ -1162,7 +1330,9 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onWeekdays( string time = "00:00" ){
-		// Check for mintues else add them
+		doLog( "onWeekdays" , arguments );
+
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
@@ -1185,7 +1355,8 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to every day in seconds
 		variables.period   = variables.timeUnitHelper.get( "DAYS" ).toSeconds( 1 );
@@ -1193,6 +1364,7 @@ component accessors="true" {
 		// Constraint to only run on weekdays
 		variables.weekdays = true;
 		variables.weekends = false;
+
 		return this;
 	}
 
@@ -1202,6 +1374,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onMondays( string time = "00:00" ){
+		doLog( "onMondays", arguments );
+
 		return this.everyWeekOn( 1, arguments.time );
 	}
 
@@ -1211,6 +1385,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onTuesdays( string time = "00:00" ){
+		doLog( "onTuesdays", arguments );
+
 		return this.everyWeekOn( 2, arguments.time );
 	}
 
@@ -1220,6 +1396,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onWednesdays( string time = "00:00" ){
+		doLog( "onWednesdays", arguments );
+
 		return this.everyWeekOn( 3, arguments.time );
 	}
 
@@ -1229,6 +1407,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onThursdays( string time = "00:00" ){
+		doLog( "onThursdays", arguments );
+
 		return this.everyWeekOn( 4, arguments.time );
 	}
 
@@ -1238,6 +1418,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onFridays( string time = "00:00" ){
+		doLog( "onFridays", arguments );
+
 		return this.everyWeekOn( 5, arguments.time );
 	}
 
@@ -1247,6 +1429,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onSaturdays( string time = "00:00" ){
+		doLog( "onSaturdays", arguments );
+
 		return this.everyWeekOn( 6, arguments.time );
 	}
 
@@ -1256,6 +1440,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onSundays( string time = "00:00" ){
+		doLog( "onSundays", arguments );
+
 		return this.everyWeekOn( 7, arguments.time );
 	}
 
@@ -1266,6 +1452,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function startOn( required date, string time = "00:00" ){
+		doLog( "startOn", arguments );
+
 		variables.startOnDateTime = variables.dateTimeHelper.parse(
 			"#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#"
 		);
@@ -1279,6 +1467,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function endOn( required date, string time = "00:00" ){
+		doLog( "endOn", arguments );
+
 		variables.endOnDateTime = variables.dateTimeHelper.parse(
 			"#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#"
 		);
@@ -1297,6 +1487,8 @@ component accessors="true" {
 	 * Set the time unit in days
 	 */
 	ScheduledTask function inDays(){
+		doLog( "inDays" );
+
 		variables.timeUnit = "days";
 		return this;
 	}
@@ -1305,6 +1497,8 @@ component accessors="true" {
 	 * Set the time unit in hours
 	 */
 	ScheduledTask function inHours(){
+		doLog( "inHours" );
+
 		variables.timeUnit = "hours";
 		return this;
 	}
@@ -1313,6 +1507,8 @@ component accessors="true" {
 	 * Set the time unit in microseconds
 	 */
 	ScheduledTask function inMicroseconds(){
+		doLog( "inMicroseconds" );
+
 		variables.timeUnit = "microseconds";
 		return this;
 	}
@@ -1321,6 +1517,8 @@ component accessors="true" {
 	 * Set the time unit in milliseconds
 	 */
 	ScheduledTask function inMilliseconds(){
+		doLog( "inMilliseconds" );
+
 		variables.timeUnit = "milliseconds";
 		return this;
 	}
@@ -1329,6 +1527,8 @@ component accessors="true" {
 	 * Set the time unit in minutes
 	 */
 	ScheduledTask function inMinutes(){
+		doLog( "inMinutes" );
+
 		variables.timeUnit = "minutes";
 		return this;
 	}
@@ -1337,6 +1537,8 @@ component accessors="true" {
 	 * Set the time unit in nanoseconds
 	 */
 	ScheduledTask function inNanoseconds(){
+		doLog( "inNanoseconds" );
+
 		variables.timeUnit = "nanoseconds";
 		return this;
 	}
@@ -1345,6 +1547,8 @@ component accessors="true" {
 	 * Set the time unit in seconds
 	 */
 	ScheduledTask function inSeconds(){
+		doLog( "inSeconds" );
+
 		variables.timeUnit = "seconds";
 		return this;
 	}
@@ -1382,4 +1586,260 @@ component accessors="true" {
 		} );
 	}
 
+	/**
+	 * This utility method gives us the first business day of the month in Java format
+	 *
+	 * @time The specific time using 24 hour format => HH:mm, defaults to midnight
+	 * @addMonth Boolean to specify adding a month to today's date
+	 * @now The date to use as the starting point, defaults to now()
+	 */
+	private function getFirstBusinessDayOfTheMonth(
+		string time = "00:00",
+		boolean addMonth = false,
+		date now = now()
+	){
+		// Get the last day of the month
+		return variables.dateTimeHelper
+			.toLocalDateTime(
+				arguments.addMonth ? dateAdd( "m", 1, arguments.now ) : arguments.now,
+				this.getTimezone()
+			)
+			// First business day of the month
+			.with(
+				createObject( "java", "java.time.temporal.TemporalAdjusters" ).firstInMonth(
+					createObject( "java", "java.time.DayOfWeek" ).MONDAY
+				)
+			)
+			// Specific Time
+			.withHour( javacast( "int", getToken( arguments.time, 1, ":" ) ) )
+			.withMinute( javacast( "int", getToken( arguments.time, 2, ":" ) ) )
+			.withSecond( javacast( "int", 0 ) );
+	}
+
+	/**
+	 * This utility method gives us the last business day of the month in Java format
+	 *
+	 * @time The specific time using 24 hour format => HH:mm, defaults to midnight
+	 * @addMonth Boolean to specify adding a month to today's date
+	 * @now The date to use as the starting point, defaults to now()
+	 */
+	private function getLastBusinessDayOfTheMonth(
+		string time = "00:00",
+		boolean addMonth = false,
+		date now = now()
+	){
+		doLog( "getLastBusinessDayOfTheMonth" );
+
+		// Get the last day of the month
+		var lastDay = variables.dateTimeHelper
+			.toLocalDateTime(
+				arguments.addMonth ? dateAdd( "m", 1, arguments.now ) : arguments.now,
+				this.getTimezone()
+			)
+			.with( createObject( "java", "java.time.temporal.TemporalAdjusters" ).lastDayOfMonth() )
+			// Specific Time
+			.withHour( javacast( "int", getToken( arguments.time, 1, ":" ) ) )
+			.withMinute( javacast( "int", getToken( arguments.time, 2, ":" ) ) )
+			.withSecond( javacast( "int", 0 ) );
+		// Verify if on weekend
+		switch ( lastDay.getDayOfWeek().getValue() ) {
+			// Sunday - 2 days
+			case 7: {
+				lastDay = lastDay.minusDays( 2 );
+				break;
+			}
+			// Saturday - 1 day
+			case 6: {
+				lastDay = lastDay.minusDays( 1 );
+				break;
+			}
+		}
+
+		return lastDay;
+	}
+
+	/**
+	 * This method is called to set the initial next run time of the task
+	 * if none exists it sets it to now or it can be also passed in as an argument
+	 *
+	 * If a delay is set, it will set the next run time based on the delay and timeUnit
+	 *
+	 * @nextRun An instance of java.time.LocalDateTime to set the next run time to
+	 * @delay   The delay to set the next run time to
+	 * @timeUnit The time unit to use for the delay
+	 */
+	private function setInitialNextRunTime(
+		any nextRun,
+		numeric delay,
+		string timeUnit
+	){
+		var amount = structKeyExists( arguments, "delay" ) ? arguments.delay : variables.delay;
+		var unit   = structKeyExists( arguments, "timeUnit" ) ? arguments.timeUnit : variables.timeUnit;
+
+		if ( !isDate(variables.stats.nextRun) ){
+
+			doLog( "setInitialNextRunTime", {
+				delay         : amount,
+				timeUnit      : unit,
+				nextRunSet    : isDate(variables.stats.nextRun) ? true : false,
+				nextRunInArgs : !isNull(arguments.nextRun)
+			} );
+
+			if ( !isNull(arguments.nextRun) && isInstanceOf( arguments.nextRun, "java.time.LocalDateTime" ) )
+				variables.stats.nextRun = arguments.nextRun;
+			else if ( !isInstanceOf( variables.stats.nextRun, "java.time.LocalDateTime" ) )
+				variables.stats.nextRun = getJavaNow();
+
+			if ( amount ) {
+				switch ( unit ) {
+					case "days":
+						variables.stats.nextRun = variables.stats.nextRun.plusDays( javacast( "int", amount ) );
+						break;
+					case "hours":
+						variables.stats.nextRun = variables.stats.nextRun.plusHours( javacast( "int", amount ) );
+						break;
+					case "minutes":
+						variables.stats.nextRun = variables.stats.nextRun.plusMinutes( javacast( "int", amount ) );
+						break;
+					case "milliseconds":
+						variables.stats.nextRun = variables.stats.nextRun.plusSeconds( javacast( "int", amount/1000 ) );
+						break;
+					case "microseconds":
+						variables.stats.nextRun = variables.stats.nextRun.plusNanos( javacast( "int", amount * 1000 ) );
+						break;
+					case "nanoseconds":
+						variables.stats.nextRun = variables.stats.nextRun.plusNanos( javacast( "int", amount ) );
+						break;
+					default:
+						variables.stats.nextRun = variables.stats.nextRun.plusSeconds( javacast( "int", amount ) );
+						break;
+				}
+			}
+
+			var now       = getJavaNow();
+			var startTime = len(variables.startTime) ?
+									now
+										.withHour( javacast( "int", getToken( variables.startTime, 1, ":" ) ) )
+										.withMinute( javacast( "int", getToken( variables.startTime, 2, ":" ) ) )
+										.withSecond( javacast( "int", 0 ) ) :
+									now
+										.withHour( javacast( "int", 0 ) )
+										.withMinute( javacast( "int", 0 ) )
+										.withSecond( javacast( "int", 0 ) ) ;
+			var endTime = len(variables.endTime) ?
+									now
+										.withHour( javacast( "int", getToken( variables.endTime, 1, ":" ) ) )
+										.withMinute( javacast( "int", getToken( variables.endTime, 2, ":" ) ) )
+										.withSecond( javacast( "int", 0 ) ) :
+									now
+										.withHour( javacast( "int", 23 ) )
+										.withMinute( javacast( "int", 59 ) )
+										.withSecond( javacast( "int", 59 ) ) ;
+
+
+			doLog ( "startTime", { startTime:startTime.toString(), comp:now.compareTo( startTime ) } );
+			doLog ( "endTime", { endTime:endTime.toString(), comp:now.compareTo( endTime ) } );
+
+			if ( now.compareTo( startTime ) < 0 )
+				variables.stats.nextRun = startTime;
+
+			if ( now.compareTo( endTime ) > 0 )
+				variables.stats.nextRun = startTime.plusDays( javacast( "int", 1 ) );
+
+			variables.stats.nextRun = variables.stats.nextRun.toString();
+		}
+	}
+
+	/**
+	 * This method is called to set the next run time of the task based on the timeUnit and period.
+	 */
+	private function setNextRunTime(){
+		doLog( "setNextRunTime", arguments );
+
+		var now = getJavaNow();
+
+		var amount = variables.spacedDelay != 0 ? variables.spacedDelay : variables.period;
+
+		// if overlaps are allowed task is immediately scheduled
+		if ( variables.spacedDelay == 0 && variables.stats.lastExecutionTime/1000 > variables.period )
+			amount = 0;
+
+		// reset nextRun to empty string to continue with process of setting
+		// next run time
+		variables.stats.nextRun = "";
+
+		// check if we are a first or last business day of month entry
+		if ( variables.firstBusinessDay ){
+			variables.stats.nextRun = getFirstBusinessDayOfTheMonth( variables.taskTime, true );
+		}
+		else if ( variables.lastBusinessDay ) {
+			variables.stats.nextRun = getLastBusinessDayOfTheMonth( variables.taskTime, true );
+		}
+		// check if we have a daily start or end time
+		else if ( len( variables.startTime) || len( variables.endTime ) ){
+			var startTime = len(variables.startTime) ?
+								now
+									.withHour( javacast( "int", getToken( variables.startTime, 1, ":" ) ) )
+									.withMinute( javacast( "int", getToken( variables.startTime, 2, ":" ) ) )
+									.withSecond( javacast( "int", 0 ) ) :
+								now
+									.withHour( javacast( "int", 0 ) )
+									.withMinute( javacast( "int", 0 ) )
+									.withSecond( javacast( "int", 0 ) ) ;
+			var endTime = len(variables.endTime) ?
+									now
+										.withHour( javacast( "int", getToken( variables.endTime, 1, ":" ) ) )
+										.withMinute( javacast( "int", getToken( variables.endTime, 2, ":" ) ) )
+										.withSecond( javacast( "int", 0 ) ) :
+									now
+										.withHour( javacast( "int", 23 ) )
+										.withMinute( javacast( "int", 59 ) )
+										.withSecond( javacast( "int", 59 ) ) ;
+
+			if ( now.compareTo( startTime ) < 0 )
+				variables.stats.nextRun = startTime;
+			else if ( now.compareTo( endTime ) > 0 )
+				variables.stats.nextRun = startTime.plusDays( javacast( "int", 1 ) );
+		}
+
+		if ( !len(variables.stats.nextRun) ){
+			switch ( variables.timeUnit ) {
+				case "days":
+					variables.stats.nextRun = now.plusDays( javacast( "int", amount ) );
+					break;
+				case "hours":
+					variables.stats.nextRun = now.plusHours( javacast( "int", amount ) );
+					break;
+				case "minutes":
+					variables.stats.nextRun = now.plusMinutes( javacast( "int", amount ) );
+					break;
+				case "milliseconds":
+					variables.stats.nextRun = now.plusSeconds( javacast( "int", amount / 1000 ) );
+					break;
+				case "microseconds":
+					variables.stats.nextRun = now.plusNanos( javacast( "int", amount * 1000 ) );
+					break;
+				case "nanoseconds":
+					variables.stats.nextRun = now.plusNanos( javacast( "int", amount ) );
+					break;
+				default:
+					variables.stats.nextRun = now.plusSeconds( javacast( "int", amount ) );
+					break;
+			}
+		}
+
+		variables.stats.nextRun = variables.stats.nextRun.toString();
+	}
+
+	/**
+	 * Debug logging method
+	 */
+	private function doLog( required string caller, struct args = {} ){
+		if ( variables.debugEnabled ){
+			var message = "ScheduledTask : " & variables.name & " : " & arguments.caller & "()" & (
+				structIsEmpty( arguments.args ) ? "" : " : " & serializeJSON( arguments.args )
+			);
+			variables.System.out.println( message );
+		}
+	}
 }

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -190,7 +190,7 @@ component accessors="true" {
 		debug    = false
 	){
 		// used for debugging output
-		variables.System = createObject( "java", "java.lang.System" );
+		variables.System           = createObject( "java", "java.lang.System" );
 		// Utility class
 		variables.util             = new coldbox.system.core.util.Util();
 		// Link up the executor and name
@@ -413,7 +413,7 @@ component accessors="true" {
 	/**
 	 *
 	 * @startTime The specific time using 24 hour format => HH:mm
-	 * @endTime The specific time using 24 hour format => HH:mm
+	 * @endTime   The specific time using 24 hour format => HH:mm
 	 */
 	ScheduledTask function between( required string startTime, required string endTime ){
 		doLog( "between" );
@@ -497,7 +497,7 @@ component accessors="true" {
 		if (
 			variables.dayOfTheMonth > 0 &&
 			now.getDayOfMonth() != variables.dayOfTheMonth &&
-			daysInMonth( now.toString() ) >	variables.dayOfTheMonth
+			daysInMonth( now.toString() ) > variables.dayOfTheMonth
 		) {
 			return true;
 		}
@@ -563,14 +563,15 @@ component accessors="true" {
 			len( variables.startTime ) ||
 			len( variables.endTime )
 		) {
-			var _startTime =  variables.dateTimeHelper.parse(
-				dateFormat( now(), "yyyy-mm-dd" ) & "T" & ( len( variables.startTime ) ? variables.startTime : "00:00:00" )
+			var _startTime = variables.dateTimeHelper.parse(
+				dateFormat( now(), "yyyy-mm-dd" ) & "T" & (
+					len( variables.startTime ) ? variables.startTime : "00:00:00"
+				)
 			);
-			var _endTime =  variables.dateTimeHelper.parse(
+			var _endTime = variables.dateTimeHelper.parse(
 				dateFormat( now(), "yyyy-mm-dd" ) & "T" & ( len( variables.endTime ) ? variables.endTime : "23:59:59" )
 			);
-			if ( now.isBefore( _startTime ) || now.isAfter( _endTime ) )
-				return true;
+			if ( now.isBefore( _startTime ) || now.isAfter( _endTime ) ) return true;
 		}
 
 		return false;
@@ -687,7 +688,6 @@ component accessors="true" {
 	 * @return A ScheduledFuture from where you can monitor the task, an empty ScheduledFuture if the task was not registered
 	 */
 	ScheduledFuture function start(){
-
 		// If we have overlaps and the spaced delay is 0 then grab it from the period
 		if ( variables.noOverlaps && variables.spacedDelay == 0 ) {
 			variables.spacedDelay = variables.period;
@@ -702,11 +702,11 @@ component accessors="true" {
 		// the time setting of the task based on the order presented
 		if (
 			variables.delay > 0 &&
-			len(variables.delayTimeUnit) &&
-			compare( variables.delayTimeUnit, variables.timeUnit)
-		){
-			if ( variables.timeUnit != "seconds" ){
-				variables.delay = 0;
+			len( variables.delayTimeUnit ) &&
+			compare( variables.delayTimeUnit, variables.timeUnit )
+		) {
+			if ( variables.timeUnit != "seconds" ) {
+				variables.delay         = 0;
 				// reset the initial nextRunTime
 				variables.stats.nextRun = "";
 			} else {
@@ -738,11 +738,11 @@ component accessors="true" {
 
 		doLog(
 			"start - " & variables.name & " - should execute initial next run call " &
-			serializeJSON({
+			serializeJSON( {
 				"spacedDelay" : variables.spacedDelay,
 				"period"      : variables.period,
 				"delay"       : variables.delay
-			})
+			} )
 		);
 
 		// Startup a spaced frequency task: no overlaps
@@ -846,19 +846,19 @@ component accessors="true" {
 	 */
 	ScheduledTask function delay(
 		numeric delay,
-		timeUnit = "milliseconds",
-		boolean overwrites = false,
+		timeUnit               = "milliseconds",
+		boolean overwrites     = false,
 		boolean setNextRunTime = true
 	){
 		doLog( "delay", arguments );
 
-		if ( arguments.overwrites || !variables.delay ){
+		if ( arguments.overwrites || !variables.delay ) {
 			variables.delay         = arguments.delay;
 			variables.delayTimeUnit = arguments.timeUnit;
 		}
 
 		if ( arguments.setNextRunTime )
-			setInitialNextRunTime( delay:arguments.delay, timeUnit:arguments.timeUnit );
+			setInitialNextRunTime( delay: arguments.delay, timeUnit: arguments.timeUnit );
 
 		return this;
 	}
@@ -867,7 +867,7 @@ component accessors="true" {
 	 * Run the task every custom spaced delay of execution, meaning no overlaps
 	 *
 	 * @spacedDelay The delay that will be used before executing the task with no overlaps
-	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
+	 * @timeUnit    The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 */
 	ScheduledTask function spacedDelay( numeric spacedDelay, timeUnit = "milliseconds" ){
 		doLog( "spacedDelay", arguments );
@@ -1330,7 +1330,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onWeekdays( string time = "00:00" ){
-		doLog( "onWeekdays" , arguments );
+		doLog( "onWeekdays", arguments );
 
 		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
@@ -1589,14 +1589,14 @@ component accessors="true" {
 	/**
 	 * This utility method gives us the first business day of the month in Java format
 	 *
-	 * @time The specific time using 24 hour format => HH:mm, defaults to midnight
+	 * @time     The specific time using 24 hour format => HH:mm, defaults to midnight
 	 * @addMonth Boolean to specify adding a month to today's date
-	 * @now The date to use as the starting point, defaults to now()
+	 * @now      The date to use as the starting point, defaults to now()
 	 */
 	private function getFirstBusinessDayOfTheMonth(
-		string time = "00:00",
+		string time      = "00:00",
 		boolean addMonth = false,
-		date now = now()
+		date now         = now()
 	){
 		// Get the last day of the month
 		return variables.dateTimeHelper
@@ -1619,14 +1619,14 @@ component accessors="true" {
 	/**
 	 * This utility method gives us the last business day of the month in Java format
 	 *
-	 * @time The specific time using 24 hour format => HH:mm, defaults to midnight
+	 * @time     The specific time using 24 hour format => HH:mm, defaults to midnight
 	 * @addMonth Boolean to specify adding a month to today's date
-	 * @now The date to use as the starting point, defaults to now()
+	 * @now      The date to use as the starting point, defaults to now()
 	 */
 	private function getLastBusinessDayOfTheMonth(
-		string time = "00:00",
+		string time      = "00:00",
 		boolean addMonth = false,
-		date now = now()
+		date now         = now()
 	){
 		doLog( "getLastBusinessDayOfTheMonth" );
 
@@ -1664,28 +1664,26 @@ component accessors="true" {
 	 *
 	 * If a delay is set, it will set the next run time based on the delay and timeUnit
 	 *
-	 * @nextRun An instance of java.time.LocalDateTime to set the next run time to
-	 * @delay   The delay to set the next run time to
+	 * @nextRun  An instance of java.time.LocalDateTime to set the next run time to
+	 * @delay    The delay to set the next run time to
 	 * @timeUnit The time unit to use for the delay
 	 */
-	private function setInitialNextRunTime(
-		any nextRun,
-		numeric delay,
-		string timeUnit
-	){
+	private function setInitialNextRunTime( any nextRun, numeric delay, string timeUnit ){
 		var amount = structKeyExists( arguments, "delay" ) ? arguments.delay : variables.delay;
 		var unit   = structKeyExists( arguments, "timeUnit" ) ? arguments.timeUnit : variables.timeUnit;
 
-		if ( !isDate(variables.stats.nextRun) ){
+		if ( !isDate( variables.stats.nextRun ) ) {
+			doLog(
+				"setInitialNextRunTime",
+				{
+					delay         : amount,
+					timeUnit      : unit,
+					nextRunSet    : isDate( variables.stats.nextRun ) ? true : false,
+					nextRunInArgs : !isNull( arguments.nextRun )
+				}
+			);
 
-			doLog( "setInitialNextRunTime", {
-				delay         : amount,
-				timeUnit      : unit,
-				nextRunSet    : isDate(variables.stats.nextRun) ? true : false,
-				nextRunInArgs : !isNull(arguments.nextRun)
-			} );
-
-			if ( !isNull(arguments.nextRun) && isInstanceOf( arguments.nextRun, "java.time.LocalDateTime" ) )
+			if ( !isNull( arguments.nextRun ) && isInstanceOf( arguments.nextRun, "java.time.LocalDateTime" ) )
 				variables.stats.nextRun = arguments.nextRun;
 			else if ( !isInstanceOf( variables.stats.nextRun, "java.time.LocalDateTime" ) )
 				variables.stats.nextRun = getJavaNow();
@@ -1702,10 +1700,14 @@ component accessors="true" {
 						variables.stats.nextRun = variables.stats.nextRun.plusMinutes( javacast( "int", amount ) );
 						break;
 					case "milliseconds":
-						variables.stats.nextRun = variables.stats.nextRun.plusSeconds( javacast( "int", amount/1000 ) );
+						variables.stats.nextRun = variables.stats.nextRun.plusSeconds(
+							javacast( "int", amount / 1000 )
+						);
 						break;
 					case "microseconds":
-						variables.stats.nextRun = variables.stats.nextRun.plusNanos( javacast( "int", amount * 1000 ) );
+						variables.stats.nextRun = variables.stats.nextRun.plusNanos(
+							javacast( "int", amount * 1000 )
+						);
 						break;
 					case "nanoseconds":
 						variables.stats.nextRun = variables.stats.nextRun.plusNanos( javacast( "int", amount ) );
@@ -1717,34 +1719,40 @@ component accessors="true" {
 			}
 
 			var now       = getJavaNow();
-			var startTime = len(variables.startTime) ?
-									now
-										.withHour( javacast( "int", getToken( variables.startTime, 1, ":" ) ) )
-										.withMinute( javacast( "int", getToken( variables.startTime, 2, ":" ) ) )
-										.withSecond( javacast( "int", 0 ) ) :
-									now
-										.withHour( javacast( "int", 0 ) )
-										.withMinute( javacast( "int", 0 ) )
-										.withSecond( javacast( "int", 0 ) ) ;
-			var endTime = len(variables.endTime) ?
-									now
-										.withHour( javacast( "int", getToken( variables.endTime, 1, ":" ) ) )
-										.withMinute( javacast( "int", getToken( variables.endTime, 2, ":" ) ) )
-										.withSecond( javacast( "int", 0 ) ) :
-									now
-										.withHour( javacast( "int", 23 ) )
-										.withMinute( javacast( "int", 59 ) )
-										.withSecond( javacast( "int", 59 ) ) ;
+			var startTime = len( variables.startTime ) ? now
+				.withHour( javacast( "int", getToken( variables.startTime, 1, ":" ) ) )
+				.withMinute( javacast( "int", getToken( variables.startTime, 2, ":" ) ) )
+				.withSecond( javacast( "int", 0 ) ) : now
+				.withHour( javacast( "int", 0 ) )
+				.withMinute( javacast( "int", 0 ) )
+				.withSecond( javacast( "int", 0 ) );
+			var endTime = len( variables.endTime ) ? now
+				.withHour( javacast( "int", getToken( variables.endTime, 1, ":" ) ) )
+				.withMinute( javacast( "int", getToken( variables.endTime, 2, ":" ) ) )
+				.withSecond( javacast( "int", 0 ) ) : now
+				.withHour( javacast( "int", 23 ) )
+				.withMinute( javacast( "int", 59 ) )
+				.withSecond( javacast( "int", 59 ) );
 
 
-			doLog ( "startTime", { startTime:startTime.toString(), comp:now.compareTo( startTime ) } );
-			doLog ( "endTime", { endTime:endTime.toString(), comp:now.compareTo( endTime ) } );
+			doLog(
+				"startTime",
+				{
+					startTime : startTime.toString(),
+					comp      : now.compareTo( startTime )
+				}
+			);
+			doLog(
+				"endTime",
+				{
+					endTime : endTime.toString(),
+					comp    : now.compareTo( endTime )
+				}
+			);
 
-			if ( now.compareTo( startTime ) < 0 )
-				variables.stats.nextRun = startTime;
+			if ( now.compareTo( startTime ) < 0 ) variables.stats.nextRun = startTime;
 
-			if ( now.compareTo( endTime ) > 0 )
-				variables.stats.nextRun = startTime.plusDays( javacast( "int", 1 ) );
+			if ( now.compareTo( endTime ) > 0 ) variables.stats.nextRun = startTime.plusDays( javacast( "int", 1 ) );
 
 			variables.stats.nextRun = variables.stats.nextRun.toString();
 		}
@@ -1761,48 +1769,41 @@ component accessors="true" {
 		var amount = variables.spacedDelay != 0 ? variables.spacedDelay : variables.period;
 
 		// if overlaps are allowed task is immediately scheduled
-		if ( variables.spacedDelay == 0 && variables.stats.lastExecutionTime/1000 > variables.period )
-			amount = 0;
+		if ( variables.spacedDelay == 0 && variables.stats.lastExecutionTime / 1000 > variables.period ) amount = 0;
 
 		// reset nextRun to empty string to continue with process of setting
 		// next run time
 		variables.stats.nextRun = "";
 
 		// check if we are a first or last business day of month entry
-		if ( variables.firstBusinessDay ){
+		if ( variables.firstBusinessDay ) {
 			variables.stats.nextRun = getFirstBusinessDayOfTheMonth( variables.taskTime, true );
-		}
-		else if ( variables.lastBusinessDay ) {
+		} else if ( variables.lastBusinessDay ) {
 			variables.stats.nextRun = getLastBusinessDayOfTheMonth( variables.taskTime, true );
 		}
 		// check if we have a daily start or end time
-		else if ( len( variables.startTime) || len( variables.endTime ) ){
-			var startTime = len(variables.startTime) ?
-								now
-									.withHour( javacast( "int", getToken( variables.startTime, 1, ":" ) ) )
-									.withMinute( javacast( "int", getToken( variables.startTime, 2, ":" ) ) )
-									.withSecond( javacast( "int", 0 ) ) :
-								now
-									.withHour( javacast( "int", 0 ) )
-									.withMinute( javacast( "int", 0 ) )
-									.withSecond( javacast( "int", 0 ) ) ;
-			var endTime = len(variables.endTime) ?
-									now
-										.withHour( javacast( "int", getToken( variables.endTime, 1, ":" ) ) )
-										.withMinute( javacast( "int", getToken( variables.endTime, 2, ":" ) ) )
-										.withSecond( javacast( "int", 0 ) ) :
-									now
-										.withHour( javacast( "int", 23 ) )
-										.withMinute( javacast( "int", 59 ) )
-										.withSecond( javacast( "int", 59 ) ) ;
+		else if ( len( variables.startTime ) || len( variables.endTime ) ) {
+			var startTime = len( variables.startTime ) ? now
+				.withHour( javacast( "int", getToken( variables.startTime, 1, ":" ) ) )
+				.withMinute( javacast( "int", getToken( variables.startTime, 2, ":" ) ) )
+				.withSecond( javacast( "int", 0 ) ) : now
+				.withHour( javacast( "int", 0 ) )
+				.withMinute( javacast( "int", 0 ) )
+				.withSecond( javacast( "int", 0 ) );
+			var endTime = len( variables.endTime ) ? now
+				.withHour( javacast( "int", getToken( variables.endTime, 1, ":" ) ) )
+				.withMinute( javacast( "int", getToken( variables.endTime, 2, ":" ) ) )
+				.withSecond( javacast( "int", 0 ) ) : now
+				.withHour( javacast( "int", 23 ) )
+				.withMinute( javacast( "int", 59 ) )
+				.withSecond( javacast( "int", 59 ) );
 
-			if ( now.compareTo( startTime ) < 0 )
-				variables.stats.nextRun = startTime;
+			if ( now.compareTo( startTime ) < 0 ) variables.stats.nextRun = startTime;
 			else if ( now.compareTo( endTime ) > 0 )
 				variables.stats.nextRun = startTime.plusDays( javacast( "int", 1 ) );
 		}
 
-		if ( !len(variables.stats.nextRun) ){
+		if ( !len( variables.stats.nextRun ) ) {
 			switch ( variables.timeUnit ) {
 				case "days":
 					variables.stats.nextRun = now.plusDays( javacast( "int", amount ) );
@@ -1835,11 +1836,12 @@ component accessors="true" {
 	 * Debug logging method
 	 */
 	private function doLog( required string caller, struct args = {} ){
-		if ( variables.debugEnabled ){
+		if ( variables.debugEnabled ) {
 			var message = "ScheduledTask : " & variables.name & " : " & arguments.caller & "()" & (
 				structIsEmpty( arguments.args ) ? "" : " : " & serializeJSON( arguments.args )
 			);
 			variables.System.out.println( message );
 		}
 	}
+
 }

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -143,6 +143,11 @@ component accessors="true" {
 	property name="scheduler";
 
 	/**
+	 * A struct for the task that can be used to store any metadata
+	 */
+	property name="meta" type="struct";
+
+	/**
 	 * The collection of stats for the task: { name, created, lastRun, nextRun, totalRuns, totalFailures, totalSuccess, lastResult, neverRun, lastExecutionTime }
 	 */
 	property name="stats" type="struct";
@@ -255,6 +260,8 @@ component accessors="true" {
 			// Server IP
 			"localIp"           : variables.util.getServerIp()
 		};
+		// Prepare for the user to store metadata
+		variables.meta          = {};
 		// Life cycle methods
 		variables.beforeTask    = "";
 		variables.afterTask     = "";
@@ -352,6 +359,46 @@ component accessors="true" {
 	}
 
 	/**
+	 * Update the debug setting for this task!
+	 */
+	ScheduledTask function debug( required boolean value ){
+		doLog( "debug" );
+
+		variables.debugEnabled = arguments.value;
+		return this;
+	}
+
+	/**
+	 * Set the meta data for this task!
+	 */
+	ScheduledTask function setMeta( required struct meta ){
+		doLog( "setMeta" );
+
+		variables.meta = arguments.meta;
+		return this;
+	}
+
+	/**
+	 * Set a specific meta data key for this task!
+	 */
+	ScheduledTask function setMetaKey( required string key, required any value ){
+		doLog( "setMetaKey" );
+
+		variables.meta[ arguments.key ] = arguments.value;
+		return this;
+	}
+
+	/**
+	 * Delete a specific meta data key from this task!
+	 */
+	ScheduledTask function deleteMetaKey( required string key ){
+		doLog( "deleteMetaKey" );
+
+		variables.meta.delete( arguments.key );
+		return this;
+	}
+
+	/**
 	 * --------------------------------------------------------------------------
 	 * Restrictions
 	 * --------------------------------------------------------------------------
@@ -375,16 +422,6 @@ component accessors="true" {
 		doLog( "disable" );
 
 		variables.disabled = true;
-		return this;
-	}
-
-	/**
-	 * Update the debug setting for this task!
-	 */
-	ScheduledTask function debug( required boolean value ){
-		doLog( "debug" );
-
-		variables.debugEnabled = arguments.value;
 		return this;
 	}
 
@@ -1585,6 +1622,12 @@ component accessors="true" {
 			return isCustomFunction( value ) || listFindNoCase( "this", key ) ? false : true;
 		} );
 	}
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Private Methods
+	 * --------------------------------------------------------------------------
+	 */
 
 	/**
 	 * This utility method gives us the first business day of the month in Java format

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -1672,17 +1672,17 @@ component accessors="true" {
 		var amount = structKeyExists( arguments, "delay" ) ? arguments.delay : variables.delay;
 		var unit   = structKeyExists( arguments, "timeUnit" ) ? arguments.timeUnit : variables.timeUnit;
 
-		if ( !isDate( variables.stats.nextRun ) ) {
-			doLog(
-				"setInitialNextRunTime",
-				{
-					delay         : amount,
-					timeUnit      : unit,
-					nextRunSet    : isDate( variables.stats.nextRun ) ? true : false,
-					nextRunInArgs : !isNull( arguments.nextRun )
-				}
-			);
+		doLog(
+			"setInitialNextRunTime",
+			{
+				delay         : amount,
+				timeUnit      : unit,
+				nextRunSet    : isValid( "date", variables.stats.nextRun ) ? true : false,
+				nextRunInArgs : !isNull( arguments.nextRun )
+			}
+		);
 
+		if ( !isValid( "date", variables.stats.nextRun ) ) {
 			if ( !isNull( arguments.nextRun ) && isInstanceOf( arguments.nextRun, "java.time.LocalDateTime" ) )
 				variables.stats.nextRun = arguments.nextRun;
 			else if ( !isInstanceOf( variables.stats.nextRun, "java.time.LocalDateTime" ) )

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -9,17 +9,17 @@ component accessors="true" {
 	/**
 	 * The human name of this task
 	 */
-	property name="name";
+	property name="name" type="string";
 
 	/**
 	 * The task closure or CFC to execute in the task
 	 */
-	property name="task";
+	property name="task" type="any";
 
 	/**
 	 * The method to execute if the task is a CFC
 	 */
-	property name="method";
+	property name="method" type="string";
 
 	/**
 	 * The delay or time to wait before we execute the task in the scheduler
@@ -29,7 +29,7 @@ component accessors="true" {
 	/**
 	 * The time unit string used when there is a delay requested for the task
 	 */
-	property name="delayTimeUnit";
+	property name="delayTimeUnit" type="string";
 
 	/**
 	 * A fixed time period of execution of the tasks in this schedule. It does not wait for tasks to finish,
@@ -45,7 +45,7 @@ component accessors="true" {
 	/**
 	 * The time unit string used to schedule the task
 	 */
-	property name="timeUnit";
+	property name="timeUnit" type="string";
 
 	/**
 	 * A handy boolean that is set when the task is annually scheduled
@@ -55,7 +55,7 @@ component accessors="true" {
 	/**
 	 * The boolean value is used for debugging
 	 */
-	property name="debug";
+	property name="debug" type="boolean";
 
 	/**
 	 * A handy boolean that disables the scheduling of this task
@@ -115,32 +115,32 @@ component accessors="true" {
 	/**
 	 * Constraint of when the task can start execution.
 	 */
-	property name="startOnDateTime";
+	property name="startOnDateTime" type="date";
 
 	/**
 	 * Constraint of when the task must not continue to execute
 	 */
-	property name="endOnDateTime";
+	property name="endOnDateTime" type="date";
 
 	/**
 	 * Constraint to limit the task to run after a specified time of day.
 	 */
-	property name="startTime";
+	property name="startTime" type="string";
 
 	/**
 	 * Constraint to limit the task to run before a specified time of day.
 	 */
-	property name="endTime";
+	property name="endTime" type="string";
 
 	/**
 	 * The boolean value that lets us know if this task has been scheduled
 	 */
-	property name="scheduled";
+	property name="scheduled" type="boolean";
 
 	/**
 	 * This task can be assigned to a task scheduler or be executed on its own at runtime
 	 */
-	property name="scheduler";
+	property name="scheduler" type="any";
 
 	/**
 	 * A struct for the task that can be used to store any metadata
@@ -155,27 +155,27 @@ component accessors="true" {
 	/**
 	 * The timezone this task runs under, by default we use the timezone defined in the schedulers
 	 */
-	property name="timezone";
+	property name="timezone" type="string";
 
 	/**
 	 * The before task closure
 	 */
-	property name="beforeTask";
+	property name="beforeTask" type="any";
 
 	/**
 	 * The after task closure
 	 */
-	property name="afterTask";
+	property name="afterTask" type="any";
 
 	/**
 	 * The task success closure
 	 */
-	property name="onTaskSuccess";
+	property name="onTaskSuccess" type="any";
 
 	/**
 	 * The task failure closure
 	 */
-	property name="onTaskFailure";
+	property name="onTaskFailure" type="any";
 
 
 	/**
@@ -465,12 +465,8 @@ component accessors="true" {
 	ScheduledTask function startOnTime( required string time ){
 		debugLog( "startOnTime" );
 
-		// Check for minutes else add them
-		if ( !find( ":", arguments.time ) ) {
-			arguments.time &= ":00";
-		}
 		// Validate time format
-		validateTime( arguments.time );
+		arguments.time = validateTime( arguments.time );
 
 		variables.startTime = arguments.time;
 		return this;
@@ -483,12 +479,8 @@ component accessors="true" {
 	ScheduledTask function endOnTime( required string time ){
 		debugLog( "endOnTime" );
 
-		// Check for minutes else add them
-		if ( !find( ":", arguments.time ) ) {
-			arguments.time &= ":00";
-		}
 		// Validate time format
-		validateTime( arguments.time );
+		arguments.time = validateTime( arguments.time );
 
 		variables.endTime = arguments.time;
 		return this;
@@ -622,7 +614,7 @@ component accessors="true" {
 	 * This is the runnable proxy method that executes your code by the executors
 	 */
 	function run( boolean force = false ){
-		debugLog( "run - " & arguments.force );
+		debugLog( "run( #arguments.force# )" );
 
 		var sTime = getTickCount();
 
@@ -677,8 +669,8 @@ component accessors="true" {
 			// store failures
 			variables.stats.totalFailures = variables.stats.totalFailures + 1;
 			// Log it, so it doesn't go to ether
-			err( "Error running task (#getname()#) : #e.message & e.detail#" );
-			err( "Stacktrace for task (#getname()#) : #e.stackTrace#" );
+			err( "Error running task (#getName()#) : #e.message & e.detail#" );
+			err( "Stacktrace for task (#geNname()#) : #e.stackTrace#" );
 
 			// Try to execute the error handlers. Try try try just in case.
 			try {
@@ -699,8 +691,8 @@ component accessors="true" {
 				}
 			} catch ( any afterException ) {
 				// Log it, so it doesn't go to ether and executor doesn't die.
-				err( "Error running task (#getname()#) after/error handlers : #afterException.message & afterException.detail#" );
-				err( "Stacktrace for task (#getname()#) after/error handlers : #afterException.stackTrace#" );
+				err( "Error running task (#getName()#) after/error handlers : #afterException.message & afterException.detail#" );
+				err( "Stacktrace for task (#getName()#) after/error handlers : #afterException.stackTrace#" );
 			}
 		} finally {
 			// Store finalization stats
@@ -776,16 +768,19 @@ component accessors="true" {
 			}
 		}
 
-		variables.scheduled = true;
-
 		debugLog(
-			"start - " & variables.name & " - should execute initial next run call " &
-			serializeJSON( {
-				"spacedDelay" : variables.spacedDelay,
-				"period"      : variables.period,
-				"delay"       : variables.delay
-			} )
+			"start",
+			{
+				delay         : variables.delay,
+				delayTimeUnit : variables.delayTimeUnit,
+				period        : variables.period,
+				spacedDelay   : variables.spacedDelay,
+				timeUnit      : variables.timeUnit,
+				type          : variables.spacedDelay > 0 ? "scheduleWithFixedDelay" : variables.period > 0 ? "scheduleAtFixedRate" : "runOnce"
+			}
 		);
+
+		variables.scheduled = true;
 
 		// Startup a spaced frequency task: no overlaps
 		if ( variables.spacedDelay > 0 ) {
@@ -883,7 +878,7 @@ component accessors="true" {
 	 *
 	 * @delay          The delay that will be used before executing the task
 	 * @timeUnit       The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
-	 * @overwrites     Boolean to overwrite delay and timeUnit even if value is already set, this is helpful if the delay is set later in the chain when creating the task - defaults to false
+	 * @overwrites     Boolean to overwrite delay and delayTimeUnit even if value is already set, this is helpful if the delay is set later in the chain when creating the task - defaults to false
 	 * @setNextRunTime Boolean to execute setInitialNextRunTime() - defaults to true
 	 */
 	ScheduledTask function delay(
@@ -930,7 +925,8 @@ component accessors="true" {
 		return this;
 	}
 
-	/**	 * Run the task every custom period of execution
+	/**
+	 * Run the task every custom period of execution
 	 *
 	 * @period   The period of execution
 	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
@@ -950,7 +946,7 @@ component accessors="true" {
 	 * Run the task every minute from the time it get's scheduled
 	 */
 	ScheduledTask function everyMinute(){
-		debugLog( "everyMinute", arguments );
+		debugLog( "everyMinute" );
 
 		return this.every( 1, "minutes" );
 	}
@@ -959,7 +955,7 @@ component accessors="true" {
 	 * Run the task every hour from the time it get's scheduled
 	 */
 	ScheduledTask function everyHour(){
-		debugLog( "everyHour", arguments );
+		debugLog( "everyHour" );
 
 		return this.every( 1, "hours" );
 	}
@@ -972,25 +968,15 @@ component accessors="true" {
 	ScheduledTask function everyHourAt( required numeric minutes ){
 		debugLog( "everyHourAt", arguments );
 
+		// Get times
 		var now     = getJavaNow();
 		var nextRun = now.withMinute( javacast( "int", arguments.minutes ) ).withSecond( javacast( "int", 0 ) );
-		// If we passed it, then move the hour by 1
+		// If we passed it, then move to the next hour
 		if ( now.compareTo( nextRun ) > 0 ) {
 			nextRun = nextRun.plusHours( javacast( "int", 1 ) );
 		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.dateTimeHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds",
-			true
-		);
-		// Set the period to be every hour
-		variables.period   = variables.timeUnitHelper.get( "hours" ).toSeconds( 1 );
-		variables.timeUnit = "seconds";
+		// Set the initial delay, period, and time unit
+		setInitialDelayPeriodAndTimeUnit( now, nextRun, "hours" );
 
 		return this;
 	}
@@ -999,7 +985,7 @@ component accessors="true" {
 	 * Run the task every day at midnight
 	 */
 	ScheduledTask function everyDay(){
-		debugLog( "everyDay", arguments );
+		debugLog( "everyDay" );
 
 		return this.everyDayAt( "00:00" );
 	}
@@ -1013,12 +999,9 @@ component accessors="true" {
 	ScheduledTask function everyDayAt( required string time ){
 		debugLog( "everyDayAt", arguments );
 
-		// Check for minutes else add them
-		if ( !find( ":", arguments.time ) ) {
-			arguments.time &= ":00";
-		}
 		// Validate time format
-		validateTime( arguments.time );
+		arguments.time = validateTime( arguments.time );
+
 		// Get times
 		var now     = getJavaNow();
 		var nextRun = now
@@ -1029,19 +1012,8 @@ component accessors="true" {
 		if ( now.compareTo( nextRun ) > 0 ) {
 			nextRun = nextRun.plusDays( javacast( "int", 1 ) );
 		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.dateTimeHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds",
-			true
-		);
-		// Set the period to every day in seconds
-		variables.period   = variables.timeUnitHelper.get( "DAYS" ).toSeconds( 1 );
-		variables.timeUnit = "seconds";
+		// Set the initial delay, period, and time unit
+		setInitialDelayPeriodAndTimeUnit( now, nextRun );
 
 		return this;
 	}
@@ -1050,7 +1022,7 @@ component accessors="true" {
 	 * Run the task every Sunday at midnight
 	 */
 	ScheduledTask function everyWeek(){
-		debugLog( "everyWeek", arguments );
+		debugLog( "everyWeek" );
 
 		return this.everyWeekOn( 7 );
 	}
@@ -1064,13 +1036,11 @@ component accessors="true" {
 	ScheduledTask function everyWeekOn( required numeric dayOfWeek, string time = "00:00" ){
 		debugLog( "everyWeekOn", arguments );
 
-		var now = getJavaNow();
-		// Check for minutes else add them
-		if ( !find( ":", arguments.time ) ) {
-			arguments.time &= ":00";
-		}
 		// Validate time format
-		validateTime( arguments.time );
+		arguments.time = validateTime( arguments.time );
+
+		// Get times
+		var now     = getJavaNow();
 		var nextRun = now
 			// Given day
 			.with( variables.dateTimeHelper.ChronoField.DAY_OF_WEEK, javacast( "int", arguments.dayOfWeek ) )
@@ -1082,19 +1052,9 @@ component accessors="true" {
 		if ( now.compareTo( nextRun ) > 0 ) {
 			nextRun = nextRun.plusWeeks( javacast( "int", 1 ) );
 		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.dateTimeHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds",
-			true
-		);
-		// Set the period to every week in seconds
-		variables.period       = variables.timeUnitHelper.get( "days" ).toSeconds( 7 );
-		variables.timeUnit     = "seconds";
+		// Set the initial delay, period, and time unit
+		setInitialDelayPeriodAndTimeUnit( now, nextRun, "days", 7 );
+		// set constraints
 		variables.dayOfTheWeek = arguments.dayOfWeek;
 
 		return this;
@@ -1104,7 +1064,7 @@ component accessors="true" {
 	 * Run the task on the first day of every month at midnight
 	 */
 	ScheduledTask function everyMonth(){
-		debugLog( "everyMonth", arguments );
+		debugLog( "everyMonth" );
 
 		return this.everyMonthOn( 1 );
 	}
@@ -1118,14 +1078,11 @@ component accessors="true" {
 	ScheduledTask function everyMonthOn( required numeric day, string time = "00:00" ){
 		debugLog( "everyMonthOn", arguments );
 
-		var now = getJavaNow();
-		// Check for minutes else add them
-		if ( !find( ":", arguments.time ) ) {
-			arguments.time &= ":00";
-		}
 		// Validate time format
-		validateTime( arguments.time );
-		// Get new time
+		arguments.time = validateTime( arguments.time );
+
+		// Get times
+		var now     = getJavaNow();
 		var nextRun = now
 			// First day of the month
 			.with( variables.dateTimeHelper.ChronoField.DAY_OF_MONTH, javacast( "int", arguments.day ) )
@@ -1133,24 +1090,13 @@ component accessors="true" {
 			.withHour( javacast( "int", getToken( arguments.time, 1, ":" ) ) )
 			.withMinute( javacast( "int", getToken( arguments.time, 2, ":" ) ) )
 			.withSecond( javacast( "int", 0 ) );
-		// Have we passed it
+		// If we passed it, then move to the next month
 		if ( now.compareTo( nextRun ) > 0 ) {
 			nextRun = nextRun.plusMonths( javacast( "int", 1 ) );
 		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.dateTimeHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds",
-			true
-		);
-		// Set the period to one day. And make sure we add a constraint for it
-		// Mostly because every month is different
-		variables.period        = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
-		variables.timeUnit      = "seconds";
+		// Set the initial delay, period, and time unit
+		setInitialDelayPeriodAndTimeUnit( now, nextRun );
+		// Set constraints
 		variables.dayOfTheMonth = arguments.day;
 
 		return this;
@@ -1164,33 +1110,19 @@ component accessors="true" {
 	ScheduledTask function onFirstBusinessDayOfTheMonth( string time = "00:00" ){
 		debugLog( "onFirstBusinessDayOfTheMonth", arguments );
 
-		var now = getJavaNow();
-		// Check for minutes else add them
-		if ( !find( ":", arguments.time ) ) {
-			arguments.time &= ":00";
-		}
 		// Validate time format
-		validateTime( arguments.time );
-		// Get new time
+		arguments.time = validateTime( arguments.time );
+
+		// Get times
+		var now     = getJavaNow();
 		var nextRun = getFirstBusinessDayOfTheMonth( arguments.time );
-		// Have we passed it
+		// If we passed it, then move to the first business day of next month
 		if ( now.compareTo( nextRun ) > 0 ) {
 			nextRun = getFirstBusinessDayOfTheMonth( arguments.time, true );
 		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.dateTimeHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds",
-			true
-		);
-		// Set the period to one day. And make sure we add a constraint for it
-		// Mostly because every month is different
-		variables.period           = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
-		variables.timeUnit         = "seconds";
+		// Set the initial delay, period, and time unit
+		setInitialDelayPeriodAndTimeUnit( now, nextRun );
+		// Set constraints
 		variables.firstBusinessDay = true;
 		variables.taskTime         = arguments.time;
 
@@ -1205,33 +1137,19 @@ component accessors="true" {
 	ScheduledTask function onLastBusinessDayOfTheMonth( string time = "00:00" ){
 		debugLog( "onLastBusinessDayOfTheMonth", arguments );
 
-		var now = getJavaNow();
-		// Check for minutes else add them
-		if ( !find( ":", arguments.time ) ) {
-			arguments.time &= ":00";
-		}
 		// Validate time format
-		validateTime( arguments.time );
-		// Get the last day of the month
+		arguments.time = validateTime( arguments.time );
+
+		// Get times
+		var now     = getJavaNow();
 		var nextRun = getLastBusinessDayOfTheMonth( arguments.time );
-		// Have we passed it
+		// If we passed it, then move to the last business day of next month
 		if ( now.compareTo( nextRun ) > 0 ) {
 			nextRun = getLastBusinessDayOfTheMonth( arguments.time, true );
 		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.dateTimeHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds",
-			true
-		);
-		// Set the period to one day. And make sure we add a constraint for it
-		// Mostly because every month is different
-		variables.period          = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
-		variables.timeUnit        = "seconds";
+		// Set the initial delay, period, and time unit
+		setInitialDelayPeriodAndTimeUnit( now, nextRun );
+		// Set constraints
 		variables.lastBusinessDay = true;
 		variables.taskTime        = arguments.time;
 
@@ -1261,13 +1179,11 @@ component accessors="true" {
 	){
 		debugLog( "everyYearOn", arguments );
 
-		var now = getJavaNow();
-		// Check for minutes else add them
-		if ( !find( ":", arguments.time ) ) {
-			arguments.time &= ":00";
-		}
 		// Validate time format
-		validateTime( arguments.time );
+		arguments.time = validateTime( arguments.time );
+
+		// Get times
+		var now     = getJavaNow();
 		var nextRun = now
 			// Specific month
 			.with( variables.dateTimeHelper.ChronoField.MONTH_OF_YEAR, javacast( "int", arguments.month ) )
@@ -1277,23 +1193,13 @@ component accessors="true" {
 			.withHour( javacast( "int", getToken( arguments.time, 1, ":" ) ) )
 			.withMinute( javacast( "int", getToken( arguments.time, 2, ":" ) ) )
 			.withSecond( javacast( "int", 0 ) );
-		// Have we passed it?
+		// If we passed it, then move to the next year
 		if ( now.compareTo( nextRun ) > 0 ) {
 			nextRun = nextRun.plusYears( javacast( "int", 1 ) );
 		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.dateTimeHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds",
-			true
-		);
-		// Set the period to
-		variables.period   = variables.timeUnitHelper.get( "days" ).toSeconds( 365 );
-		variables.timeUnit = "seconds";
+		// Set the initial delay, period, and time unit
+		setInitialDelayPeriodAndTimeUnit( now, nextRun, "days", 365 );
+		// Set constraints
 		variables.annually = true;
 
 		return this;
@@ -1307,12 +1213,9 @@ component accessors="true" {
 	ScheduledTask function onWeekends( string time = "00:00" ){
 		debugLog( "onWeekends", arguments );
 
-		// Check for minutes else add them
-		if ( !find( ":", arguments.time ) ) {
-			arguments.time &= ":00";
-		}
 		// Validate time format
-		validateTime( arguments.time );
+		arguments.time = validateTime( arguments.time );
+
 		// Get times
 		var now     = getJavaNow();
 		var nextRun = now
@@ -1323,20 +1226,9 @@ component accessors="true" {
 		if ( now.compareTo( nextRun ) > 0 ) {
 			nextRun = nextRun.plusDays( javacast( "int", 1 ) );
 		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.dateTimeHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds",
-			true
-		);
-		// Set the period to every day in seconds
-		variables.period   = variables.timeUnitHelper.get( "DAYS" ).toSeconds( 1 );
-		variables.timeUnit = "seconds";
-		// Constraint to only run on weekends
+		// Set the initial delay, period, and time unit
+		setInitialDelayPeriodAndTimeUnit( now, nextRun );
+		// Set constraints
 		variables.weekends = true;
 		variables.weekdays = false;
 
@@ -1351,12 +1243,9 @@ component accessors="true" {
 	ScheduledTask function onWeekdays( string time = "00:00" ){
 		debugLog( "onWeekdays", arguments );
 
-		// Check for minutes else add them
-		if ( !find( ":", arguments.time ) ) {
-			arguments.time &= ":00";
-		}
 		// Validate time format
-		validateTime( arguments.time );
+		arguments.time = validateTime( arguments.time );
+
 		// Get times
 		var now     = getJavaNow();
 		var nextRun = now
@@ -1367,20 +1256,9 @@ component accessors="true" {
 		if ( now.compareTo( nextRun ) > 0 ) {
 			nextRun = nextRun.plusDays( javacast( "int", 1 ) );
 		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.dateTimeHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds",
-			true
-		);
-		// Set the period to every day in seconds
-		variables.period   = variables.timeUnitHelper.get( "DAYS" ).toSeconds( 1 );
-		variables.timeUnit = "seconds";
-		// Constraint to only run on weekdays
+		// Set the initial delay, period, and time unit
+		setInitialDelayPeriodAndTimeUnit( now, nextRun );
+		// Set constraints
 		variables.weekdays = true;
 		variables.weekends = false;
 
@@ -1573,13 +1451,20 @@ component accessors="true" {
 	}
 
 	/**
-	 * Validates an incoming string to adhere to either: HH:mm
+	 * Validates an incoming string to adhere to HH:mm
 	 *
 	 * @time The time to check
 	 *
-	 * @throws InvalidTimeException - If the time is invalid, else it just continues operation
+	 * @throws InvalidTimeException - If the time is invalid, else it returns the time value
 	 */
-	function validateTime( required time ){
+	string function validateTime( required time ){
+		// Check for minutes else add them
+		if ( !find( ":", arguments.time ) ) {
+			arguments.time &= ":00";
+		}
+
+		debugLog( "validateTime", arguments );
+
 		// Regex check
 		if ( !reFind( "^[0-2][0-9]\:[0-5][0-9]$", arguments.time ) ) {
 			throw(
@@ -1587,13 +1472,17 @@ component accessors="true" {
 				type    = "InvalidTimeException"
 			);
 		}
+
+		return arguments.time;
 	}
 
 	/**
 	 * Get a Java localDateTime object using the current date/time and timezone
+	 *
+	 * @now The date to use as the starting point, defaults to now() - modifications are helpful for testing
 	 */
-	function getJavaNow(){
-		return variables.dateTimeHelper.toLocalDateTime( now(), this.getTimezone() );
+	function getJavaNow( date now = now() ){
+		return variables.dateTimeHelper.toLocalDateTime( arguments.now, this.getTimezone() );
 	}
 
 	/**
@@ -1788,10 +1677,51 @@ component accessors="true" {
 	}
 
 	/**
+	 * This method is called to set the initial delay period which
+	 * calls setInitialNextRunTime, then sets the timeUnit to seconds
+	 * and the period based on a value to convert to seconds.
+	 *
+	 * @now              The current time to use for calculating the initial delay
+	 * @nextRun          The first run time to use for calculating the initial delay
+	 * @periodValue      The value to use when calculating the period to seconds
+	 * @periodMultiplier The multiplier to use when calculating the period to seconds
+	 */
+	private function setInitialDelayPeriodAndTimeUnit(
+		required now,
+		required nextRun,
+		string periodValue       = "days",
+		numeric periodMultiplier = 1
+	){
+		debugLog(
+			"setInitialDelayPeriodAndTimeUnit",
+			{
+				now              : arguments.now.toString(),
+				nextRun          : arguments.nextRun.toString(),
+				periodValue      : arguments.periodValue,
+				periodMultiplier : arguments.periodMultiplier
+			}
+		);
+
+		// Get the duration time for the next run and delay accordingly
+		this.delay(
+			variables.dateTimeHelper
+				.duration()
+				.getNative()
+				.between( arguments.now, arguments.nextRun )
+				.getSeconds(),
+			"seconds",
+			true
+		);
+		// Set the period to be every hour in seconds
+		variables.period   = variables.timeUnitHelper.get( arguments.period ).toSeconds( arguments.periodMultiplier );
+		variables.timeUnit = "seconds";
+	}
+
+	/**
 	 * This method is called to set the next run time of the task based on the timeUnit and period.
 	 */
 	private function setNextRunTime(){
-		debugLog( "setNextRunTime", arguments );
+		debugLog( "setNextRunTime" );
 
 		var now    = getJavaNow();
 		var amount = variables.spacedDelay != 0 ? variables.spacedDelay : variables.period;
@@ -1870,8 +1800,14 @@ component accessors="true" {
 	function debugLog( required string caller, struct args = {} ){
 		if ( variables.debug ) {
 			var message = dateTimeFormat( now(), "yyyy-mm-dd hh:nn:ss" ) &
-			" : ScheduledTask : " & variables.name & " : " & arguments.caller & "()" & (
-				structIsEmpty( arguments.args ) ? "" : " : " & serializeJSON( arguments.args )
+			" : ScheduledTask : " &
+			variables.name & " : " &
+			arguments.caller &
+			( !arguments.caller.find( "(" ) ? "()" : "" ) &
+			(
+				structIsEmpty( arguments.args ) ? "" : chr( 10 ) & repeatString( " ", 8 ) & serializeJSON(
+					arguments.args
+				)
 			);
 			variables.executor.out( message );
 		}

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -55,7 +55,7 @@ component accessors="true" {
 	/**
 	 * The boolean value is used for debugging
 	 */
-	property name="debugEnabled";
+	property name="debug";
 
 	/**
 	 * A handy boolean that disables the scheduling of this task
@@ -194,8 +194,6 @@ component accessors="true" {
 		method   = "run",
 		debug    = false
 	){
-		// used for debugging output
-		variables.System           = createObject( "java", "java.lang.System" );
 		// Utility class
 		variables.util             = new coldbox.system.core.util.Util();
 		// Link up the executor and name
@@ -216,7 +214,7 @@ component accessors="true" {
 		variables.noOverlaps       = false;
 		// Constraints
 		variables.annually         = false;
-		variables.debugEnabled     = arguments.debug;
+		variables.debug            = arguments.debug;
 		variables.disabled         = false;
 		variables.whenClosure      = "";
 		variables.dayOfTheMonth    = 0;
@@ -268,7 +266,7 @@ component accessors="true" {
 		variables.onTaskSuccess = "";
 		variables.onTaskFailure = "";
 
-		doLog( "init" );
+		debugLog( "init" );
 
 		return this;
 	}
@@ -285,7 +283,7 @@ component accessors="true" {
 	 * @throws UserInterruptException - When the thread has been interrupted
 	 */
 	function checkInterrupted(){
-		doLog( "checkInterrupted" );
+		debugLog( "checkInterrupted" );
 
 		var thisThread = createObject( "java", "java.lang.Thread" ).currentThread();
 		// Has the user/system tried to interrupt this thread?
@@ -327,7 +325,7 @@ component accessors="true" {
 	 * @timezone The timezone string identifier
 	 */
 	ScheduledTask function setTimezone( required timezone ){
-		doLog( "setTimezone", arguments );
+		debugLog( "setTimezone", arguments );
 
 		variables.timezone = createObject( "java", "java.time.ZoneId" ).of( arguments.timezone );
 		return this;
@@ -337,7 +335,7 @@ component accessors="true" {
 	 * Has this task been assigned to a scheduler or not?
 	 */
 	boolean function hasScheduler(){
-		doLog( "hasScheduler" );
+		debugLog( "hasScheduler" );
 
 		return isObject( variables.scheduler );
 	}
@@ -351,7 +349,7 @@ component accessors="true" {
 	 * @return The schedule with the task/method registered on it
 	 */
 	ScheduledTask function call( required task, method = "run" ){
-		doLog( "call" );
+		debugLog( "call" );
 
 		variables.task   = arguments.task;
 		variables.method = arguments.method;
@@ -362,9 +360,9 @@ component accessors="true" {
 	 * Update the debug setting for this task!
 	 */
 	ScheduledTask function debug( required boolean value ){
-		doLog( "debug" );
+		debugLog( "debug" );
 
-		variables.debugEnabled = arguments.value;
+		variables.debug = arguments.value;
 		return this;
 	}
 
@@ -372,7 +370,7 @@ component accessors="true" {
 	 * Set the meta data for this task!
 	 */
 	ScheduledTask function setMeta( required struct meta ){
-		doLog( "setMeta" );
+		debugLog( "setMeta" );
 
 		variables.meta = arguments.meta;
 		return this;
@@ -382,7 +380,7 @@ component accessors="true" {
 	 * Set a specific meta data key for this task!
 	 */
 	ScheduledTask function setMetaKey( required string key, required any value ){
-		doLog( "setMetaKey" );
+		debugLog( "setMetaKey" );
 
 		variables.meta[ arguments.key ] = arguments.value;
 		return this;
@@ -392,7 +390,7 @@ component accessors="true" {
 	 * Delete a specific meta data key from this task!
 	 */
 	ScheduledTask function deleteMetaKey( required string key ){
-		doLog( "deleteMetaKey" );
+		debugLog( "deleteMetaKey" );
 
 		variables.meta.delete( arguments.key );
 		return this;
@@ -409,7 +407,7 @@ component accessors="true" {
 	 * If the closure returns true we schedule, else we disable it.
 	 */
 	ScheduledTask function when( target ){
-		doLog( "when" );
+		debugLog( "when" );
 
 		variables.whenClosure = arguments.target;
 		return this;
@@ -419,7 +417,7 @@ component accessors="true" {
 	 * Disable the task when scheduled, meaning, don't run this sucker!
 	 */
 	ScheduledTask function disable(){
-		doLog( "disable" );
+		debugLog( "disable" );
 
 		variables.disabled = true;
 		return this;
@@ -429,7 +427,7 @@ component accessors="true" {
 	 * Enable the task when disabled so we can run again
 	 */
 	ScheduledTask function enable(){
-		doLog( "enable" );
+		debugLog( "enable" );
 
 		variables.disabled = false;
 		return this;
@@ -442,7 +440,7 @@ component accessors="true" {
 	 * - when closure
 	 */
 	boolean function isDisabled(){
-		doLog( "isDisabled" );
+		debugLog( "isDisabled" );
 
 		return variables.disabled;
 	}
@@ -453,7 +451,8 @@ component accessors="true" {
 	 * @endTime   The specific time using 24 hour format => HH:mm
 	 */
 	ScheduledTask function between( required string startTime, required string endTime ){
-		doLog( "between" );
+		debugLog( "between" );
+
 		startOnTime( arguments.startTime );
 		endOnTime( arguments.endTime );
 		return this;
@@ -464,7 +463,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm
 	 */
 	ScheduledTask function startOnTime( required string time ){
-		doLog( "startOnTime" );
+		debugLog( "startOnTime" );
 
 		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
@@ -482,7 +481,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm
 	 */
 	ScheduledTask function endOnTime( required string time ){
-		doLog( "endOnTime" );
+		debugLog( "endOnTime" );
 
 		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
@@ -492,7 +491,6 @@ component accessors="true" {
 		validateTime( arguments.time );
 
 		variables.endTime = arguments.time;
-
 		return this;
 	}
 
@@ -515,7 +513,7 @@ component accessors="true" {
 	 * This method is called by the `run()` method at runtime to determine if the task can be ran at that point in time
 	 */
 	boolean function isConstrained(){
-		doLog( "isConstrained" );
+		debugLog( "isConstrained" );
 
 		var now = getJavaNow();
 
@@ -595,7 +593,7 @@ component accessors="true" {
 			return true;
 		}
 
-		// if we have a start time constraint
+		// if we have a start time and / or end time constraint
 		if (
 			len( variables.startTime ) ||
 			len( variables.endTime )
@@ -608,7 +606,9 @@ component accessors="true" {
 			var _endTime = variables.dateTimeHelper.parse(
 				dateFormat( now(), "yyyy-mm-dd" ) & "T" & ( len( variables.endTime ) ? variables.endTime : "23:59:59" )
 			);
-			if ( now.isBefore( _startTime ) || now.isAfter( _endTime ) ) return true;
+			if ( now.isBefore( _startTime ) || now.isAfter( _endTime ) ) {
+				return true;
+			}
 		}
 
 		return false;
@@ -618,7 +618,7 @@ component accessors="true" {
 	 * This is the runnable proxy method that executes your code by the executors
 	 */
 	function run( boolean force = false ){
-		doLog( "run - " & arguments.force );
+		debugLog( "run - " & arguments.force );
 
 		var sTime = getTickCount();
 
@@ -715,6 +715,7 @@ component accessors="true" {
 	 * any type of cleanups
 	 */
 	function cleanupTaskRun(){
+		debugLog( "cleanupTaskRun" );
 		// no cleanups for now
 	}
 
@@ -773,7 +774,7 @@ component accessors="true" {
 
 		variables.scheduled = true;
 
-		doLog(
+		debugLog(
 			"start - " & variables.name & " - should execute initial next run call " &
 			serializeJSON( {
 				"spacedDelay" : variables.spacedDelay,
@@ -825,7 +826,7 @@ component accessors="true" {
 	 * @target The closure to execute
 	 */
 	ScheduledTask function before( required target ){
-		doLog( "before" );
+		debugLog( "before" );
 
 		variables.beforeTask = arguments.target;
 		return this;
@@ -837,7 +838,7 @@ component accessors="true" {
 	 * @target The closure to execute
 	 */
 	ScheduledTask function after( required target ){
-		doLog( "after" );
+		debugLog( "after" );
 
 		variables.afterTask = arguments.target;
 		return this;
@@ -849,7 +850,7 @@ component accessors="true" {
 	 * @target The closure to execute
 	 */
 	ScheduledTask function onSuccess( required target ){
-		doLog( "onSuccess" );
+		debugLog( "onSuccess" );
 
 		variables.onTaskSuccess = arguments.target;
 		return this;
@@ -861,7 +862,7 @@ component accessors="true" {
 	 * @target The closure to execute
 	 */
 	ScheduledTask function onFailure( required target ){
-		doLog( "onFailure" );
+		debugLog( "onFailure" );
 
 		variables.onTaskFailure = arguments.target;
 		return this;
@@ -887,7 +888,7 @@ component accessors="true" {
 		boolean overwrites     = false,
 		boolean setNextRunTime = true
 	){
-		doLog( "delay", arguments );
+		debugLog( "delay", arguments );
 
 		if ( arguments.overwrites || !variables.delay ) {
 			variables.delay         = arguments.delay;
@@ -907,7 +908,7 @@ component accessors="true" {
 	 * @timeUnit    The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 */
 	ScheduledTask function spacedDelay( numeric spacedDelay, timeUnit = "milliseconds" ){
-		doLog( "spacedDelay", arguments );
+		debugLog( "spacedDelay", arguments );
 
 		variables.spacedDelay = arguments.spacedDelay;
 		variables.timeUnit    = arguments.timeUnit;
@@ -919,7 +920,7 @@ component accessors="true" {
 	 * interval but could potentially overlap if they take longer to execute than the period.
 	 */
 	ScheduledTask function withNoOverlaps(){
-		doLog( "withNoOverlaps" );
+		debugLog( "withNoOverlaps" );
 
 		variables.noOverlaps = true;
 		return this;
@@ -931,7 +932,7 @@ component accessors="true" {
 	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 */
 	ScheduledTask function every( numeric period, timeUnit = "milliseconds" ){
-		doLog( "every", arguments );
+		debugLog( "every", arguments );
 
 		variables.period   = arguments.period;
 		variables.timeUnit = arguments.timeUnit;
@@ -945,7 +946,7 @@ component accessors="true" {
 	 * Run the task every minute from the time it get's scheduled
 	 */
 	ScheduledTask function everyMinute(){
-		doLog( "everyMinute", arguments );
+		debugLog( "everyMinute", arguments );
 
 		return this.every( 1, "minutes" );
 	}
@@ -954,7 +955,7 @@ component accessors="true" {
 	 * Run the task every hour from the time it get's scheduled
 	 */
 	ScheduledTask function everyHour(){
-		doLog( "everyHour", arguments );
+		debugLog( "everyHour", arguments );
 
 		return this.every( 1, "hours" );
 	}
@@ -965,7 +966,7 @@ component accessors="true" {
 	 * @minutes The minutes past the hour mark
 	 */
 	ScheduledTask function everyHourAt( required numeric minutes ){
-		doLog( "everyHourAt", arguments );
+		debugLog( "everyHourAt", arguments );
 
 		var now     = getJavaNow();
 		var nextRun = now.withMinute( javacast( "int", arguments.minutes ) ).withSecond( javacast( "int", 0 ) );
@@ -994,33 +995,9 @@ component accessors="true" {
 	 * Run the task every day at midnight
 	 */
 	ScheduledTask function everyDay(){
-		doLog( "everyDay", arguments );
+		debugLog( "everyDay", arguments );
 
-		var now     = getJavaNow();
-		// Set at midnight
-		var nextRun = now
-			.withHour( javacast( "int", 0 ) )
-			.withMinute( javacast( "int", 0 ) )
-			.withSecond( javacast( "int", 0 ) );
-		// If we passed it, then move to the next day
-		if ( now.compareTo( nextRun ) > 0 ) {
-			nextRun = nextRun.plusDays( javacast( "int", 1 ) );
-		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.dateTimeHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds",
-			true
-		);
-		// Set the period to every day in seconds
-		variables.period   = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
-		variables.timeUnit = "seconds";
-
-		return this;
+		return this.everyDayAt( "00:00" );
 	}
 
 	/**
@@ -1030,7 +1007,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm
 	 */
 	ScheduledTask function everyDayAt( required string time ){
-		doLog( "everyDayAt", arguments );
+		debugLog( "everyDayAt", arguments );
 
 		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
@@ -1069,7 +1046,7 @@ component accessors="true" {
 	 * Run the task every Sunday at midnight
 	 */
 	ScheduledTask function everyWeek(){
-		doLog( "everyWeek", arguments );
+		debugLog( "everyWeek", arguments );
 
 		return this.everyWeekOn( 7 );
 	}
@@ -1081,7 +1058,7 @@ component accessors="true" {
 	 * @time      The specific time using 24 hour format => HH:mm, defaults to midnight
 	 */
 	ScheduledTask function everyWeekOn( required numeric dayOfWeek, string time = "00:00" ){
-		doLog( "everyWeekOn", arguments );
+		debugLog( "everyWeekOn", arguments );
 
 		var now = getJavaNow();
 		// Check for minutes else add them
@@ -1123,7 +1100,7 @@ component accessors="true" {
 	 * Run the task on the first day of every month at midnight
 	 */
 	ScheduledTask function everyMonth(){
-		doLog( "everyMonth", arguments );
+		debugLog( "everyMonth", arguments );
 
 		return this.everyMonthOn( 1 );
 	}
@@ -1135,7 +1112,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to midnight
 	 */
 	ScheduledTask function everyMonthOn( required numeric day, string time = "00:00" ){
-		doLog( "everyMonthOn", arguments );
+		debugLog( "everyMonthOn", arguments );
 
 		var now = getJavaNow();
 		// Check for minutes else add them
@@ -1181,7 +1158,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to midnight
 	 */
 	ScheduledTask function onFirstBusinessDayOfTheMonth( string time = "00:00" ){
-		doLog( "onFirstBusinessDayOfTheMonth", arguments );
+		debugLog( "onFirstBusinessDayOfTheMonth", arguments );
 
 		var now = getJavaNow();
 		// Check for minutes else add them
@@ -1222,7 +1199,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to midnight
 	 */
 	ScheduledTask function onLastBusinessDayOfTheMonth( string time = "00:00" ){
-		doLog( "onLastBusinessDayOfTheMonth", arguments );
+		debugLog( "onLastBusinessDayOfTheMonth", arguments );
 
 		var now = getJavaNow();
 		// Check for minutes else add them
@@ -1261,7 +1238,8 @@ component accessors="true" {
 	 * Run the task on the first day of the year at midnight
 	 */
 	ScheduledTask function everyYear(){
-		doLog( "everyYear" );
+		debugLog( "everyYear" );
+
 		return this.everyYearOn( 1, 1 );
 	}
 
@@ -1277,7 +1255,7 @@ component accessors="true" {
 		required numeric day,
 		required string time = "00:00"
 	){
-		doLog( "everyYearOn", arguments );
+		debugLog( "everyYearOn", arguments );
 
 		var now = getJavaNow();
 		// Check for minutes else add them
@@ -1323,7 +1301,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onWeekends( string time = "00:00" ){
-		doLog( "onWeekends", arguments );
+		debugLog( "onWeekends", arguments );
 
 		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
@@ -1367,7 +1345,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onWeekdays( string time = "00:00" ){
-		doLog( "onWeekdays", arguments );
+		debugLog( "onWeekdays", arguments );
 
 		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
@@ -1411,7 +1389,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onMondays( string time = "00:00" ){
-		doLog( "onMondays", arguments );
+		debugLog( "onMondays", arguments );
 
 		return this.everyWeekOn( 1, arguments.time );
 	}
@@ -1422,7 +1400,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onTuesdays( string time = "00:00" ){
-		doLog( "onTuesdays", arguments );
+		debugLog( "onTuesdays", arguments );
 
 		return this.everyWeekOn( 2, arguments.time );
 	}
@@ -1433,7 +1411,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onWednesdays( string time = "00:00" ){
-		doLog( "onWednesdays", arguments );
+		debugLog( "onWednesdays", arguments );
 
 		return this.everyWeekOn( 3, arguments.time );
 	}
@@ -1444,7 +1422,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onThursdays( string time = "00:00" ){
-		doLog( "onThursdays", arguments );
+		debugLog( "onThursdays", arguments );
 
 		return this.everyWeekOn( 4, arguments.time );
 	}
@@ -1455,7 +1433,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onFridays( string time = "00:00" ){
-		doLog( "onFridays", arguments );
+		debugLog( "onFridays", arguments );
 
 		return this.everyWeekOn( 5, arguments.time );
 	}
@@ -1466,7 +1444,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onSaturdays( string time = "00:00" ){
-		doLog( "onSaturdays", arguments );
+		debugLog( "onSaturdays", arguments );
 
 		return this.everyWeekOn( 6, arguments.time );
 	}
@@ -1477,7 +1455,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onSundays( string time = "00:00" ){
-		doLog( "onSundays", arguments );
+		debugLog( "onSundays", arguments );
 
 		return this.everyWeekOn( 7, arguments.time );
 	}
@@ -1489,7 +1467,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function startOn( required date, string time = "00:00" ){
-		doLog( "startOn", arguments );
+		debugLog( "startOn", arguments );
 
 		variables.startOnDateTime = variables.dateTimeHelper.parse(
 			"#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#"
@@ -1504,7 +1482,7 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function endOn( required date, string time = "00:00" ){
-		doLog( "endOn", arguments );
+		debugLog( "endOn", arguments );
 
 		variables.endOnDateTime = variables.dateTimeHelper.parse(
 			"#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#"
@@ -1524,7 +1502,7 @@ component accessors="true" {
 	 * Set the time unit in days
 	 */
 	ScheduledTask function inDays(){
-		doLog( "inDays" );
+		debugLog( "inDays" );
 
 		variables.timeUnit = "days";
 		return this;
@@ -1534,7 +1512,7 @@ component accessors="true" {
 	 * Set the time unit in hours
 	 */
 	ScheduledTask function inHours(){
-		doLog( "inHours" );
+		debugLog( "inHours" );
 
 		variables.timeUnit = "hours";
 		return this;
@@ -1544,7 +1522,7 @@ component accessors="true" {
 	 * Set the time unit in microseconds
 	 */
 	ScheduledTask function inMicroseconds(){
-		doLog( "inMicroseconds" );
+		debugLog( "inMicroseconds" );
 
 		variables.timeUnit = "microseconds";
 		return this;
@@ -1554,7 +1532,7 @@ component accessors="true" {
 	 * Set the time unit in milliseconds
 	 */
 	ScheduledTask function inMilliseconds(){
-		doLog( "inMilliseconds" );
+		debugLog( "inMilliseconds" );
 
 		variables.timeUnit = "milliseconds";
 		return this;
@@ -1564,7 +1542,7 @@ component accessors="true" {
 	 * Set the time unit in minutes
 	 */
 	ScheduledTask function inMinutes(){
-		doLog( "inMinutes" );
+		debugLog( "inMinutes" );
 
 		variables.timeUnit = "minutes";
 		return this;
@@ -1574,7 +1552,7 @@ component accessors="true" {
 	 * Set the time unit in nanoseconds
 	 */
 	ScheduledTask function inNanoseconds(){
-		doLog( "inNanoseconds" );
+		debugLog( "inNanoseconds" );
 
 		variables.timeUnit = "nanoseconds";
 		return this;
@@ -1584,7 +1562,7 @@ component accessors="true" {
 	 * Set the time unit in seconds
 	 */
 	ScheduledTask function inSeconds(){
-		doLog( "inSeconds" );
+		debugLog( "inSeconds" );
 
 		variables.timeUnit = "seconds";
 		return this;
@@ -1671,7 +1649,7 @@ component accessors="true" {
 		boolean addMonth = false,
 		date now         = now()
 	){
-		doLog( "getLastBusinessDayOfTheMonth" );
+		debugLog( "getLastBusinessDayOfTheMonth" );
 
 		// Get the last day of the month
 		var lastDay = variables.dateTimeHelper
@@ -1715,7 +1693,7 @@ component accessors="true" {
 		var amount = structKeyExists( arguments, "delay" ) ? arguments.delay : variables.delay;
 		var unit   = structKeyExists( arguments, "timeUnit" ) ? arguments.timeUnit : variables.timeUnit;
 
-		doLog(
+		debugLog(
 			"setInitialNextRunTime",
 			{
 				delay         : amount,
@@ -1778,14 +1756,14 @@ component accessors="true" {
 				.withSecond( javacast( "int", 59 ) );
 
 
-			doLog(
+			debugLog(
 				"startTime",
 				{
 					startTime : startTime.toString(),
 					comp      : now.compareTo( startTime )
 				}
 			);
-			doLog(
+			debugLog(
 				"endTime",
 				{
 					endTime : endTime.toString(),
@@ -1793,9 +1771,13 @@ component accessors="true" {
 				}
 			);
 
-			if ( now.compareTo( startTime ) < 0 ) variables.stats.nextRun = startTime;
+			if ( now.compareTo( startTime ) < 0 ) {
+				variables.stats.nextRun = startTime
+			};
 
-			if ( now.compareTo( endTime ) > 0 ) variables.stats.nextRun = startTime.plusDays( javacast( "int", 1 ) );
+			if ( now.compareTo( endTime ) > 0 ) {
+				variables.stats.nextRun = startTime.plusDays( javacast( "int", 1 ) )
+			};
 
 			variables.stats.nextRun = variables.stats.nextRun.toString();
 		}
@@ -1805,14 +1787,15 @@ component accessors="true" {
 	 * This method is called to set the next run time of the task based on the timeUnit and period.
 	 */
 	private function setNextRunTime(){
-		doLog( "setNextRunTime", arguments );
+		debugLog( "setNextRunTime", arguments );
 
-		var now = getJavaNow();
-
+		var now    = getJavaNow();
 		var amount = variables.spacedDelay != 0 ? variables.spacedDelay : variables.period;
 
 		// if overlaps are allowed task is immediately scheduled
-		if ( variables.spacedDelay == 0 && variables.stats.lastExecutionTime / 1000 > variables.period ) amount = 0;
+		if ( variables.spacedDelay == 0 && variables.stats.lastExecutionTime / 1000 > variables.period ) {
+			amount = 0;
+		}
 
 		// reset nextRun to empty string to continue with process of setting
 		// next run time
@@ -1841,9 +1824,11 @@ component accessors="true" {
 				.withMinute( javacast( "int", 59 ) )
 				.withSecond( javacast( "int", 59 ) );
 
-			if ( now.compareTo( startTime ) < 0 ) variables.stats.nextRun = startTime;
-			else if ( now.compareTo( endTime ) > 0 )
+			if ( now.compareTo( startTime ) < 0 ) {
+				variables.stats.nextRun = startTime;
+			} else if ( now.compareTo( endTime ) > 0 ) {
 				variables.stats.nextRun = startTime.plusDays( javacast( "int", 1 ) );
+			}
 		}
 
 		if ( !len( variables.stats.nextRun ) ) {
@@ -1876,14 +1861,14 @@ component accessors="true" {
 	}
 
 	/**
-	 * Debug logging method
+	 * Debug output method
 	 */
-	private function doLog( required string caller, struct args = {} ){
-		if ( variables.debugEnabled ) {
+	function debugLog( required string caller, struct args = {} ){
+		if ( variables.debug ) {
 			var message = "ScheduledTask : " & variables.name & " : " & arguments.caller & "()" & (
 				structIsEmpty( arguments.args ) ? "" : " : " & serializeJSON( arguments.args )
 			);
-			variables.System.out.println( message );
+			variables.executor.out( message );
 		}
 	}
 

--- a/system/web/tasks/ColdBoxScheduler.cfc
+++ b/system/web/tasks/ColdBoxScheduler.cfc
@@ -28,10 +28,10 @@ component
 
 	property
 		name    ="controller"
-		inject  ="coldbox" 
+		inject  ="coldbox"
 		delegate="runEvent,runRoute";
 	property
-		name    ="cachebox"  
+		name    ="cachebox"
 		inject  ="cachebox"
 		delegate="getCache";
 	property name="log" inject="logbox:logger:{this}";
@@ -83,14 +83,16 @@ component
 	 * Register a new task in this scheduler that will be executed once the `startup()` is fired or manually
 	 * via the run() method of the task.
 	 *
+	 * @name   The name of this task
+	 * @debug  Add debugging logs to System out, disabled by default in coldbox.system.web.tasks.ColdBoxScheduledTask
 	 * @return a ScheduledTask object so you can work on the registration of the task
 	 */
-	ColdBoxScheduledTask function task( required name ){
+	ColdBoxScheduledTask function task( required name, boolean debug = false ){
 		// Create task with custom name
 		var oColdBoxTask = variables.wirebox
 			.getInstance(
 				"coldbox.system.web.tasks.ColdBoxScheduledTask",
-				{ name : arguments.name, executor : variables.executor }
+				{ name : arguments.name, executor : variables.executor, debug: arguments.debug }
 			)
 			// Set ourselves into the task
 			.setScheduler( this )

--- a/system/web/tasks/ColdBoxScheduler.cfc
+++ b/system/web/tasks/ColdBoxScheduler.cfc
@@ -28,10 +28,10 @@ component
 
 	property
 		name    ="controller"
-		inject  ="coldbox"
+		inject  ="coldbox" 
 		delegate="runEvent,runRoute";
 	property
-		name    ="cachebox"
+		name    ="cachebox"  
 		inject  ="cachebox"
 		delegate="getCache";
 	property name="log" inject="logbox:logger:{this}";
@@ -83,8 +83,9 @@ component
 	 * Register a new task in this scheduler that will be executed once the `startup()` is fired or manually
 	 * via the run() method of the task.
 	 *
-	 * @name   The name of this task
-	 * @debug  Add debugging logs to System out, disabled by default in coldbox.system.web.tasks.ColdBoxScheduledTask
+	 * @name  The name of this task
+	 * @debug Add debugging logs to System out, disabled by default in coldbox.system.web.tasks.ColdBoxScheduledTask
+	 *
 	 * @return a ScheduledTask object so you can work on the registration of the task
 	 */
 	ColdBoxScheduledTask function task( required name, boolean debug = false ){
@@ -92,7 +93,11 @@ component
 		var oColdBoxTask = variables.wirebox
 			.getInstance(
 				"coldbox.system.web.tasks.ColdBoxScheduledTask",
-				{ name : arguments.name, executor : variables.executor, debug: arguments.debug }
+				{
+					name     : arguments.name,
+					executor : variables.executor,
+					debug    : arguments.debug
+				}
 			)
 			// Set ourselves into the task
 			.setScheduler( this )


### PR DESCRIPTION
**New Properties**
 * `annually` 
 boolean to flag task as annually scheduled
 * `delayTimeUnit`
 used to work with delays regardless of setting in chain
 * `debug`  
 used for debug output
 * `firstBusinessDay` 
 boolean to flag task as on first business day schedule
 * `lastBusinessDay` 
 boolean to flag task as on last business day schedule
 * `taskTime` 
 log of time of day for firstBusinessDay and lastBusinessDay tasks
 * `startTime`
 limits task to run on or after specific time of day
 * `endTime`
 limits task to run on or before specific time of day
 * `meta`
 struct that user can use to store any data for the task ( helpful for building UIs and not having to manage outside of task )
 * `stats.nextRun`
 missing value from docs now works 😄 

**Fixed**
  * `onFirstBusinessDayOfTheMonth()` 
  was not properly setting the value if it required to add a month
  * `onLastBusinessDayOfTheMonth()`
  was not getting the correct value
  * `delay()` 
  would overwrite the time unit based when it was defined in the chain, now it gets checked in `start()` and only applied if the `timeUnit` matches the `delayTimeUnit` or if the `timeUnit` is **"seconds"**, which will convert the delay value to seconds from the `delayTimeUnit` setting.
  * `isConstrained()` 
    * **updated check for dayOfTheMonth**
    If the day the user intended to run is higher than the last day of the current month then we allow it to run on the last day of the month.
     * Added checks for new `startTime` and `endTime` properties

**Simplified Functions**
 * `everyDay()`
 * `everyWeek()`
 * `everyMonth()`

**Updated Functions**
  * `run()` 
  added  force argument, to allow to run the task on demand, even if it is paused.
  * `validateTime()`
  sets minutes if missing from time entry and returns time value if successful -  removes a lot of repetitive code

**New Functions**
  * `debug()` 
  used for setting debug setting ( can also be done in task init )
  * `startOnTime()` 
  used to set variables.startTime
  * `endOnTime()`
  used to set variables.endTime
  * `between()`
  used to set variables.startTime and variables.endTime in one call
  * `setMeta()`
  used to set variables.meta
  * `setMetaKey()`
  used to add / save a key to variables.meta
  * `deleteMetaKey()`
  used to delete a key from variables.meta

**New Private Functions**
 * `getLastBusinessDayOfTheMonth()`
 * `getFirstBusinessDayOfTheMonth()`
 * `setInitialNextRunTime()`
 * `setInitialDelayPeriodAndTimeUnit()`
 * `setNextRunTime()`
 * `debugLog()`

**Known Bugs**
The fix for delay is temporary as we need to support other timeUnit conversions and update the documentation.

## Jira Issues
COLDBOX-1226

## Type of change
- [x] Improvement

