### PR TITLE
thisLocationToken is not var scoped

### DIFF
--- a/system/ioc/dsl/ColdBoxDSL.cfc
+++ b/system/ioc/dsl/ColdBoxDSL.cfc
@@ -74,12 +74,13 @@ component accessors="true" {
 	 * @targetObject The target object we are building the DSL dependency for. If empty, means we are just requesting building
 	 */
 	private function getColdBoxDSL( required definition, targetObject ){
-		var thisName         = arguments.definition.name;
-		var thisType         = arguments.definition.dsl;
-		var thisTypeLen      = listLen( thisType, ":" );
-		var thisLocationType = "";
-		var thisLocationKey  = "";
-		var moduleSettings   = "";
+		var thisName          = arguments.definition.name;
+		var thisType          = arguments.definition.dsl;
+		var thisTypeLen       = listLen( thisType, ":" );
+		var thisLocationType  = "";
+		var thisLocationKey   = "";
+		var thisLocationToken = "";
+		var moduleSettings    = "";
 
 		// Support shortcut for specifying name in the definition instead of the DSl for supporting namespaces
 		if (


### PR DESCRIPTION
The `thisLocationToken` variable is not var scoped (referenced in case '4')

https://github.com/ColdBox/coldbox-platform/blob/development/system/ioc/dsl/ColdBoxDSL.cfc#L252

Also includes formatting changes to make the initial variable assignments line up.

# Description

Please include a summary of the changes and which issue(s) is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Jira Issues

https://ortussolutions.atlassian.net/browse/COLDBOX-1304

## Type of change

- [x] Bug Fix
