### PR TITLE
Update BugReport.cfm: add error line

### DIFF
--- a/system/exceptions/BugReport.cfm
+++ b/system/exceptions/BugReport.cfm
@@ -66,6 +66,14 @@ A reporting template about exceptions in your ColdBox Apps
 					<td>#HTMLEditFormat( oException.getDetail() ).listChangeDelims( '<br>', chr(13)&chr(10) )#</td>
 				</tr>
 			 </cfif>
+			 <cfif oException.getTagContext().indexExists(1)>
+				<tr>
+					<td align="right" class="info"><strong>Line:</strong></td>
+					<td>
+						#HTMLEditFormat( oException.getTagContext()[1].line )#
+					</td>
+				</tr>
+			</cfif>
 			<tr>
 				<td align="right" class="info"><strong>Timestamp: </strong></td>
 				<td>#dateformat(now(), "mm/dd/yyyy")# #timeformat(now(),"hh:mm:ss tt")#</td>


### PR DESCRIPTION
I add line of error in this report. 
It is very useful to have the error line during development, otherwise you have to look for it below.
I'm assuming it's the first row of the tagContext array.

- [x] Improvement
- [ ] 
- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
