### PR TITLE
Add exception for set-cookie headers to always append

### DIFF
--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -1803,9 +1803,16 @@ component serializable="false" accessors="true" {
 		}
 		// Name Exists and not already set.
 		else if ( !isNull( arguments.name ) ) {
-			getPageContext()
-				.getResponse()
-				.setHeader( javacast( "string", arguments.name ), javacast( "string", arguments.value ) );
+
+			var response = getPageContext().getResponse();
+						
+			// special exception for Set-Cookie. We always append this header, instead of overwriting
+ 			if ( arguments.name == "Set-Cookie" ) {
+				response.addHeader( javacast( "string", arguments.name ), javacast( "string", arguments.value ) );
+			} else {
+				response.setHeader( javacast( "string", arguments.name ), javacast( "string", arguments.value ) );
+			}
+				
 			variables.responseHeaders[ arguments.name ] = arguments.value;
 		} else {
 			throw(


### PR DESCRIPTION
# Description

See https://ortussolutions.atlassian.net/browse/COLDBOX-1269 for a discussion on why this PR was created.

Important: Before merging, check line 1816. I'm unclear on the purpose of the `responseHeaders` value in the `variables` scope, but that value will always be overwritten.  If you want to append the header there too, let me know and I will amend the PR.

## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [ ] Improvement
