### PR TITLE
ScheduledTasks Casting Error

### DIFF
--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -1531,7 +1531,7 @@ component accessors="true" {
 		// Set the period to be every hour in seconds
 		variables.period = variables.timeUnitHelper
 			.get( arguments.periodValue )
-			.toSeconds( arguments.periodMultiplier );
+			.toSeconds( javacast( "long", arguments.periodMultiplier ) );
 		variables.timeUnit = "seconds";
 	}
 


### PR DESCRIPTION
BoxLang requires the value passed into
java.util.concurrent.TimeUnit to be casted to long to avoid error.

COLDBOX-1282

- [  x ] Bug Fix