### PR TITLE
Install Ortus ORM extension via server.json's env prop

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     secrets:
       SLACK_WEBHOOK_URL:
-        required: true
+        required: false
 
 jobs:
   tests:

--- a/server-lucee@5.json
+++ b/server-lucee@5.json
@@ -1,6 +1,6 @@
 {
     "app":{
-        "cfengine":"lucee@5.3",
+        "cfengine":"lucee@5.4",
         "serverHomeDirectory":".engine/lucee5"
     },
     "name":"coldbox-lucee@5",
@@ -23,5 +23,8 @@
     },
     "cfconfig":{
         "file":".cfconfig.json"
+    },
+    "env":{
+        "lucee-extensions":"D062D72F-F8A2-46F0-8CBC91325B2F067B"
     }
 }

--- a/server-lucee@6.json
+++ b/server-lucee@6.json
@@ -23,5 +23,8 @@
     },
     "cfconfig":{
         "file":".cfconfig.json"
+    },
+    "env":{
+        "lucee-extensions":"D062D72F-F8A2-46F0-8CBC91325B2F067B"
     }
 }

--- a/server-lucee@be.json
+++ b/server-lucee@be.json
@@ -21,7 +21,10 @@
     "JVM":{
         "heapSize":"1024"
     },
-	"cfconfig": {
-		"file" : ".cfconfig.json"
-	}
+    "cfconfig":{
+        "file":".cfconfig.json"
+    },
+    "env":{
+        "lucee-extensions":"D062D72F-F8A2-46F0-8CBC91325B2F067B"
+    }
 }

--- a/server-lucee@light.json
+++ b/server-lucee@light.json
@@ -21,7 +21,10 @@
     "JVM":{
         "heapSize":"1024"
     },
-	"cfconfig": {
-		"file" : ".cfconfig.json"
-	}
+    "cfconfig":{
+        "file":".cfconfig.json"
+    },
+    "env":{
+        "lucee-extensions":"D062D72F-F8A2-46F0-8CBC91325B2F067B,37C61C0A-5D7E-4256-8572639BE0CF5838 "
+    }
 }


### PR DESCRIPTION
Since the latest Lucee builds don't bundle the Hibernate extension, it is time to switch to the Ortus-maintained extension.

# Description

> Lucee ORM is no longer being developed or bundled by the Lucee Team, Ortus have forked and taken over the development of ORM for Lucee, see [Introducing: The Ortus ORM Extension](https://www.ortussolutions.com/blog/introducing-the-ortus-orm-extension).

For this reason, we need to install the ortus orm extension into the Lucee builds on server startup, or the builds will fail.

## Type of change

Please delete options that are not relevant.

- [X] Build fix

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
