### PR TITLE
Consistent American English spelling of "License"

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -2,7 +2,7 @@
 Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
 www.coldbox.org | www.ortussolutions.com
 ********************************************************************************
-ColdBox is open source. However, if you use this product please know that it is bound to the following Licence.
+ColdBox is open source. However, if you use this product please know that it is bound to the following License.
 If you use ColdBox, please make mention of it in your code or web site or add a Powered By Coldbox icon.
 
 Apache License, Version 2.0

--- a/system/cache/license.txt
+++ b/system/cache/license.txt
@@ -2,7 +2,7 @@
 Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
 www.ortussolutions.com
 ********************************************************************************
-ColdBox is open source. However, if you use this product please know that it is bound to the following Licence.
+ColdBox is open source. However, if you use this product please know that it is bound to the following License.
 If you use ColdBox, please make mention of it in your code or web site or add a Powered By Coldbox icon.
 
 Apache License, Version 2.0

--- a/system/ioc/license.txt
+++ b/system/ioc/license.txt
@@ -2,7 +2,7 @@
 Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
 www.ortussolutions.com
 ********************************************************************************
-ColdBox is open source. However, if you use this product please know that it is bound to the following Licence.
+ColdBox is open source. However, if you use this product please know that it is bound to the following License.
 If you use ColdBox, please make mention of it in your code or web site or add a Powered By Coldbox icon.
 
 Apache License, Version 2.0

--- a/system/logging/license.txt
+++ b/system/logging/license.txt
@@ -2,7 +2,7 @@
 Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
 www.ortussolutions.com
 ********************************************************************************
-ColdBox is open source. However, if you use this product please know that it is bound to the following Licence.
+ColdBox is open source. However, if you use this product please know that it is bound to the following License.
 If you use ColdBox, please make mention of it in your code or web site or add a Powered By Coldbox icon.
 
 Apache License, Version 2.0


### PR DESCRIPTION
# Description

Consistent American English spelling of "License" -- specifically in the various license.txt files throughout the codebase.

## Type of change

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
