### PR TITLE
Use a callback to handle dynamic getHttpHeader calls in testing

### DIFF
--- a/system/testing/BaseTestCase.cfc
+++ b/system/testing/BaseTestCase.cfc
@@ -604,14 +604,18 @@ component extends="testbox.system.compat.framework.TestCase" accessors="true" {
 			.each( function( name ){
 				mockedEvent.setValue( arguments.name, params[ arguments.name ] );
 			} );
-		arguments.headers
-			.keyArray()
-			.each( function( name ){
-				mockedEvent
-					.$( "getHTTPHeader" )
-					.$args( arguments.name )
-					.$results( headers[ arguments.name ] );
-			} );
+		mockedEvent
+			.$(
+				method="getHTTPHeader",
+				callback=function( name, defaultValue ){
+					if( headers.keyExists( arguments.name ) ){
+						return headers[ arguments.name ];
+					}
+					if( !isNull( arguments.defaultValue ) ){
+						return arguments.defaultValue;
+					}
+				}
+			);
 		return this.execute( argumentCollection = arguments );
 	}
 


### PR DESCRIPTION
Here is a POC to fix tests which fail due to headers not being dynamic. 
This should solve the cbotel errors because it expects headers, or default values to work. 

This has been painful for a while, especially in more dynamic testing flows.

I'll let you decide if its worth while or not to make a ticket etc. 