### PR TITLE
Debug update for Core ScheduledTasks and Code Re-org

### DIFF
--- a/system/async/executors/ScheduledExecutor.cfc
+++ b/system/async/executors/ScheduledExecutor.cfc
@@ -163,11 +163,13 @@ component extends="Executor" accessors="true" singleton {
 	 * Build out a new scheduled task representation. Calling this method does not mean that the task is executed.
 	 *
 	 * @name   The name of the task
+	 * @debug  Add debugging logs to System out, disabled by default
 	 * @task   The closure or cfc that represents the task (optional)
 	 * @method The method on the cfc to call, defaults to "run" (optional)
 	 */
 	ScheduledTask function newTask(
-		name = "task-#getName()#-#createUUID()#",
+		name  = "task-#getName()#-#createUUID()#",
+		debug = false,
 		task,
 		method = "run"
 	){

--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -367,6 +367,38 @@ component accessors="true" {
 	}
 
 	/**
+	 * Disable the task when scheduled, meaning, don't run this sucker!
+	 */
+	ScheduledTask function disable(){
+		debugLog( "disable" );
+
+		variables.disabled = true;
+		return this;
+	}
+
+	/**
+	 * Enable the task when disabled so we can run again
+	 */
+	ScheduledTask function enable(){
+		debugLog( "enable" );
+
+		variables.disabled = false;
+		return this;
+	}
+
+	/**
+	 * Verifies if we can schedule this task or not by looking at the following constraints:
+	 *
+	 * - disabled
+	 * - when closure
+	 */
+	boolean function isDisabled(){
+		debugLog( "isDisabled" );
+
+		return variables.disabled;
+	}
+
+	/**
 	 * Set the meta data for this task!
 	 */
 	ScheduledTask function setMeta( required struct meta ){
@@ -414,38 +446,37 @@ component accessors="true" {
 	}
 
 	/**
-	 * Disable the task when scheduled, meaning, don't run this sucker!
-	 */
-	ScheduledTask function disable(){
-		debugLog( "disable" );
-
-		variables.disabled = true;
-		return this;
-	}
-
-	/**
-	 * Enable the task when disabled so we can run again
-	 */
-	ScheduledTask function enable(){
-		debugLog( "enable" );
-
-		variables.disabled = false;
-		return this;
-	}
-
-	/**
-	 * Verifies if we can schedule this task or not by looking at the following constraints:
+	 * Set when this task should start execution on. By default it starts automatically.
 	 *
-	 * - disabled
-	 * - when closure
+	 * @date The date when this task should start execution on => yyyy-mm-dd format is preferred.
+	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
 	 */
-	boolean function isDisabled(){
-		debugLog( "isDisabled" );
+	ScheduledTask function startOn( required date, string time = "00:00" ){
+		debugLog( "startOn", arguments );
 
-		return variables.disabled;
+		variables.startOnDateTime = variables.chronoUnitHelper.parse(
+			"#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#"
+		);
+		return this;
 	}
 
 	/**
+	 * Set when this task should stop execution on. By default it never ends
+	 *
+	 * @date The date when this task should stop execution on => yyyy-mm-dd format is preferred.
+	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
+	 */
+	ScheduledTask function endOn( required date, string time = "00:00" ){
+		debugLog( "endOn", arguments );
+
+		variables.endOnDateTime = variables.chronoUnitHelper.parse(
+			"#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#"
+		);
+		return this;
+	}
+
+	/**
+	 * Sets a daily time range restriction where this task can run on.
 	 *
 	 * @startTime The specific time using 24 hour format => HH:mm
 	 * @endTime   The specific time using 24 hour format => HH:mm
@@ -459,6 +490,7 @@ component accessors="true" {
 	}
 
 	/**
+	 * Sets a daily start time restriction for this task.
 	 *
 	 * @time The specific time using 24 hour format => HH:mm
 	 */
@@ -473,6 +505,7 @@ component accessors="true" {
 	}
 
 	/**
+	 * Sets a daily end time restriction for this task.
 	 *
 	 * @time The specific time using 24 hour format => HH:mm
 	 */
@@ -1342,36 +1375,6 @@ component accessors="true" {
 		debugLog( "onSundays", arguments );
 
 		return this.everyWeekOn( 7, arguments.time );
-	}
-
-	/**
-	 * Set when this task should start execution on. By default it starts automatically.
-	 *
-	 * @date The date when this task should start execution on => yyyy-mm-dd format is preferred.
-	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
-	 */
-	ScheduledTask function startOn( required date, string time = "00:00" ){
-		debugLog( "startOn", arguments );
-
-		variables.startOnDateTime = variables.chronoUnitHelper.parse(
-			"#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#"
-		);
-		return this;
-	}
-
-	/**
-	 * Set when this task should stop execution on. By default it never ends
-	 *
-	 * @date The date when this task should stop execution on => yyyy-mm-dd format is preferred.
-	 * @time The specific time using 24 hour format => HH:mm, defaults to 00:00
-	 */
-	ScheduledTask function endOn( required date, string time = "00:00" ){
-		debugLog( "endOn", arguments );
-
-		variables.endOnDateTime = variables.chronoUnitHelper.parse(
-			"#dateFormat( arguments.date, "yyyy-mm-dd" )#T#arguments.time#"
-		);
-		return this;
 	}
 
 	/**

--- a/system/async/tasks/Scheduler.cfc
+++ b/system/async/tasks/Scheduler.cfc
@@ -97,9 +97,12 @@ component accessors="true" singleton {
 	 * Register a new task in this scheduler but disable it immediately.  This is useful
 	 * when debugging tasks and have the easy ability to disable them.
 	 *
+	 * @name  The name of this task
+	 * @debug Add debugging logs to System out, disabled by default in coldbox.system.async.tasks.ScheduledTask
+	 *
 	 * @return The registered and disabled Scheduled Task
 	 */
-	ScheduledTask function xtask( required name ){
+	ScheduledTask function xtask( required name, boolean debug = false ){
 		return task( argumentCollection = arguments ).disable();
 	}
 
@@ -107,13 +110,16 @@ component accessors="true" singleton {
 	 * Register a new task in this scheduler that will be executed once the `startup()` is fired or manually
 	 * via the run() method of the task.
 	 *
+	 * @name  The name of this task
+	 * @debug Add debugging logs to System out, disabled by default in coldbox.system.async.tasks.ScheduledTask
+	 *
 	 * @return a ScheduledTask object so you can work on the registration of the task
 	 */
-	ScheduledTask function task( required name ){
+	ScheduledTask function task( required name, boolean debug = false ){
 		// Create task with custom name
 		var oTask = variables.executor
 			// Give me the task broda!
-			.newTask( arguments.name )
+			.newTask( argumentCollection = arguments )
 			// Register ourselves in the task
 			.setScheduler( this )
 			// Set default timezone into the task


### PR DESCRIPTION
Added debug argument to ScheduleExecutor and Scheduler, which is required for new functionality when using core ScheduledTasks.

Reorganized ScheduledTasks
- moved disable, enable, and isDisabled to Utility and Operational code group
- moved between, startOnTime, endOnTime, startOn, and endOn to Restrictions and added additional comments

- [ ] Improvement