### PR TITLE
Feature/scheduled tasks updates for 6.8

### DIFF
--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -1869,8 +1869,8 @@ component accessors="true" {
 	 */
 	function debugLog( required string caller, struct args = {} ){
 		if ( variables.debug ) {
-			var message = dateTimeFormat(now(),"yyyy-mm-dd hh:nn:ss") &
-				" : ScheduledTask : " & variables.name & " : " & arguments.caller & "()" & (
+			var message = dateTimeFormat( now(), "yyyy-mm-dd hh:nn:ss" ) &
+			" : ScheduledTask : " & variables.name & " : " & arguments.caller & "()" & (
 				structIsEmpty( arguments.args ) ? "" : " : " & serializeJSON( arguments.args )
 			);
 			variables.executor.out( message );

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -1713,7 +1713,9 @@ component accessors="true" {
 			true
 		);
 		// Set the period to be every hour in seconds
-		variables.period   = variables.timeUnitHelper.get( arguments.period ).toSeconds( arguments.periodMultiplier );
+		variables.period = variables.timeUnitHelper
+			.get( arguments.periodValue )
+			.toSeconds( arguments.periodMultiplier );
 		variables.timeUnit = "seconds";
 	}
 

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -1869,7 +1869,8 @@ component accessors="true" {
 	 */
 	function debugLog( required string caller, struct args = {} ){
 		if ( variables.debug ) {
-			var message = "ScheduledTask : " & variables.name & " : " & arguments.caller & "()" & (
+			var message = dateTimeFormat(now(),"yyyy-mm-dd hh:nn:ss") &
+				" : ScheduledTask : " & variables.name & " : " & arguments.caller & "()" & (
 				structIsEmpty( arguments.args ) ? "" : " : " & serializeJSON( arguments.args )
 			);
 			variables.executor.out( message );

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -506,9 +506,13 @@ component accessors="true" {
 	 * - when
 	 * - dayOfTheMonth
 	 * - dayOfTheWeek
+	 * - firstBusinessDay
 	 * - lastBusinessDay
-	 * - weekends
 	 * - weekdays
+	 * - weekends
+	 * - startOnDateTime
+	 * - endOnDateTime
+	 * - startTime and/or endTime
 	 *
 	 * This method is called by the `run()` method at runtime to determine if the task can be ran at that point in time
 	 */
@@ -537,6 +541,14 @@ component accessors="true" {
 			return true;
 		}
 
+		// Do we have day of the week?
+		if (
+			variables.dayOfTheWeek > 0 &&
+			now.getDayOfWeek().getValue() != variables.dayOfTheWeek
+		) {
+			return true;
+		}
+
 		// Do we have a first business day constraint
 		if (
 			variables.firstBusinessDay &&
@@ -553,14 +565,6 @@ component accessors="true" {
 			return true;
 		}
 
-		// Do we have weekends?
-		if (
-			variables.weekends &&
-			now.getDayOfWeek().getValue() <= 5
-		) {
-			return true;
-		}
-
 		// Do we have weekdays?
 		if (
 			variables.weekdays &&
@@ -569,10 +573,10 @@ component accessors="true" {
 			return true;
 		}
 
-		// Do we have day of the week?
+		// Do we have weekends?
 		if (
-			variables.dayOfTheWeek > 0 &&
-			now.getDayOfWeek().getValue() != variables.dayOfTheWeek
+			variables.weekends &&
+			now.getDayOfWeek().getValue() <= 5
 		) {
 			return true;
 		}
@@ -585,7 +589,7 @@ component accessors="true" {
 			return true;
 		}
 
-		// Do we have a end on constraint
+		// Do we have an end on constraint
 		if (
 			len( variables.endOnDateTime ) &&
 			now.isAfter( variables.endOnDateTime )
@@ -593,7 +597,7 @@ component accessors="true" {
 			return true;
 		}
 
-		// if we have a start time and / or end time constraint
+		// Do we have a start time and / or end time constraint
 		if (
 			len( variables.startTime ) ||
 			len( variables.endTime )

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -7,9 +7,29 @@
 component accessors="true" {
 
 	/**
+	 * The human name of this task
+	 */
+	property name="name";
+
+	/**
+	 * The task closure or CFC to execute in the task
+	 */
+	property name="task";
+
+	/**
+	 * The method to execute if the task is a CFC
+	 */
+	property name="method";
+
+	/**
 	 * The delay or time to wait before we execute the task in the scheduler
 	 */
 	property name="delay" type="numeric";
+
+	/**
+	 * The time unit string used when there is a delay requested for the task
+	 */
+	property name="delayTimeUnit";
 
 	/**
 	 * A fixed time period of execution of the tasks in this schedule. It does not wait for tasks to finish,
@@ -25,22 +45,17 @@ component accessors="true" {
 	/**
 	 * The time unit string used to schedule the task
 	 */
-	property name="timeunit";
+	property name="timeUnit";
 
 	/**
-	 * The task closure or CFC to execute in the task
+	 * A handy boolean that is set when the task is annually scheduled
 	 */
-	property name="task";
+	property name="annually" type="boolean";
 
 	/**
-	 * The method to execute if the task is a CFC
+	 * The boolean value is used for debugging
 	 */
-	property name="method";
-
-	/**
-	 * The human name of this task
-	 */
-	property name="name";
+	property name="debug";
 
 	/**
 	 * A handy boolean that disables the scheduling of this task
@@ -54,9 +69,73 @@ component accessors="true" {
 	property name="whenClosure" type="any";
 
 	/**
-	 * The timezone this task runs under, by default we use the timezone defined in the schedulers
+	 * Constraint of what day of the month we need to run on: 1-31
 	 */
-	property name="timezone";
+	property name="dayOfTheMonth" type="numeric";
+
+	/**
+	 * Constraint of what day of the week this runs on: 1-7
+	 */
+	property name="dayOfTheWeek" type="numeric";
+
+	/**
+	 * Constraint to run only on weekends
+	 */
+	property name="weekends" type="boolean";
+
+	/**
+	 * Constraint to run only on weekdays
+	 */
+	property name="weekdays" type="boolean";
+
+	/**
+	 * Constraint to run only on the first business day of the month
+	 */
+	property name="firstBusinessDay" type="boolean";
+
+	/**
+	 * Constraint to run only on the last business day of the month
+	 */
+	property name="lastBusinessDay" type="boolean";
+
+	/**
+	 * By default tasks execute in an interval frequency which can cause tasks to
+	 * stack if they take longer than their periods ( fire immediately after completion ).
+	 * With this boolean flag turned on, the schedulers don't kick off the
+	 * intervals until the tasks finish executing. Meaning no stacking.
+	 */
+	property name="noOverlaps" type="boolean";
+
+	/**
+	 * Used by first and last business day constraints to
+	 * log the time of day for use in setNextRunTime()
+	 */
+	property name="taskTime" type="string";
+
+	/**
+	 * Constraint of when the task can start execution.
+	 */
+	property name="startOnDateTime";
+
+	/**
+	 * Constraint of when the task must not continue to execute
+	 */
+	property name="endOnDateTime";
+
+	/**
+	 * Constraint to limit the task to run after a specified time of day.
+	 */
+	property name="startTime";
+
+	/**
+	 * Constraint to limit the task to run before a specified time of day.
+	 */
+	property name="endTime";
+
+	/**
+	 * The boolean value that lets us know if this task has been scheduled
+	 */
+	property name="scheduled";
 
 	/**
 	 * This task can be assigned to a task scheduler or be executed on its own at runtime
@@ -64,9 +143,19 @@ component accessors="true" {
 	property name="scheduler";
 
 	/**
-	 * The collection of stats for the task: { created, lastRun, totalRuns, totalFailures, totalSuccess, lastResult, neverRun, lastExecutionTime }
+	 * A struct for the task that can be used to store any metadata
+	 */
+	property name="meta" type="struct";
+
+	/**
+	 * The collection of stats for the task: { name, created, lastRun, nextRun, totalRuns, totalFailures, totalSuccess, lastResult, neverRun, lastExecutionTime }
 	 */
 	property name="stats" type="struct";
+
+	/**
+	 * The timezone this task runs under, by default we use the timezone defined in the schedulers
+	 */
+	property name="timezone";
 
 	/**
 	 * The before task closure
@@ -88,48 +177,6 @@ component accessors="true" {
 	 */
 	property name="onTaskFailure";
 
-	/**
-	 * The constraint of what day of the month we need to run on: 1-31
-	 */
-	property name="dayOfTheMonth" type="numeric";
-
-	/**
-	 * The constraint of what day of the week this runs on: 1-7
-	 */
-	property name="dayOfTheWeek" type="numeric";
-
-	/**
-	 * Constraint to run only on weekends
-	 */
-	property name="weekends" type="boolean";
-
-	/**
-	 * Constraint to run only on weekdays
-	 */
-	property name="weekdays" type="boolean";
-
-	/**
-	 * Constraint to run only on the last business day of the month
-	 */
-	property name="lastBusinessDay" type="boolean";
-
-	/**
-	 * By default tasks execute in an interval frequency which can cause overlaps if tasks
-	 * take longer than their periods. With this boolean flag turned on, the schedulers
-	 * don't kick off the intervals until the tasks finish executing. Meaning no overlaps.
-	 */
-	property name="noOverlaps" type="boolean";
-
-	/**
-	 * The constraint of when the task can start execution.
-	 */
-	property name="startOnDateTime";
-
-	/**
-	 * The constraint of when the task must not continue to execute
-	 */
-	property name="endOnDateTime";
-
 
 	/**
 	 * Constructor
@@ -138,12 +185,14 @@ component accessors="true" {
 	 * @executor The executor this task will run under and be linked to
 	 * @task     The closure or cfc that represents the task (optional)
 	 * @method   The method on the cfc to call, defaults to "run" (optional)
+	 * @debug    Add debugging logs to System out, disabled by default
 	 */
 	ScheduledTask function init(
 		required name,
 		required executor,
 		any task = "",
-		method   = "run"
+		method   = "run",
+		debug    = false
 	){
 		// Utility class
 		variables.util             = new coldbox.system.core.util.Util();
@@ -157,22 +206,29 @@ component accessors="true" {
 		variables.task             = arguments.task;
 		variables.method           = arguments.method;
 		// Default Frequencies
-		variables.period           = 0;
 		variables.delay            = 0;
+		variables.delayTimeUnit    = "";
+		variables.period           = 0;
 		variables.spacedDelay      = 0;
 		variables.timeUnit         = "milliseconds";
-		variables.noOverlap        = false;
+		variables.noOverlaps       = false;
 		// Constraints
+		variables.annually         = false;
+		variables.debug            = arguments.debug;
 		variables.disabled         = false;
 		variables.whenClosure      = "";
 		variables.dayOfTheMonth    = 0;
 		variables.dayOfTheWeek     = 0;
 		variables.weekends         = false;
 		variables.weekdays         = false;
+		variables.firstBusinessDay = false;
 		variables.lastBusinessDay  = false;
-		variables.noOverlaps       = false;
+		variables.taskTime         = "";
 		variables.startOnDateTime  = "";
 		variables.endOnDateTime    = "";
+		variables.startTime        = "";
+		variables.endTime          = "";
+		variables.scheduled        = false;
 		// Probable Scheduler or not
 		variables.scheduler        = "";
 		// Prepare execution tracking stats
@@ -183,6 +239,8 @@ component accessors="true" {
 			"created"           : now(),
 			// The last execution run timestamp
 			"lastRun"           : "",
+			// The next execution run timestamp
+			"nextRun"           : "",
 			// Total runs
 			"totalRuns"         : 0,
 			// Total faiulres
@@ -200,11 +258,15 @@ component accessors="true" {
 			// Server IP
 			"localIp"           : variables.util.getServerIp()
 		};
+		// Prepare for the user to store metadata
+		variables.meta          = {};
 		// Life cycle methods
 		variables.beforeTask    = "";
 		variables.afterTask     = "";
 		variables.onTaskSuccess = "";
 		variables.onTaskFailure = "";
+
+		debugLog( "init" );
 
 		return this;
 	}
@@ -221,6 +283,8 @@ component accessors="true" {
 	 * @throws UserInterruptException - When the thread has been interrupted
 	 */
 	function checkInterrupted(){
+		debugLog( "checkInterrupted" );
+
 		var thisThread = createObject( "java", "java.lang.Thread" ).currentThread();
 		// Has the user/system tried to interrupt this thread?
 		if ( thisThread.isInterrupted() ) {
@@ -261,6 +325,8 @@ component accessors="true" {
 	 * @timezone The timezone string identifier
 	 */
 	ScheduledTask function setTimezone( required timezone ){
+		debugLog( "setTimezone", arguments );
+
 		variables.timezone = createObject( "java", "java.time.ZoneId" ).of( arguments.timezone );
 		return this;
 	}
@@ -269,6 +335,8 @@ component accessors="true" {
 	 * Has this task been assigned to a scheduler or not?
 	 */
 	boolean function hasScheduler(){
+		debugLog( "hasScheduler" );
+
 		return isObject( variables.scheduler );
 	}
 
@@ -281,8 +349,50 @@ component accessors="true" {
 	 * @return The schedule with the task/method registered on it
 	 */
 	ScheduledTask function call( required task, method = "run" ){
+		debugLog( "call" );
+
 		variables.task   = arguments.task;
 		variables.method = arguments.method;
+		return this;
+	}
+
+	/**
+	 * Update the debug setting for this task!
+	 */
+	ScheduledTask function debug( required boolean value ){
+		debugLog( "debug" );
+
+		variables.debug = arguments.value;
+		return this;
+	}
+
+	/**
+	 * Set the meta data for this task!
+	 */
+	ScheduledTask function setMeta( required struct meta ){
+		debugLog( "setMeta" );
+
+		variables.meta = arguments.meta;
+		return this;
+	}
+
+	/**
+	 * Set a specific meta data key for this task!
+	 */
+	ScheduledTask function setMetaKey( required string key, required any value ){
+		debugLog( "setMetaKey" );
+
+		variables.meta[ arguments.key ] = arguments.value;
+		return this;
+	}
+
+	/**
+	 * Delete a specific meta data key from this task!
+	 */
+	ScheduledTask function deleteMetaKey( required string key ){
+		debugLog( "deleteMetaKey" );
+
+		variables.meta.delete( arguments.key );
 		return this;
 	}
 
@@ -297,6 +407,8 @@ component accessors="true" {
 	 * If the closure returns true we schedule, else we disable it.
 	 */
 	ScheduledTask function when( target ){
+		debugLog( "when" );
+
 		variables.whenClosure = arguments.target;
 		return this;
 	}
@@ -305,6 +417,8 @@ component accessors="true" {
 	 * Disable the task when scheduled, meaning, don't run this sucker!
 	 */
 	ScheduledTask function disable(){
+		debugLog( "disable" );
+
 		variables.disabled = true;
 		return this;
 	}
@@ -313,6 +427,8 @@ component accessors="true" {
 	 * Enable the task when disabled so we can run again
 	 */
 	ScheduledTask function enable(){
+		debugLog( "enable" );
+
 		variables.disabled = false;
 		return this;
 	}
@@ -324,7 +440,58 @@ component accessors="true" {
 	 * - when closure
 	 */
 	boolean function isDisabled(){
+		debugLog( "isDisabled" );
+
 		return variables.disabled;
+	}
+
+	/**
+	 *
+	 * @startTime The specific time using 24 hour format => HH:mm
+	 * @endTime   The specific time using 24 hour format => HH:mm
+	 */
+	ScheduledTask function between( required string startTime, required string endTime ){
+		debugLog( "between" );
+
+		startOnTime( arguments.startTime );
+		endOnTime( arguments.endTime );
+		return this;
+	}
+
+	/**
+	 *
+	 * @time The specific time using 24 hour format => HH:mm
+	 */
+	ScheduledTask function startOnTime( required string time ){
+		debugLog( "startOnTime" );
+
+		// Check for minutes else add them
+		if ( !find( ":", arguments.time ) ) {
+			arguments.time &= ":00";
+		}
+		// Validate time format
+		validateTime( arguments.time );
+
+		variables.startTime = arguments.time;
+		return this;
+	}
+
+	/**
+	 *
+	 * @time The specific time using 24 hour format => HH:mm
+	 */
+	ScheduledTask function endOnTime( required string time ){
+		debugLog( "endOnTime" );
+
+		// Check for minutes else add them
+		if ( !find( ":", arguments.time ) ) {
+			arguments.time &= ":00";
+		}
+		// Validate time format
+		validateTime( arguments.time );
+
+		variables.endTime = arguments.time;
+		return this;
 	}
 
 	/**
@@ -346,6 +513,8 @@ component accessors="true" {
 	 * This method is called by the `run()` method at runtime to determine if the task can be ran at that point in time
 	 */
 	boolean function isConstrained(){
+		debugLog( "isConstrained" );
+
 		var now = getJavaNow();
 
 		// When Closure that dictates if the task can be scheduled/ran: true => yes, false => no
@@ -358,9 +527,20 @@ component accessors="true" {
 		}
 
 		// Do we have a day of the month constraint? and the same as the running date/time? Else skip it
+		// If the day day assigned is greater than the days in the month, then we let it thru
+		// as the user intended to run it at the end of the month
 		if (
 			variables.dayOfTheMonth > 0 &&
-			now.getDayOfMonth() != variables.dayOfTheMonth
+			now.getDayOfMonth() != variables.dayOfTheMonth &&
+			daysInMonth( now.toString() ) > variables.dayOfTheMonth
+		) {
+			return true;
+		}
+
+		// Do we have a first business day constraint
+		if (
+			variables.firstBusinessDay &&
+			now.getDayOfMonth() != getFirstBusinessDayOfTheMonth().getDayOfMonth()
 		) {
 			return true;
 		}
@@ -368,7 +548,7 @@ component accessors="true" {
 		// Do we have a last business day constraint
 		if (
 			variables.lastBusinessDay &&
-			now.getDayOfMonth() != getLastDayOfTheMonth().getDayOfMonth()
+			now.getDayOfMonth() != getLastBusinessDayOfTheMonth().getDayOfMonth()
 		) {
 			return true;
 		}
@@ -413,26 +593,48 @@ component accessors="true" {
 			return true;
 		}
 
+		// if we have a start time and / or end time constraint
+		if (
+			len( variables.startTime ) ||
+			len( variables.endTime )
+		) {
+			var _startTime = variables.chronoUnitHelper.parse(
+				dateFormat( now(), "yyyy-mm-dd" ) & "T" & (
+					len( variables.startTime ) ? variables.startTime : "00:00:00"
+				)
+			);
+			var _endTime = variables.chronoUnitHelper.parse(
+				dateFormat( now(), "yyyy-mm-dd" ) & "T" & ( len( variables.endTime ) ? variables.endTime : "23:59:59" )
+			);
+			if ( now.isBefore( _startTime ) || now.isAfter( _endTime ) ) {
+				return true;
+			}
+		}
+
 		return false;
 	}
 
 	/**
 	 * This is the runnable proxy method that executes your code by the executors
 	 */
-	function run(){
+	function run( boolean force = false ){
+		debugLog( "run - " & arguments.force );
+
 		var sTime = getTickCount();
 
 		// If disabled or paused
-		if ( isDisabled() ) {
+		if ( !arguments.force && isDisabled() ) {
+			setNextRunTime();
 			return;
 		}
 
 		// Check for constraints of execution
-		if ( isConstrained() ) {
+		if ( !arguments.force && isConstrained() ) {
+			setNextRunTime();
 			return;
 		}
 
-		// Mark the task as it wil run now for the first time
+		// Mark the task as it will run now for the first time
 		variables.stats.neverRun = false;
 
 		try {
@@ -493,9 +695,7 @@ component accessors="true" {
 				}
 			} catch ( any afterException ) {
 				// Log it, so it doesn't go to ether and executor doesn't die.
-				err(
-					"Error running task (#getname()#) after/error handlers : #afterException.message & afterException.detail#"
-				);
+				err( "Error running task (#getname()#) after/error handlers : #afterException.message & afterException.detail#" );
 				err( "Stacktrace for task (#getname()#) after/error handlers : #afterException.stackTrace#" );
 			}
 		} finally {
@@ -505,6 +705,8 @@ component accessors="true" {
 			variables.stats.lastExecutionTime = getTickCount() - sTime;
 			// Call internal cleanups event
 			cleanupTaskRun();
+			// set next run time based on timeUnit and period
+			setNextRunTime();
 		}
 	}
 
@@ -513,6 +715,7 @@ component accessors="true" {
 	 * any type of cleanups
 	 */
 	function cleanupTaskRun(){
+		debugLog( "cleanupTaskRun" );
 		// no cleanups for now
 	}
 
@@ -524,9 +727,61 @@ component accessors="true" {
 	 */
 	ScheduledFuture function start(){
 		// If we have overlaps and the spaced delay is 0 then grab it from the period
-		if ( variables.noOverlaps and variables.spacedDelay eq 0 ) {
+		if ( variables.noOverlaps && variables.spacedDelay == 0 ) {
 			variables.spacedDelay = variables.period;
 		}
+
+		// If we have a delay and a delayTimeUnit, then we need to compare to our
+		// current timeUnit and convert to support the delay
+		// ( only if our time unit is seconds , if not we disable the delay )
+		//
+		// TODO: We need to support other time units - this is a temporary fix
+		// for the previous issue where the delay and/or setting would replace
+		// the time setting of the task based on the order presented
+		if (
+			variables.delay > 0 &&
+			len( variables.delayTimeUnit ) &&
+			compare( variables.delayTimeUnit, variables.timeUnit )
+		) {
+			if ( variables.timeUnit != "seconds" ) {
+				variables.delay         = 0;
+				// reset the initial nextRunTime
+				variables.stats.nextRun = "";
+			} else {
+				// transform all to seconds
+				switch ( variables.delayTimeUnit ) {
+					case "days":
+						variables.delay = javacast( "int", variables.delay * 60 * 60 * 24 );
+						break;
+					case "hours":
+						variables.delay = javacast( "int", variables.delay * 60 * 60 );
+						break;
+					case "minutes":
+						variables.delay = javacast( "int", variables.delay * 60 );
+						break;
+					case "milliseconds":
+						variables.delay = javacast( "int", variables.delay / 1000 );
+						break;
+					case "microseconds":
+						variables.delay = javacast( "int", variables.delay / 1000000 );
+						break;
+					case "nanoseconds":
+						variables.delay = javacast( "int", variables.delay / 1000000000 );
+						break;
+				}
+			}
+		}
+
+		variables.scheduled = true;
+
+		debugLog(
+			"start - " & variables.name & " - should execute initial next run call " &
+			serializeJSON( {
+				"spacedDelay" : variables.spacedDelay,
+				"period"      : variables.period,
+				"delay"       : variables.delay
+			} )
+		);
 
 		// Startup a spaced frequency task: no overlaps
 		if ( variables.spacedDelay > 0 ) {
@@ -571,6 +826,8 @@ component accessors="true" {
 	 * @target The closure to execute
 	 */
 	ScheduledTask function before( required target ){
+		debugLog( "before" );
+
 		variables.beforeTask = arguments.target;
 		return this;
 	}
@@ -581,6 +838,8 @@ component accessors="true" {
 	 * @target The closure to execute
 	 */
 	ScheduledTask function after( required target ){
+		debugLog( "after" );
+
 		variables.afterTask = arguments.target;
 		return this;
 	}
@@ -591,6 +850,8 @@ component accessors="true" {
 	 * @target The closure to execute
 	 */
 	ScheduledTask function onSuccess( required target ){
+		debugLog( "onSuccess" );
+
 		variables.onTaskSuccess = arguments.target;
 		return this;
 	}
@@ -601,6 +862,8 @@ component accessors="true" {
 	 * @target The closure to execute
 	 */
 	ScheduledTask function onFailure( required target ){
+		debugLog( "onFailure" );
+
 		variables.onTaskFailure = arguments.target;
 		return this;
 	}
@@ -614,22 +877,39 @@ component accessors="true" {
 	/**
 	 * Set a delay in the running of the task that will be registered with this schedule
 	 *
-	 * @delay    The delay that will be used before executing the task
-	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
+	 * @delay          The delay that will be used before executing the task
+	 * @timeUnit       The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
+	 * @overwrites     Boolean to overwrite delay and timeUnit even if value is already set, this is helpful if the delay is set later in the chain when creating the task - defaults to false
+	 * @setNextRunTime Boolean to execute setInitialNextRunTime() - defaults to true
 	 */
-	ScheduledTask function delay( numeric delay, timeUnit = "milliseconds" ){
-		variables.delay    = arguments.delay;
-		variables.timeUnit = arguments.timeUnit;
+	ScheduledTask function delay(
+		numeric delay,
+		timeUnit               = "milliseconds",
+		boolean overwrites     = false,
+		boolean setNextRunTime = true
+	){
+		debugLog( "delay", arguments );
+
+		if ( arguments.overwrites || !variables.delay ) {
+			variables.delay         = arguments.delay;
+			variables.delayTimeUnit = arguments.timeUnit;
+		}
+
+		if ( arguments.setNextRunTime )
+			setInitialNextRunTime( delay: arguments.delay, timeUnit: arguments.timeUnit );
+
 		return this;
 	}
 
 	/**
 	 * Run the task every custom spaced delay of execution, meaning no overlaps
 	 *
-	 * @delay    The delay that will be used before executing the task
-	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
+	 * @spacedDelay The delay that will be used before executing the task with no overlaps
+	 * @timeUnit    The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 */
 	ScheduledTask function spacedDelay( numeric spacedDelay, timeUnit = "milliseconds" ){
+		debugLog( "spacedDelay", arguments );
+
 		variables.spacedDelay = arguments.spacedDelay;
 		variables.timeUnit    = arguments.timeUnit;
 		return this;
@@ -637,25 +917,28 @@ component accessors="true" {
 
 	/**
 	 * Calling this method prevents task frequencies to overlap.  By default all tasks are executed with an
-	 * interval but ccould potentially overlap if they take longer to execute than the period.
-	 *
-	 * @period  
-	 * @timeUnit
+	 * interval but could potentially overlap if they take longer to execute than the period.
 	 */
 	ScheduledTask function withNoOverlaps(){
+		debugLog( "withNoOverlaps" );
+
 		variables.noOverlaps = true;
 		return this;
 	}
 
-	/**
-	 * Run the task every custom period of execution
+	/**	 * Run the task every custom period of execution
 	 *
 	 * @period   The period of execution
 	 * @timeUnit The time unit to use, available units are: days, hours, microseconds, milliseconds, minutes, nanoseconds, and seconds. The default is milliseconds
 	 */
 	ScheduledTask function every( numeric period, timeUnit = "milliseconds" ){
+		debugLog( "every", arguments );
+
 		variables.period   = arguments.period;
 		variables.timeUnit = arguments.timeUnit;
+
+		setInitialNextRunTime();
+
 		return this;
 	}
 
@@ -663,18 +946,18 @@ component accessors="true" {
 	 * Run the task every minute from the time it get's scheduled
 	 */
 	ScheduledTask function everyMinute(){
-		variables.period   = 1;
-		variables.timeUnit = "minutes";
-		return this;
+		debugLog( "everyMinute", arguments );
+
+		return this.every( 1, "minutes" );
 	}
 
 	/**
 	 * Run the task every hour from the time it get's scheduled
 	 */
 	ScheduledTask function everyHour(){
-		variables.period   = 1;
-		variables.timeUnit = "hours";
-		return this;
+		debugLog( "everyHour", arguments );
+
+		return this.every( 1, "hours" );
 	}
 
 	/**
@@ -683,6 +966,8 @@ component accessors="true" {
 	 * @minutes The minutes past the hour mark
 	 */
 	ScheduledTask function everyHourAt( required numeric minutes ){
+		debugLog( "everyHourAt", arguments );
+
 		var now     = getJavaNow();
 		var nextRun = now.withMinute( javacast( "int", arguments.minutes ) ).withSecond( javacast( "int", 0 ) );
 		// If we passed it, then move the hour by 1
@@ -696,7 +981,8 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to be every hour
 		variables.period   = variables.timeUnitHelper.get( "hours" ).toSeconds( 1 );
@@ -709,30 +995,9 @@ component accessors="true" {
 	 * Run the task every day at midnight
 	 */
 	ScheduledTask function everyDay(){
-		var now     = getJavaNow();
-		// Set at midnight
-		var nextRun = now
-			.withHour( javacast( "int", 0 ) )
-			.withMinute( javacast( "int", 0 ) )
-			.withSecond( javacast( "int", 0 ) );
-		// If we passed it, then move to the next day
-		if ( now.compareTo( nextRun ) > 0 ) {
-			nextRun = nextRun.plusDays( javacast( "int", 1 ) );
-		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.chronoUnitHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds"
-		);
-		// Set the period to every day in seconds
-		variables.period   = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
-		variables.timeUnit = "seconds";
+		debugLog( "everyDay", arguments );
 
-		return this;
+		return this.everyDayAt( "00:00" );
 	}
 
 	/**
@@ -742,7 +1007,9 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm
 	 */
 	ScheduledTask function everyDayAt( required string time ){
-		// Check for mintues else add them
+		debugLog( "everyDayAt", arguments );
+
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
@@ -765,7 +1032,8 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to every day in seconds
 		variables.period   = variables.timeUnitHelper.get( "DAYS" ).toSeconds( 1 );
@@ -778,33 +1046,9 @@ component accessors="true" {
 	 * Run the task every Sunday at midnight
 	 */
 	ScheduledTask function everyWeek(){
-		var now     = getJavaNow();
-		// Set at midnight
-		var nextRun = now
-			// Sunday
-			.with( variables.chronoUnitHelper.ChronoField.DAY_OF_WEEK, javacast( "int", 7 ) )
-			// Midnight
-			.withHour( javacast( "int", 0 ) )
-			.withMinute( javacast( "int", 0 ) )
-			.withSecond( javacast( "int", 0 ) );
-		// If we passed it, then move to the next week
-		if ( now.compareTo( nextRun ) > 0 ) {
-			nextRun = nextRun.plusWeeks( javacast( "int", 1 ) );
-		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.chronoUnitHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds"
-		);
-		// Set the period to every week in seconds
-		variables.period       = variables.timeUnitHelper.get( "days" ).toSeconds( 7 );
-		variables.timeUnit     = "seconds";
-		variables.dayOfTheWeek = 7;
-		return this;
+		debugLog( "everyWeek", arguments );
+
+		return this.everyWeekOn( 7 );
 	}
 
 	/**
@@ -814,8 +1058,10 @@ component accessors="true" {
 	 * @time      The specific time using 24 hour format => HH:mm, defaults to midnight
 	 */
 	ScheduledTask function everyWeekOn( required numeric dayOfWeek, string time = "00:00" ){
+		debugLog( "everyWeekOn", arguments );
+
 		var now = getJavaNow();
-		// Check for mintues else add them
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
@@ -839,12 +1085,14 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to every week in seconds
 		variables.period       = variables.timeUnitHelper.get( "days" ).toSeconds( 7 );
 		variables.timeUnit     = "seconds";
 		variables.dayOfTheWeek = arguments.dayOfWeek;
+
 		return this;
 	}
 
@@ -852,34 +1100,9 @@ component accessors="true" {
 	 * Run the task on the first day of every month at midnight
 	 */
 	ScheduledTask function everyMonth(){
-		var now     = getJavaNow();
-		// Set at midnight
-		var nextRun = now
-			// First day of the month
-			.with( variables.chronoUnitHelper.ChronoField.DAY_OF_MONTH, javacast( "int", 1 ) )
-			// Midnight
-			.withHour( javacast( "int", 0 ) )
-			.withMinute( javacast( "int", 0 ) )
-			.withSecond( javacast( "int", 0 ) );
+		debugLog( "everyMonth", arguments );
 
-		if ( now.compareTo( nextRun ) > 0 ) {
-			nextRun = nextRun.plusMonths( javacast( "int", 1 ) );
-		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.chronoUnitHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds"
-		);
-		// Set the period to one day. And make sure we add a constraint for it
-		// Mostly because every month is different
-		variables.period        = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
-		variables.timeUnit      = "seconds";
-		variables.dayOfTheMonth = 1;
-		return this;
+		return this.everyMonthOn( 1 );
 	}
 
 	/**
@@ -889,8 +1112,10 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to midnight
 	 */
 	ScheduledTask function everyMonthOn( required numeric day, string time = "00:00" ){
+		debugLog( "everyMonthOn", arguments );
+
 		var now = getJavaNow();
-		// Check for mintues else add them
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
@@ -915,13 +1140,15 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to one day. And make sure we add a constraint for it
 		// Mostly because every month is different
 		variables.period        = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
 		variables.timeUnit      = "seconds";
 		variables.dayOfTheMonth = arguments.day;
+
 		return this;
 	}
 
@@ -931,28 +1158,20 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to midnight
 	 */
 	ScheduledTask function onFirstBusinessDayOfTheMonth( string time = "00:00" ){
+		debugLog( "onFirstBusinessDayOfTheMonth", arguments );
+
 		var now = getJavaNow();
-		// Check for mintues else add them
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
 		// Validate time format
 		validateTime( arguments.time );
 		// Get new time
-		var nextRun = now
-			// First business day of the month
-			.with(
-				createObject( "java", "java.time.temporal.TemporalAdjusters" ).firstInMonth(
-					createObject( "java", "java.time.DayOfWeek" ).MONDAY
-				)
-			)
-			// Specific Time
-			.withHour( javacast( "int", getToken( arguments.time, 1, ":" ) ) )
-			.withMinute( javacast( "int", getToken( arguments.time, 2, ":" ) ) )
-			.withSecond( javacast( "int", 0 ) );
+		var nextRun = getFirstBusinessDayOfTheMonth( arguments.time );
 		// Have we passed it
 		if ( now.compareTo( nextRun ) > 0 ) {
-			nextRun = nextRun.plusMonths( javacast( "int", 1 ) );
+			nextRun = getFirstBusinessDayOfTheMonth( arguments.time, true );
 		}
 		// Get the duration time for the next run and delay accordingly
 		this.delay(
@@ -961,39 +1180,17 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to one day. And make sure we add a constraint for it
 		// Mostly because every month is different
-		variables.period        = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
-		variables.timeUnit      = "seconds";
-		variables.dayOfTheMonth = 1;
+		variables.period           = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
+		variables.timeUnit         = "seconds";
+		variables.firstBusinessDay = true;
+		variables.taskTime         = arguments.time;
+
 		return this;
-	}
-
-	/**
-	 * This utility method gives us the last day of the month in Java format
-	 */
-	private function getLastDayOfTheMonth(){
-		// Get the last day of the month
-		var lastDay = variables.chronoUnitHelper
-			.toLocalDateTime( now(), this.getTimezone() )
-			.with( createObject( "java", "java.time.temporal.TemporalAdjusters" ).lastDayOfMonth() );
-		// Verify if on weekend
-		switch ( lastDay.getDayOfWeek().getValue() ) {
-			// Sunday - 2 days
-			case 7: {
-				lastDay = lastDay.minusDays( 2 );
-				break;
-			}
-			// Saturday - 1 day
-			case 6: {
-				lastDay = lastDay.minusDays( 1 );
-				break;
-			}
-		}
-
-		return lastDay;
 	}
 
 	/**
@@ -1002,22 +1199,20 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to midnight
 	 */
 	ScheduledTask function onLastBusinessDayOfTheMonth( string time = "00:00" ){
+		debugLog( "onLastBusinessDayOfTheMonth", arguments );
+
 		var now = getJavaNow();
-		// Check for mintues else add them
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
 		// Validate time format
 		validateTime( arguments.time );
 		// Get the last day of the month
-		var nextRun = getLastDayOfTheMonth()
-			// Specific Time
-			.withHour( javacast( "int", getToken( arguments.time, 1, ":" ) ) )
-			.withMinute( javacast( "int", getToken( arguments.time, 2, ":" ) ) )
-			.withSecond( javacast( "int", 0 ) );
+		var nextRun = getLastBusinessDayOfTheMonth( arguments.time );
 		// Have we passed it
 		if ( now.compareTo( nextRun ) > 0 ) {
-			nextRun = nextRun.plusMonths( javacast( "int", 1 ) );
+			nextRun = getLastBusinessDayOfTheMonth( arguments.time, true );
 		}
 		// Get the duration time for the next run and delay accordingly
 		this.delay(
@@ -1026,13 +1221,16 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to one day. And make sure we add a constraint for it
 		// Mostly because every month is different
 		variables.period          = variables.timeUnitHelper.get( "days" ).toSeconds( 1 );
 		variables.timeUnit        = "seconds";
 		variables.lastBusinessDay = true;
+		variables.taskTime        = arguments.time;
+
 		return this;
 	}
 
@@ -1040,32 +1238,9 @@ component accessors="true" {
 	 * Run the task on the first day of the year at midnight
 	 */
 	ScheduledTask function everyYear(){
-		var now     = getJavaNow();
-		// Set at midnight
-		var nextRun = now
-			// First day of the month
-			.with( variables.chronoUnitHelper.ChronoField.DAY_OF_YEAR, javacast( "int", 1 ) )
-			// Midnight
-			.withHour( javacast( "int", 0 ) )
-			.withMinute( javacast( "int", 0 ) )
-			.withSecond( javacast( "int", 0 ) );
+		debugLog( "everyYear" );
 
-		if ( now.compareTo( nextRun ) > 0 ) {
-			nextRun = nextRun.plusYears( javacast( "int", 1 ) );
-		}
-		// Get the duration time for the next run and delay accordingly
-		this.delay(
-			variables.chronoUnitHelper
-				.duration()
-				.getNative()
-				.between( now, nextRun )
-				.getSeconds(),
-			"seconds"
-		);
-		// Set the period to
-		variables.period   = variables.timeUnitHelper.get( "days" ).toSeconds( 365 );
-		variables.timeUnit = "seconds";
-		return this;
+		return this.everyYearOn( 1, 1 );
 	}
 
 	/**
@@ -1080,8 +1255,10 @@ component accessors="true" {
 		required numeric day,
 		required string time = "00:00"
 	){
+		debugLog( "everyYearOn", arguments );
+
 		var now = getJavaNow();
-		// Check for mintues else add them
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
@@ -1107,11 +1284,14 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to
 		variables.period   = variables.timeUnitHelper.get( "days" ).toSeconds( 365 );
 		variables.timeUnit = "seconds";
+		variables.annually = true;
+
 		return this;
 	}
 
@@ -1121,7 +1301,9 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onWeekends( string time = "00:00" ){
-		// Check for mintues else add them
+		debugLog( "onWeekends", arguments );
+
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
@@ -1144,7 +1326,8 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to every day in seconds
 		variables.period   = variables.timeUnitHelper.get( "DAYS" ).toSeconds( 1 );
@@ -1162,7 +1345,9 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onWeekdays( string time = "00:00" ){
-		// Check for mintues else add them
+		debugLog( "onWeekdays", arguments );
+
+		// Check for minutes else add them
 		if ( !find( ":", arguments.time ) ) {
 			arguments.time &= ":00";
 		}
@@ -1185,7 +1370,8 @@ component accessors="true" {
 				.getNative()
 				.between( now, nextRun )
 				.getSeconds(),
-			"seconds"
+			"seconds",
+			true
 		);
 		// Set the period to every day in seconds
 		variables.period   = variables.timeUnitHelper.get( "DAYS" ).toSeconds( 1 );
@@ -1193,6 +1379,7 @@ component accessors="true" {
 		// Constraint to only run on weekdays
 		variables.weekdays = true;
 		variables.weekends = false;
+
 		return this;
 	}
 
@@ -1202,6 +1389,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onMondays( string time = "00:00" ){
+		debugLog( "onMondays", arguments );
+
 		return this.everyWeekOn( 1, arguments.time );
 	}
 
@@ -1211,6 +1400,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onTuesdays( string time = "00:00" ){
+		debugLog( "onTuesdays", arguments );
+
 		return this.everyWeekOn( 2, arguments.time );
 	}
 
@@ -1220,6 +1411,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onWednesdays( string time = "00:00" ){
+		debugLog( "onWednesdays", arguments );
+
 		return this.everyWeekOn( 3, arguments.time );
 	}
 
@@ -1229,6 +1422,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onThursdays( string time = "00:00" ){
+		debugLog( "onThursdays", arguments );
+
 		return this.everyWeekOn( 4, arguments.time );
 	}
 
@@ -1238,6 +1433,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onFridays( string time = "00:00" ){
+		debugLog( "onFridays", arguments );
+
 		return this.everyWeekOn( 5, arguments.time );
 	}
 
@@ -1247,6 +1444,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onSaturdays( string time = "00:00" ){
+		debugLog( "onSaturdays", arguments );
+
 		return this.everyWeekOn( 6, arguments.time );
 	}
 
@@ -1256,6 +1455,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function onSundays( string time = "00:00" ){
+		debugLog( "onSundays", arguments );
+
 		return this.everyWeekOn( 7, arguments.time );
 	}
 
@@ -1266,6 +1467,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function startOn( required date, string time = "00:00" ){
+		debugLog( "startOn", arguments );
+
 		variables.startOnDateTime = variables.chronoUnitHelper.parse(
 			"#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#"
 		);
@@ -1279,6 +1482,8 @@ component accessors="true" {
 	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
 	ScheduledTask function endOn( required date, string time = "00:00" ){
+		debugLog( "endOn", arguments );
+
 		variables.endOnDateTime = variables.chronoUnitHelper.parse(
 			"#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#"
 		);
@@ -1297,6 +1502,8 @@ component accessors="true" {
 	 * Set the time unit in days
 	 */
 	ScheduledTask function inDays(){
+		debugLog( "inDays" );
+
 		variables.timeUnit = "days";
 		return this;
 	}
@@ -1305,6 +1512,8 @@ component accessors="true" {
 	 * Set the time unit in hours
 	 */
 	ScheduledTask function inHours(){
+		debugLog( "inHours" );
+
 		variables.timeUnit = "hours";
 		return this;
 	}
@@ -1313,6 +1522,8 @@ component accessors="true" {
 	 * Set the time unit in microseconds
 	 */
 	ScheduledTask function inMicroseconds(){
+		debugLog( "inMicroseconds" );
+
 		variables.timeUnit = "microseconds";
 		return this;
 	}
@@ -1321,6 +1532,8 @@ component accessors="true" {
 	 * Set the time unit in milliseconds
 	 */
 	ScheduledTask function inMilliseconds(){
+		debugLog( "inMilliseconds" );
+
 		variables.timeUnit = "milliseconds";
 		return this;
 	}
@@ -1329,6 +1542,8 @@ component accessors="true" {
 	 * Set the time unit in minutes
 	 */
 	ScheduledTask function inMinutes(){
+		debugLog( "inMinutes" );
+
 		variables.timeUnit = "minutes";
 		return this;
 	}
@@ -1337,6 +1552,8 @@ component accessors="true" {
 	 * Set the time unit in nanoseconds
 	 */
 	ScheduledTask function inNanoseconds(){
+		debugLog( "inNanoseconds" );
+
 		variables.timeUnit = "nanoseconds";
 		return this;
 	}
@@ -1345,6 +1562,8 @@ component accessors="true" {
 	 * Set the time unit in seconds
 	 */
 	ScheduledTask function inSeconds(){
+		debugLog( "inSeconds" );
+
 		variables.timeUnit = "seconds";
 		return this;
 	}
@@ -1380,6 +1599,277 @@ component accessors="true" {
 		return variables.filter( function( key, value ){
 			return isCustomFunction( value ) || listFindNoCase( "this", key ) ? false : true;
 		} );
+	}
+
+	/**
+	 * --------------------------------------------------------------------------
+	 * Private Methods
+	 * --------------------------------------------------------------------------
+	 */
+
+	/**
+	 * This utility method gives us the first business day of the month in Java format
+	 *
+	 * @time     The specific time using 24 hour format => HH:mm, defaults to midnight
+	 * @addMonth Boolean to specify adding a month to today's date
+	 * @now      The date to use as the starting point, defaults to now()
+	 */
+	private function getFirstBusinessDayOfTheMonth(
+		string time      = "00:00",
+		boolean addMonth = false,
+		date now         = now()
+	){
+		// Get the last day of the month
+		return variables.chronoUnitHelper
+			.toLocalDateTime(
+				arguments.addMonth ? dateAdd( "m", 1, arguments.now ) : arguments.now,
+				this.getTimezone()
+			)
+			// First business day of the month
+			.with(
+				createObject( "java", "java.time.temporal.TemporalAdjusters" ).firstInMonth(
+					createObject( "java", "java.time.DayOfWeek" ).MONDAY
+				)
+			)
+			// Specific Time
+			.withHour( javacast( "int", getToken( arguments.time, 1, ":" ) ) )
+			.withMinute( javacast( "int", getToken( arguments.time, 2, ":" ) ) )
+			.withSecond( javacast( "int", 0 ) );
+	}
+
+	/**
+	 * This utility method gives us the last business day of the month in Java format
+	 *
+	 * @time     The specific time using 24 hour format => HH:mm, defaults to midnight
+	 * @addMonth Boolean to specify adding a month to today's date
+	 * @now      The date to use as the starting point, defaults to now()
+	 */
+	private function getLastBusinessDayOfTheMonth(
+		string time      = "00:00",
+		boolean addMonth = false,
+		date now         = now()
+	){
+		debugLog( "getLastBusinessDayOfTheMonth" );
+
+		// Get the last day of the month
+		var lastDay = variables.chronoUnitHelper
+			.toLocalDateTime(
+				arguments.addMonth ? dateAdd( "m", 1, arguments.now ) : arguments.now,
+				this.getTimezone()
+			)
+			.with( createObject( "java", "java.time.temporal.TemporalAdjusters" ).lastDayOfMonth() )
+			// Specific Time
+			.withHour( javacast( "int", getToken( arguments.time, 1, ":" ) ) )
+			.withMinute( javacast( "int", getToken( arguments.time, 2, ":" ) ) )
+			.withSecond( javacast( "int", 0 ) );
+		// Verify if on weekend
+		switch ( lastDay.getDayOfWeek().getValue() ) {
+			// Sunday - 2 days
+			case 7: {
+				lastDay = lastDay.minusDays( 2 );
+				break;
+			}
+			// Saturday - 1 day
+			case 6: {
+				lastDay = lastDay.minusDays( 1 );
+				break;
+			}
+		}
+
+		return lastDay;
+	}
+
+	/**
+	 * This method is called to set the initial next run time of the task
+	 * if none exists it sets it to now or it can be also passed in as an argument
+	 *
+	 * If a delay is set, it will set the next run time based on the delay and timeUnit
+	 *
+	 * @nextRun  An instance of java.time.LocalDateTime to set the next run time to
+	 * @delay    The delay to set the next run time to
+	 * @timeUnit The time unit to use for the delay
+	 */
+	private function setInitialNextRunTime( any nextRun, numeric delay, string timeUnit ){
+		var amount = structKeyExists( arguments, "delay" ) ? arguments.delay : variables.delay;
+		var unit   = structKeyExists( arguments, "timeUnit" ) ? arguments.timeUnit : variables.timeUnit;
+
+		debugLog(
+			"setInitialNextRunTime",
+			{
+				delay         : amount,
+				timeUnit      : unit,
+				nextRunSet    : isValid( "date", variables.stats.nextRun ) ? true : false,
+				nextRunInArgs : !isNull( arguments.nextRun )
+			}
+		);
+
+		if ( !isValid( "date", variables.stats.nextRun ) ) {
+			if ( !isNull( arguments.nextRun ) && isInstanceOf( arguments.nextRun, "java.time.LocalDateTime" ) )
+				variables.stats.nextRun = arguments.nextRun;
+			else if ( !isInstanceOf( variables.stats.nextRun, "java.time.LocalDateTime" ) )
+				variables.stats.nextRun = getJavaNow();
+
+			if ( amount ) {
+				switch ( unit ) {
+					case "days":
+						variables.stats.nextRun = variables.stats.nextRun.plusDays( javacast( "int", amount ) );
+						break;
+					case "hours":
+						variables.stats.nextRun = variables.stats.nextRun.plusHours( javacast( "int", amount ) );
+						break;
+					case "minutes":
+						variables.stats.nextRun = variables.stats.nextRun.plusMinutes( javacast( "int", amount ) );
+						break;
+					case "milliseconds":
+						variables.stats.nextRun = variables.stats.nextRun.plusSeconds(
+							javacast( "int", amount / 1000 )
+						);
+						break;
+					case "microseconds":
+						variables.stats.nextRun = variables.stats.nextRun.plusNanos(
+							javacast( "int", amount * 1000 )
+						);
+						break;
+					case "nanoseconds":
+						variables.stats.nextRun = variables.stats.nextRun.plusNanos( javacast( "int", amount ) );
+						break;
+					default:
+						variables.stats.nextRun = variables.stats.nextRun.plusSeconds( javacast( "int", amount ) );
+						break;
+				}
+			}
+
+			var now       = getJavaNow();
+			var startTime = len( variables.startTime ) ? now
+				.withHour( javacast( "int", getToken( variables.startTime, 1, ":" ) ) )
+				.withMinute( javacast( "int", getToken( variables.startTime, 2, ":" ) ) )
+				.withSecond( javacast( "int", 0 ) ) : now
+				.withHour( javacast( "int", 0 ) )
+				.withMinute( javacast( "int", 0 ) )
+				.withSecond( javacast( "int", 0 ) );
+			var endTime = len( variables.endTime ) ? now
+				.withHour( javacast( "int", getToken( variables.endTime, 1, ":" ) ) )
+				.withMinute( javacast( "int", getToken( variables.endTime, 2, ":" ) ) )
+				.withSecond( javacast( "int", 0 ) ) : now
+				.withHour( javacast( "int", 23 ) )
+				.withMinute( javacast( "int", 59 ) )
+				.withSecond( javacast( "int", 59 ) );
+
+
+			debugLog(
+				"startTime",
+				{
+					startTime : startTime.toString(),
+					comp      : now.compareTo( startTime )
+				}
+			);
+			debugLog(
+				"endTime",
+				{
+					endTime : endTime.toString(),
+					comp    : now.compareTo( endTime )
+				}
+			);
+
+			if ( now.compareTo( startTime ) < 0 ) {
+				variables.stats.nextRun = startTime
+			};
+
+			if ( now.compareTo( endTime ) > 0 ) {
+				variables.stats.nextRun = startTime.plusDays( javacast( "int", 1 ) )
+			};
+
+			variables.stats.nextRun = variables.stats.nextRun.toString();
+		}
+	}
+
+	/**
+	 * This method is called to set the next run time of the task based on the timeUnit and period.
+	 */
+	private function setNextRunTime(){
+		debugLog( "setNextRunTime", arguments );
+
+		var now    = getJavaNow();
+		var amount = variables.spacedDelay != 0 ? variables.spacedDelay : variables.period;
+
+		// if overlaps are allowed task is immediately scheduled
+		if ( variables.spacedDelay == 0 && variables.stats.lastExecutionTime / 1000 > variables.period ) {
+			amount = 0;
+		}
+
+		// reset nextRun to empty string to continue with process of setting
+		// next run time
+		variables.stats.nextRun = "";
+
+		// check if we are a first or last business day of month entry
+		if ( variables.firstBusinessDay ) {
+			variables.stats.nextRun = getFirstBusinessDayOfTheMonth( variables.taskTime, true );
+		} else if ( variables.lastBusinessDay ) {
+			variables.stats.nextRun = getLastBusinessDayOfTheMonth( variables.taskTime, true );
+		}
+		// check if we have a daily start or end time
+		else if ( len( variables.startTime ) || len( variables.endTime ) ) {
+			var startTime = len( variables.startTime ) ? now
+				.withHour( javacast( "int", getToken( variables.startTime, 1, ":" ) ) )
+				.withMinute( javacast( "int", getToken( variables.startTime, 2, ":" ) ) )
+				.withSecond( javacast( "int", 0 ) ) : now
+				.withHour( javacast( "int", 0 ) )
+				.withMinute( javacast( "int", 0 ) )
+				.withSecond( javacast( "int", 0 ) );
+			var endTime = len( variables.endTime ) ? now
+				.withHour( javacast( "int", getToken( variables.endTime, 1, ":" ) ) )
+				.withMinute( javacast( "int", getToken( variables.endTime, 2, ":" ) ) )
+				.withSecond( javacast( "int", 0 ) ) : now
+				.withHour( javacast( "int", 23 ) )
+				.withMinute( javacast( "int", 59 ) )
+				.withSecond( javacast( "int", 59 ) );
+
+			if ( now.compareTo( startTime ) < 0 ) {
+				variables.stats.nextRun = startTime;
+			} else if ( now.compareTo( endTime ) > 0 ) {
+				variables.stats.nextRun = startTime.plusDays( javacast( "int", 1 ) );
+			}
+		}
+
+		if ( !len( variables.stats.nextRun ) ) {
+			switch ( variables.timeUnit ) {
+				case "days":
+					variables.stats.nextRun = now.plusDays( javacast( "int", amount ) );
+					break;
+				case "hours":
+					variables.stats.nextRun = now.plusHours( javacast( "int", amount ) );
+					break;
+				case "minutes":
+					variables.stats.nextRun = now.plusMinutes( javacast( "int", amount ) );
+					break;
+				case "milliseconds":
+					variables.stats.nextRun = now.plusSeconds( javacast( "int", amount / 1000 ) );
+					break;
+				case "microseconds":
+					variables.stats.nextRun = now.plusNanos( javacast( "int", amount * 1000 ) );
+					break;
+				case "nanoseconds":
+					variables.stats.nextRun = now.plusNanos( javacast( "int", amount ) );
+					break;
+				default:
+					variables.stats.nextRun = now.plusSeconds( javacast( "int", amount ) );
+					break;
+			}
+		}
+
+		variables.stats.nextRun = variables.stats.nextRun.toString();
+	}
+
+	/**
+	 * Debug output method
+	 */
+	function debugLog( required string caller, struct args = {} ){
+		if ( variables.debug ) {
+			var message = "ScheduledTask : " & variables.name & " : " & arguments.caller & "()" & (
+				structIsEmpty( arguments.args ) ? "" : " : " & serializeJSON( arguments.args )
+			);
+			variables.executor.out( message );
+		}
 	}
 
 }

--- a/system/web/tasks/ColdBoxScheduler.cfc
+++ b/system/web/tasks/ColdBoxScheduler.cfc
@@ -91,14 +91,16 @@ component
 	 * Register a new task in this scheduler that will be executed once the `startup()` is fired or manually
 	 * via the run() method of the task.
 	 *
+	 * @name   The name of this task
+	 * @debug  Add debugging logs to System out, disabled by default in coldbox.system.web.tasks.ColdBoxScheduledTask
 	 * @return a ScheduledTask object so you can work on the registration of the task
 	 */
-	ColdBoxScheduledTask function task( required name ){
+	ColdBoxScheduledTask function task( required name, boolean debug = false ){
 		// Create task with custom name
 		var oColdBoxTask = variables.wirebox
 			.getInstance(
 				"coldbox.system.web.tasks.ColdBoxScheduledTask",
-				{ name : arguments.name, executor : variables.executor }
+				{ name : arguments.name, executor : variables.executor, debug: arguments.debug }
 			)
 			// Set ourselves into the task
 			.setScheduler( this )


### PR DESCRIPTION
**New Properties**
 * `annually` 
 boolean to flag task as annually scheduled
 * `delayTimeUnit`
 used to work with delays regardless of setting in chain
 * `debug`  
 used for debug output
 * `firstBusinessDay` 
 boolean to flag task as on first business day schedule
 * `lastBusinessDay` 
 boolean to flag task as on last business day schedule
 * `taskTime` 
 log of time of day for firstBusinessDay and lastBusinessDay tasks
 * `startTime`
 limits task to run on or after specific time of day
 * `endTime`
 limits task to run on or before specific time of day
 * `meta`
 struct that user can use to store any data for the task ( helpful for building UIs and not having to manage outside of task )
 * `stats.nextRun`
 missing value from docs now works 😄 

**Fixed**
  * `onFirstBusinessDayOfTheMonth()` 
  was not properly setting the value if it required to add a month
  * `onLastBusinessDayOfTheMonth()`
  was not getting the correct value
  * `delay()` 
  would overwrite the time unit based when it was defined in the chain, now it gets checked in `start()` and only applied if the `timeUnit` matches the `delayTimeUnit` or if the `timeUnit` is **"seconds"**, which will convert the delay value to seconds from the `delayTimeUnit` setting.
  * `isConstrained()` 
    * **updated check for dayOfTheMonth**
    If the day the user intended to run is higher than the last day of the current month then we allow it to run on the last day of the month.
     * Added checks for new `startTime` and `endTime` properties

**Simplified Functions**
 * `everyDay()`
 * `everyWeek()`
 * `everyMonth()`

**Updated Functions**
  * `run()` 
  added  force argument, to allow to run the task on demand, even if it is paused.
  * `validateTime()`
  sets minutes if missing from time entry and returns time value if successful -  removes a lot of repetitive code

**New Functions**
  * `debug()` 
  used for setting debug setting ( can also be done in task init )
  * `startOnTime()` 
  used to set variables.startTime
  * `endOnTime()`
  used to set variables.endTime
  * `between()`
  used to set variables.startTime and variables.endTime in one call
  * `setMeta()`
  used to set variables.meta
  * `setMetaKey()`
  used to add / save a key to variables.meta
  * `deleteMetaKey()`
  used to delete a key from variables.meta

**New Private Functions**
 * `getLastBusinessDayOfTheMonth()`
 * `getFirstBusinessDayOfTheMonth()`
 * `setInitialNextRunTime()`
 * `setInitialDelayPeriodAndTimeUnit()`
 * `setNextRunTime()`
 * `debugLog()`

**Known Bugs**
The fix for delay is temporary as we need to support other timeUnit conversions and update the documentation.

## Jira Issues
COLDBOX-1226

## Type of change
- [x] Improvement

