### PR TITLE
Bootstrap.cfc onSessionEnd Error

### DIFF
--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -555,7 +555,7 @@ component serializable="false" accessors="true" {
 
 		// Check for cb Controller
 		if ( structKeyExists( arguments.appScope, locateAppKey() ) ) {
-			cbController = arguments.appScope.cbController;
+			cbController = arguments.appScope[ locateAppKey() ];
 		}
 
 		if ( not isSimpleValue( cbController ) ) {


### PR DESCRIPTION
Fixed issue with onSessionEnd function when using a COLDBOX_APP_KEY value

# Description

If you are using a Coldbox_App_Key value for an application the onSessionEnd function will throw an error since it is hard coded to use the default cbController value instead of using the locateAppKey function.

[[**Please note that all PRs must have tests attached to them**

IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

> Bug Tracker: https://ortussolutions.atlassian.net/jira/software/c/projects/COLDBOX/issues](https://ortussolutions.atlassian.net/browse/COLDBOX-1244)](https://ortussolutions.atlassian.net/browse/COLDBOX-1244)


## Type of change

Please delete options that are not relevant.

- [x ] Bug Fix

## Checklist

- [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
