### PR TITLE
Restart the scheduler to call configure again to get new tasks

### DIFF
--- a/system/web/services/SchedulerService.cfc
+++ b/system/web/services/SchedulerService.cfc
@@ -198,11 +198,17 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	/**
 	 * Restarts a scheduler from this manager, if it exists.
 	 *
-	 * @name The name of the scheduler
+	 * @name    The name of the scheduler
+	 * @force   If true, it forces all shutdowns this is usually true when doing reinits
+	 * @timeout The timeout in seconds to wait for the shutdown of all tasks, defaults to the scheduler's shutdown timeout
 	 *
 	 * @return True if restarted, false if not found
 	 */
-	boolean function restartScheduler( required name ){
+	boolean function restartScheduler(
+		required name,
+		boolean force = false,
+		numeric timeout
+	){
 		if ( hasScheduler( arguments.name ) ) {
 			variables.schedulers[ arguments.name ].restart();
 			return true;

--- a/system/web/services/SchedulerService.cfc
+++ b/system/web/services/SchedulerService.cfc
@@ -210,7 +210,8 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 		numeric timeout
 	){
 		if ( hasScheduler( arguments.name ) ) {
-			variables.schedulers[ arguments.name ].restart();
+			structDelete( arguments, "name" );
+			variables.schedulers[ arguments.name ].restart( argumentCollection = arguments );
 			return true;
 		}
 		return false;

--- a/system/web/services/SchedulerService.cfc
+++ b/system/web/services/SchedulerService.cfc
@@ -210,8 +210,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 		numeric timeout
 	){
 		if ( hasScheduler( arguments.name ) ) {
+			var scheduler = variables.scheduler[ arguments.name ];
 			structDelete( arguments, "name" );
-			variables.schedulers[ arguments.name ].restart( argumentCollection = arguments );
+			scheduler.restart( argumentCollection = arguments );
 			return true;
 		}
 		return false;

--- a/system/web/services/SchedulerService.cfc
+++ b/system/web/services/SchedulerService.cfc
@@ -146,7 +146,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	}
 
 	/**
-	 * This method is ran by the laoder service once the ColdBox application is ready to serve requests.
+	 * This method is ran by the loader service once the ColdBox application is ready to serve requests.
 	 * It will startup all the schedulers in the order they where registered.
 	 */
 	SchedulerService function startupSchedulers(){
@@ -190,6 +190,21 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 		if ( hasScheduler( arguments.name ) ) {
 			variables.schedulers[ arguments.name ].shutdown();
 			structDelete( variables.schedulers, arguments.name );
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Restarts a scheduler from this manager, if it exists.
+	 *
+	 * @name The name of the scheduler
+	 *
+	 * @return True if restarted, false if not found
+	 */
+	boolean function restartScheduler( required name ){
+		if ( hasScheduler( arguments.name ) ) {
+			variables.schedulers[ arguments.name ].restart();
 			return true;
 		}
 		return false;


### PR DESCRIPTION
# Description

This PR adds a `restart` method to Schedulers so we can dynamically load tasks in the `configure` method.

`restart` will `shutdown` the Scheduler, clear the tasks, call `configure`, and then `startup` the scheduler.

## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [x] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
