### PR TITLE
Add Ability to Exclude LogBox Appenders to Root Logger and Categories

### DIFF
--- a/system/logging/config/LogBoxConfig.cfc
+++ b/system/logging/config/LogBoxConfig.cfc
@@ -155,6 +155,10 @@ component accessors="true" {
 			instance.rootLogger.appenders = structKeyList( getAllAppenders() );
 		}
 
+        if ( len( instance.rootLogger.exclude ) ) {
+            instance.rootLogger.appenders = excludeAppenders( instance.rootLogger.appenders, instance.rootLogger.exclude );
+        }
+
 		// Check root's appenders
 		for ( var x = 1; x lte listLen( instance.rootLogger.appenders ); x++ ) {
 			if ( NOT structKeyExists( instance.appenders, listGetAt( instance.rootLogger.appenders, x ) ) ) {
@@ -223,10 +227,16 @@ component accessors="true" {
 	 * @appenders A list of appenders to configure the root logger with. Send a * to add all appenders
 	 * @levelMin  The default log level for the root logger, by default it is 0 (FATAL). Optional. ex: config.logLevels.WARN
 	 * @levelMax  The default log level for the root logger, by default it is 4 (DEBUG). Optional. ex: config.logLevels.WARN
+     * @exclude a list of appenders to exclude from the root logger
 	 *
 	 * @throws InvalidAppenders
 	 */
-	LogBoxConfig function root( required appenders, levelMin = 0, levelMax = 4 ){
+	LogBoxConfig function root( 
+        required appenders, 
+        levelMin = 0, 
+        levelMax = 4,
+        exclude = "" 
+    ){
 		// Convert Levels
 		convertLevels( arguments );
 
@@ -284,9 +294,7 @@ component accessors="true" {
 
         // filter appenders based on exclusion list
         if ( len( arguments.exclude ) ) {
-            appenders = listToArray( appenders ).filter( function( item ) {
-                return !listFindNoCase( exclude, item );
-            } ).toList();
+            appenders = excludeAppenders( appenders, arguments.exclude );
         }
 
 		// Add category registration
@@ -326,6 +334,18 @@ component accessors="true" {
 	struct function getAllAppenders(){
 		return instance.appenders;
 	}
+
+    /**
+     * Exclude appenders from a list of appenders
+     *
+     * @appenders A list of appenders to exclude from
+     * @exclude A list of appenders to exclude
+     */
+    string function excludeAppenders( required string appenders, required string exclude ) {
+        return listToArray( appenders ).filter( function( item ) {
+            return !listFindNoCase( exclude, item );
+        } ).toList();
+    }   
 
 	/**
 	 * Add categories to the DEBUG level. Send each category as an argument.

--- a/system/logging/config/LogBoxConfig.cfc
+++ b/system/logging/config/LogBoxConfig.cfc
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
@@ -262,12 +262,14 @@ component accessors="true" {
 	 * @levelMin  The default log level for the root logger, by default it is 0 (FATAL). Optional. ex: config.logLevels.WARN
 	 * @levelMax  The default log level for the root logger, by default it is 4 (DEBUG). Optional. ex: config.logLevels.WARN
 	 * @appenders A list of appender names to configure this category with. By default it uses all the registered appenders
+     * @exclude A list of appender names to exclude from this category
 	 */
 	LogBoxConfig function category(
 		required name,
 		levelMin  = 0,
 		levelMax  = 4,
-		appenders = "*"
+		appenders = "*",
+        exclude = ""
 	){
 		// Convert Levels
 		convertLevels( arguments );
@@ -279,6 +281,13 @@ component accessors="true" {
 		if ( appenders eq "*" ) {
 			appenders = structKeyList( getAllAppenders() );
 		}
+
+        // filter appenders based on exclusion list
+        if ( len( arguments.exclude ) ) {
+            appenders = listToArray( appenders ).filter( function( item ) {
+                return !listFindNoCase( exclude, item );
+            } ).toList();
+        }
 
 		// Add category registration
 		instance.categories[ arguments.name ] = arguments;

--- a/tests/specs/logging/LogBoxTest.cfc
+++ b/tests/specs/logging/LogBoxTest.cfc
@@ -38,6 +38,14 @@ component extends="coldbox.system.testing.BaseModelTest" {
 				logBox.getLogger( "postInitLogger" ).info( "My Test" ); // Fails if appender was not added to internal registry
 			} );
 
+            it( "can exclude appenders from categories", function(){
+				var config = logBox.getConfig();
+				config.category( name: "noLuis2", appenders: "*", exclude: "luis2" );
+                var logger = logBox.getLogger( "noLuis2" );
+                // expect luis2 to not be present in the logger
+                expect( logger.getAppenders().keyArray().findNoCase( "luis2" ) ).toBeFalse();
+			} );
+
 			describe( "can retrieve loggers with different category names", function(){
 				given( "A valid category inheritance trail that is turned off", function(){
 					then( "it will retrieve the inherited category", function(){

--- a/tests/specs/logging/LogBoxTest.cfc
+++ b/tests/specs/logging/LogBoxTest.cfc
@@ -46,6 +46,40 @@ component extends="coldbox.system.testing.BaseModelTest" {
                 expect( logger.getAppenders().keyArray().findNoCase( "luis2" ) ).toBeFalse();
 			} );
 
+            it( "can exclude appenders from the root", function() {
+
+                logbox = createMock( "coldbox.system.logging.LogBox" );
+				config = new coldbox.system.logging.config.LogBoxConfig();
+
+				// Appenders
+				config
+					.appender( name = "luis", class = "coldbox.system.logging.appenders.ConsoleAppender" )
+					.appender( name = "luis2", class = "coldbox.system.logging.appenders.ConsoleAppender" )
+					.root( appenders = "*", exclude = "luis2" )
+					// Sample categories
+					.OFF( "coldbox.system" )
+					.debug( "coldbox.system.async" )
+                    .category( name: "allAppenders", appenders: "*" );
+
+				// init logBox
+				logBox.init( config );
+
+				// add this configuration after the fact to test another code path
+				config.category( name = "coldbox.system.web", appenders = "*" );
+
+                var logger1 = logBox.getLogger( "allAppenders" );
+                var logger2 = logBox.getLogger( "coldbox.system.web" );
+
+                // luis2 should not be in the root appenders
+                expect( listToArray( config.getRoot().appenders ).findNoCase( "luis2" ) ).toBeFalse(); 
+
+                // luis2 should be in the allAppenders and the coldbox.system.web categories
+                expect( logger1.getAppenders().keyArray().findNoCase( "luis2" ) ).toBeTrue();
+                expect( logger2.getAppenders().keyArray().findNoCase( "luis2" ) ).toBeTrue();
+
+            } );
+
+
 			describe( "can retrieve loggers with different category names", function(){
 				given( "A valid category inheritance trail that is turned off", function(){
 					then( "it will retrieve the inherited category", function(){


### PR DESCRIPTION
This PR adds the ability to define LogBox appender exclusions to the root logger and categories by using a special `exclude` key similar to Wirebox's object populator.

Tests included, of course. :)

Addresses: https://ortussolutions.atlassian.net/browse/LOGBOX-70