### PR TITLE
[COLDBOX-1331] Add ability to ignore or include RC keys when caching events

### DIFF
--- a/system/cache/util/EventURLFacade.cfc
+++ b/system/cache/util/EventURLFacade.cfc
@@ -73,7 +73,7 @@ component accessors="true" {
         } 
 
         // Cache Excludes
-        if ( len( arguments.eventDictionary?.cacheExclude ) ) {
+        if ( len( arguments.eventDictionary.cacheExclude ) ) {
             // Blacklist specific keys
             var excludeKeys = arguments.eventDictionary.cacheExclude.listToArray();
             rcTarget = rcTarget.filter( ( key, value ) => {

--- a/system/cache/util/EventURLFacade.cfc
+++ b/system/cache/util/EventURLFacade.cfc
@@ -57,15 +57,12 @@ component accessors="true" {
         // 2. Include specific keys (if `cacheInclude` is not "*")
         // 3. Exclude specific keys (if `cacheExclude` is provided and not empty)
         
-        // Use custom filter closure stored in dictionary
-        if ( len( arguments.eventDictionary?.cacheFilter ) ) {
-			rcTarget = arguments.event.getController()
-				.runEvent(
-					event = arguments.event.getCurrentHandler() & "." & arguments.eventDictionary.cacheFilter,
-					eventArguments = { rcTarget : rcTarget },
-					private   = true,
-					requestContext = arguments.event
-				);
+        // Use custom filter closure/UDF stored in dictionary
+        if ( 
+            isClosure( arguments.eventDictionary.cacheFilter ) || 
+            isCustomFunction( arguments.eventDictionary.cacheFilter )
+        ) {
+			rcTarget = arguments.eventDictionary.cacheFilter( rcTarget );
         } 
         
         // Cache Includes

--- a/system/cache/util/EventURLFacade.cfc
+++ b/system/cache/util/EventURLFacade.cfc
@@ -38,39 +38,69 @@ component accessors="true" {
      * Note: the 'event' key is always ignored from the request collection
 	 *
 	 * @event A request context object
-     * @cacheIncludeRcKeys A list of keys to include ( '*'=all keys )
+     * @targetContext The targeted request context object
+     * @eventDictionary The event metadata containing cache annotations
 	 */
-	string function getUniqueHash( required event, string cacheIncludeRcKeys="*" ){
+	string function getUniqueHash( 
+        required event,
+        required struct eventDictionary
+    ){
+        
+        // Assign the RC struct and filter out the "event" key, which is not needed for cache keys
+        var rcTarget = arguments.event.getCollection().filter( ( key, value ) => { 
+            return key != "event";
+        } );
+        
+        // Apply cache key filtering based on annotations
+        // We apply them in the following order:
+        // 1. Custom filter closure (if provided)
+        // 2. Include specific keys (if `cacheInclude` is not "*")
+        // 3. Exclude specific keys (if `cacheExclude` is provided and not empty)
+        
+        // Use custom filter closure stored in dictionary
+        if ( len( arguments.eventDictionary?.cacheFilter ) ) {
+			rcTarget = arguments.event.getController()
+				.runEvent(
+					event = arguments.event.getCurrentHandler() & "." & arguments.eventDictionary.cacheFilter,
+					eventArguments = { rcTarget : rcTarget },
+					private   = true,
+					requestContext = arguments.event
+				);
+        } 
+        
+        // Cache Includes
+        // only process if cacheInclude isn't set to "*"
+        if ( !arguments.eventDictionary.cacheInclude == "*" ) {
+            // Whitelist specific keys
+            var includeKeys = arguments.eventDictionary.cacheInclude.listToArray();
+            rcTarget = rcTarget.filter( ( key, value ) => { 
+                return includeKeys.findNoCase( key ) > 0;
+            });
+        } 
 
-        var rcTarget = arguments.event.getCollection().filter( function( key, value ){
-			return (
-                key != "event" && // Remove event, not needed for hashing purposes
-                (
-                    cacheIncludeRcKeys == "*" || // include all keys if *
-                    listFindNoCase( cacheIncludeRcKeys, key ) // or if the key is specified
-                )
-            );
-		} );
+        // Cache Excludes
+        if ( len( arguments.eventDictionary?.cacheExclude ) ) {
+            // Blacklist specific keys
+            var excludeKeys = arguments.eventDictionary.cacheExclude.listToArray();
+            rcTarget = rcTarget.filter( ( key, value ) => {
+                return excludeKeys.findNoCase( key ) == 0;
+            });
+        }
 
-		// systemOutput( "=====> uniquehash-rcTarget: #variables.jTreeMap.init( rcTarget ).toString()#", true );
-		// systemOutput( "=====> uniquehash-rcTargetHash: #hash( variables.jTreeMap.init( rcTarget ).toString() )#", true );
+        var targetMixer = {
+            // Get the original incoming context hash
+            "incomingHash" : hash( variables.jTreeMap.init( rcTarget ).toString() ),
+            // Multi-Host support
+            "cgihost"      : buildAppLink()
+        };
 
-		var targetMixer = {
-			// Get the original incoming context hash
-			"incomingHash" : hash( variables.jTreeMap.init( rcTarget ).toString() ),
-			// Multi-Host support
-			"cgihost"      : buildAppLink()
-		};
+        // Incorporate Routed Structs
+        targetMixer.append( arguments.event.getRoutedStruct(), true );
 
-		// Incorporate Routed Structs
-		structAppend(
-			targetMixer,
-			arguments.event.getRoutedStruct(),
-			true
-		);
+        
 
-		// Return unique identifier
-		return hash( targetmixer.toString() );
+        // Return unique identifier
+        return hash( targetmixer.toString() );
 	}
 
 	/**
@@ -107,18 +137,19 @@ component accessors="true" {
 	/**
 	 * Build an event key according to passed in params
 	 *
-	 * @keySuffix     The key suffix used in the cache key
 	 * @targetEvent   The targeted ColdBox event executed
 	 * @targetContext The targeted request context object
-     * @cacheIncludeRcKeys A list of keys to include ( '*'=all keys )
+     * @eventDictionary The event metadata containing cache annotations
 	 */
 	string function buildEventKey( 
-        required keySuffix, 
         required targetEvent, 
         required targetContext, 
-        string cacheIncludeRcKeys="*" 
+        required struct eventDictionary
     ){
-		return buildBasicCacheKey( argumentCollection=arguments ) & getUniqueHash( arguments.targetContext, arguments.cacheIncludeRcKeys );
+		return buildBasicCacheKey( 
+            keySuffix   = arguments.eventDictionary.suffix,
+            targetEvent = arguments.targetEvent 
+        ) & getUniqueHash( arguments.targetContext, arguments.eventDictionary );
 	}
 
 	/**

--- a/system/cache/util/EventURLFacade.cfc
+++ b/system/cache/util/EventURLFacade.cfc
@@ -57,11 +57,8 @@ component accessors="true" {
         // 2. Include specific keys (if `cacheInclude` is not "*")
         // 3. Exclude specific keys (if `cacheExclude` is provided and not empty)
         
-        // Use custom filter closure/UDF stored in dictionary
-        if ( 
-            isClosure( arguments.eventDictionary.cacheFilter ) || 
-            isCustomFunction( arguments.eventDictionary.cacheFilter )
-        ) {
+        // If cacheFilter isn't a simple value, we assume it's a closure and call it
+        if ( !isSimpleValue( arguments.eventDictionary.cacheFilter ) ) {
 			rcTarget = arguments.eventDictionary.cacheFilter( rcTarget );
         } 
         

--- a/system/cache/util/EventURLFacade.cfc
+++ b/system/cache/util/EventURLFacade.cfc
@@ -35,16 +35,22 @@ component accessors="true" {
 
 	/**
 	 * Build a unique hash from an incoming request context
+     * Note: the 'event' key is always ignored from the request collection
 	 *
 	 * @event A request context object
+     * @cacheIncludeRcKeys A list of keys to include ( '*'=all keys )
 	 */
-	string function getUniqueHash( required event ){
-		var rcTarget = arguments.event
-			.getCollection()
-			.filter( function( key, value ){
-				// Remove event, not needed for hashing purposes
-				return ( key != "event" );
-			} );
+	string function getUniqueHash( required event, string cacheIncludeRcKeys="*" ){
+
+        var rcTarget = arguments.event.getCollection().filter( function( key, value ){
+			return (
+                key != "event" && // Remove event, not needed for hashing purposes
+                (
+                    cacheIncludeRcKeys == "*" || // include all keys if *
+                    listFindNoCase( cacheIncludeRcKeys, key ) // or if the key is specified
+                )
+            );
+		} );
 
 		// systemOutput( "=====> uniquehash-rcTarget: #variables.jTreeMap.init( rcTarget ).toString()#", true );
 		// systemOutput( "=====> uniquehash-rcTargetHash: #hash( variables.jTreeMap.init( rcTarget ).toString() )#", true );
@@ -104,13 +110,15 @@ component accessors="true" {
 	 * @keySuffix     The key suffix used in the cache key
 	 * @targetEvent   The targeted ColdBox event executed
 	 * @targetContext The targeted request context object
+     * @cacheIncludeRcKeys A list of keys to include ( '*'=all keys )
 	 */
-	string function buildEventKey(
-		required keySuffix,
-		required targetEvent,
-		required targetContext
-	){
-		return buildBasicCacheKey( argumentCollection = arguments ) & getUniqueHash( arguments.targetContext );
+	string function buildEventKey( 
+        required keySuffix, 
+        required targetEvent, 
+        required targetContext, 
+        string cacheIncludeRcKeys="*" 
+    ){
+		return buildBasicCacheKey( argumentCollection=arguments ) & getUniqueHash( arguments.targetContext, arguments.cacheIncludeRcKeys );
 	}
 
 	/**

--- a/system/web/services/HandlerService.cfc
+++ b/system/web/services/HandlerService.cfc
@@ -209,10 +209,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 
 				// Create the Cache Key to save
                 eventCachingData.cacheKey = oEventURLFacade.buildEventKey(
-                    keySuffix           = eventDictionaryEntry.suffix,
                     targetEvent         = arguments.ehBean.getFullEvent(),
                     targetContext       = oRequestContext,
-                    cacheIncludeRcKeys  = eventDictionaryEntry.cacheIncludeRcKeys
+                    eventDictionary     = eventDictionaryEntry
                 );
 
 				// Event is cacheable and we need to flag it so the Renderer caches it
@@ -656,7 +655,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 			"cacheKey"          : "",
 			"suffix"            : "",
 			"provider"          : "template",
-            "cacheIncludeRcKeys": "*"
+            "cacheInclude"      : "*",
+            "cacheExclude"      : "",
+            "cacheFilter"       : "",
 		};
 	}
 
@@ -691,7 +692,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 							""
 						);
 						mdEntry.provider = arguments.ehBean.getActionMetadata( "cacheProvider", "template" );
-                        mdEntry.cacheIncludeRcKeys = arguments.ehBean.getActionMetadata( "cacheIncludeRcKeys", "*" );
+                        mdEntry.cacheInclude = arguments.ehBean.getActionMetadata( "cacheInclude", "*" );
+                        mdEntry.cacheExclude = arguments.ehBean.getActionMetadata( "cacheExclude", "" );
+                        mdEntry.cacheFilter = arguments.ehBean.getActionMetadata( "cacheFilter", "" );
 
 						// Handler Event Cache Key Suffix, this is global to the event
 						if (

--- a/system/web/services/HandlerService.cfc
+++ b/system/web/services/HandlerService.cfc
@@ -208,11 +208,12 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 				structAppend( eventCachingData, eventDictionaryEntry, true );
 
 				// Create the Cache Key to save
-				eventCachingData.cacheKey = oEventURLFacade.buildEventKey(
-					keySuffix     = eventDictionaryEntry.suffix,
-					targetEvent   = arguments.ehBean.getFullEvent(),
-					targetContext = oRequestContext
-				);
+                eventCachingData.cacheKey = oEventURLFacade.buildEventKey(
+                    keySuffix           = eventDictionaryEntry.suffix,
+                    targetEvent         = arguments.ehBean.getFullEvent(),
+                    targetContext       = oRequestContext,
+                    cacheIncludeRcKeys  = eventDictionaryEntry.cacheIncludeRcKeys
+                );
 
 				// Event is cacheable and we need to flag it so the Renderer caches it
 				oRequestContext.setEventCacheableEntry( eventCachingData );
@@ -654,7 +655,8 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 			"lastAccessTimeout" : "",
 			"cacheKey"          : "",
 			"suffix"            : "",
-			"provider"          : "template"
+			"provider"          : "template",
+            "cacheIncludeRcKeys": "*"
 		};
 	}
 
@@ -689,6 +691,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 							""
 						);
 						mdEntry.provider = arguments.ehBean.getActionMetadata( "cacheProvider", "template" );
+                        mdEntry.cacheIncludeRcKeys = arguments.ehBean.getActionMetadata( "cacheIncludeRcKeys", "*" );
 
 						// Handler Event Cache Key Suffix, this is global to the event
 						if (

--- a/system/web/services/HandlerService.cfc
+++ b/system/web/services/HandlerService.cfc
@@ -657,7 +657,7 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 			"provider"          : "template",
             "cacheInclude"      : "*",
             "cacheExclude"      : "",
-            "cacheFilter"       : "",
+            "cacheFilter"       : ""
 		};
 	}
 

--- a/system/web/services/HandlerService.cfc
+++ b/system/web/services/HandlerService.cfc
@@ -698,14 +698,24 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 
 						// Handler Event Cache Key Suffix, this is global to the event
 						if (
-							isClosure( arguments.oEventHandler.EVENT_CACHE_SUFFIX ) || isCustomFunction(
-								arguments.oEventHandler.EVENT_CACHE_SUFFIX
-							)
+							isClosure( arguments.oEventHandler.EVENT_CACHE_SUFFIX ) || 
+                            isCustomFunction( arguments.oEventHandler.EVENT_CACHE_SUFFIX )
 						) {
 							mdEntry.suffix = oEventHandler.EVENT_CACHE_SUFFIX( arguments.ehBean );
 						} else {
 							mdEntry.suffix = arguments.oEventHandler.EVENT_CACHE_SUFFIX;
 						}
+
+                        // if the cacheFilter is a closure or UDF, then we store it
+                        if ( 
+                            len( mdEntry.cacheFilter ) &&
+                            (
+                                isClosure( arguments.oEventHandler[ mdEntry.cacheFilter ] ) || 
+                                isCustomFunction( arguments.oEventHandler[ mdEntry.cacheFilter ] )
+                            )
+                        ) {
+                            mdEntry.cacheFilter = arguments.oEventHandler[ mdEntry.cacheFilter ];
+                        }
 					}
 					// end cache metadata is true
 

--- a/system/web/services/RequestService.cfc
+++ b/system/web/services/RequestService.cfc
@@ -153,7 +153,7 @@ component extends="coldbox.system.web.services.BaseService" {
 			}
 
 			// Incorporate metadata about event
-        eventCache.append( eventDictionary, true );
+            eventCache.append( eventDictionary, true );
 			// Build the event cache key according to incoming request
 			eventCache[ "cacheKey" ] = oEventURLFacade.buildEventKey(
 				targetEvent   = currentEvent,

--- a/system/web/services/RequestService.cfc
+++ b/system/web/services/RequestService.cfc
@@ -153,12 +153,13 @@ component extends="coldbox.system.web.services.BaseService" {
 			}
 
 			// Incorporate metadata about event
-			eventCache.append( eventDictionary, true );
+        eventCache.append( eventDictionary, true );
 			// Build the event cache key according to incoming request
 			eventCache[ "cacheKey" ] = oEventURLFacade.buildEventKey(
 				keySuffix     = eventDictionary.suffix,
 				targetEvent   = currentEvent,
-				targetContext = arguments.context
+				targetContext = arguments.context,
+                cacheIncludeRcKeys = eventDictionary.cacheIncludeRcKeys
 			);
 
 			// Check for Event Cache Purge

--- a/system/web/services/RequestService.cfc
+++ b/system/web/services/RequestService.cfc
@@ -156,10 +156,9 @@ component extends="coldbox.system.web.services.BaseService" {
         eventCache.append( eventDictionary, true );
 			// Build the event cache key according to incoming request
 			eventCache[ "cacheKey" ] = oEventURLFacade.buildEventKey(
-				keySuffix     = eventDictionary.suffix,
 				targetEvent   = currentEvent,
 				targetContext = arguments.context,
-                cacheIncludeRcKeys = eventDictionary.cacheIncludeRcKeys
+                eventDictionary = eventDictionary
 			);
 
 			// Check for Event Cache Purge

--- a/test-harness/handlers/eventcaching.cfc
+++ b/test-harness/handlers/eventcaching.cfc
@@ -46,6 +46,76 @@
 		return prc.data;
 	}
 
+    // cacheIncludeRcKeys (all keys)
+	function withIncludeAllRcKeys( event, rc, prc )
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheIncludeRcKeys="*"
+    {
+
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
+    // cacheIncludeRcKeys (no keys)
+    function withIncludeNoRcKeys( event, rc, prc )
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheIncludeRcKeys=""
+    {
+
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
+    // cacheIncludeRcKeys (1 RC key)
+    function withIncludeOneRcKey( event, rc, prc )
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheIncludeRcKeys="slug"
+    {
+
+        param rc.slug = "";
+
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
+    // cacheIncludeRcKeys (RC 2 keys)
+    function withIncludeRcKeyList( event, rc, prc )
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheIncludeRcKeys="slug,id"
+    {
+
+        param rc.slug = "";
+        param rc.id = "";
+
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
+
 	function cacheKeys( event, rc, prc ){
 		var keys = {
 			"template" : getCache( "template" ).getKeys(),

--- a/test-harness/handlers/eventcaching.cfc
+++ b/test-harness/handlers/eventcaching.cfc
@@ -22,7 +22,8 @@
 
 	// Default Action
 	function index( event, rc, prc ) cache="true" cacheTimeout="10"{
-		prc.data = [
+
+        prc.data = [
 			{ id : createUUID(), name : "luis" },
 			{ id : createUUID(), name : "lucas" },
 			{ id : createUUID(), name : "fernando" }
@@ -46,11 +47,12 @@
 		return prc.data;
 	}
 
-    // cacheIncludeRcKeys (all keys)
+    // CacheInclude
+
+    // Default (all keys used for cache)
 	function withIncludeAllRcKeys( event, rc, prc )
         cache        ="true"
         cacheTimeout ="10"
-        cacheIncludeRcKeys="*"
     {
 
         prc.data = [
@@ -62,11 +64,11 @@
         return prc.data;
     }
 
-    // cacheIncludeRcKeys (no keys)
+    // cacheInclude (no keys)
     function withIncludeNoRcKeys( event, rc, prc )
         cache        ="true"
         cacheTimeout ="10"
-        cacheIncludeRcKeys=""
+        cacheInclude=""
     {
 
         prc.data = [
@@ -78,11 +80,11 @@
         return prc.data;
     }
 
-    // cacheIncludeRcKeys (1 RC key)
+    // cacheInclude (1 RC key)
     function withIncludeOneRcKey( event, rc, prc )
         cache        ="true"
         cacheTimeout ="10"
-        cacheIncludeRcKeys="slug"
+        cacheInclude="slug"
     {
 
         param rc.slug = "";
@@ -96,11 +98,11 @@
         return prc.data;
     }
 
-    // cacheIncludeRcKeys (RC 2 keys)
+    // cacheInclude (RC 2 keys)
     function withIncludeRcKeyList( event, rc, prc )
         cache        ="true"
         cacheTimeout ="10"
-        cacheIncludeRcKeys="slug,id"
+        cacheInclude="slug,id"
     {
 
         param rc.slug = "";
@@ -113,6 +115,113 @@
         ];
 
         return prc.data;
+    }
+
+    // CacheExclude
+
+    // cacheExclude (nothing will be filtered)
+    function withExcludeNoRcKeys( event, rc, prc )
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheExclude=""
+    {
+
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
+    // cacheExclude (1 RC key)
+    function withExcludeOneRcKey( event, rc, prc )
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheExclude="slug"
+    {
+
+        param rc.slug = "";
+
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
+    // cacheExclude (RC 2 keys)
+    function withExcludeRcKeyList( event, rc, prc )
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheExclude="slug,id"
+    {
+
+        param rc.slug = "";
+        param rc.id = "";
+
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
+
+    // cacheFilter (closure)
+    function withFilterClosure( event, rc, prc ) 
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheFilter  = "filterUtmParams"
+    {
+
+        param rc.slug = "";
+
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
+    private function filterUtmParams( rcTarget) {
+        return rcTarget.filter( ( key, value ) => {
+            // Filter out UTM parameters
+            return !listFindNoCase( "utm_source,utm_medium,utm_campaign", key );
+        });
+    }
+
+    // all filters
+    function withAllFilters( event, rc, prc ) 
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheFilter  ="filterMutateParams" // mutate params
+        cacheInclude ="slug,id" // include slug and id
+        cacheExclude ="id"  // exclude id
+    {
+
+        param rc.slug = "";
+
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
+    private function filterMutateParams( rcTarget) {
+        rcTarget[ "slug" ] = createUuid(); // randomize slug
+        rcTarget[ "id" ] = createUuid(); // randomize id
+        return rcTarget;
     }
 
 

--- a/test-harness/handlers/eventcaching.cfc
+++ b/test-harness/handlers/eventcaching.cfc
@@ -191,7 +191,7 @@
         return prc.data;
     }
 
-    private function filterUtmParams( rcTarget) {
+    function filterUtmParams( rcTarget) {
         return rcTarget.filter( ( key, value ) => {
             // Filter out UTM parameters
             return !listFindNoCase( "utm_source,utm_medium,utm_campaign", key );
@@ -218,7 +218,7 @@
         return prc.data;
     }
 
-    private function filterMutateParams( rcTarget) {
+    function filterMutateParams( rcTarget ) {
         rcTarget[ "slug" ] = createUuid(); // randomize slug
         rcTarget[ "id" ] = createUuid(); // randomize id
         return rcTarget;

--- a/test-harness/handlers/eventcaching.cfc
+++ b/test-harness/handlers/eventcaching.cfc
@@ -191,11 +191,15 @@
         return prc.data;
     }
 
-    function filterUtmParams( rcTarget) {
-        return rcTarget.filter( ( key, value ) => {
-            // Filter out UTM parameters
-            return !listFindNoCase( "utm_source,utm_medium,utm_campaign", key );
-        });
+    // cacheFilter (returns a closure with rcTarget as argument)
+    private function filterUtmParams() {
+        var ignoreKeys = [ "utm_source", "utm_medium", "utm_campaign" ];
+        return ( rcTarget ) => {
+            return rcTarget.filter( ( key, value ) => {
+                // Filter out UTM parameters
+                return !ignoreKeys.findNoCase( key );
+            } );
+        }
     }
 
     // all filters
@@ -218,10 +222,40 @@
         return prc.data;
     }
 
-    function filterMutateParams( rcTarget ) {
-        rcTarget[ "slug" ] = createUuid(); // randomize slug
-        rcTarget[ "id" ] = createUuid(); // randomize id
-        return rcTarget;
+    // cacheFilter: Returns a closure that mutates the rcTarget
+    private function filterMutateParams() {
+        return ( rcTarget ) => {
+            rcTarget[ "slug" ] = createUuid(); // randomize slug
+            rcTarget[ "id" ] = createUuid(); // randomize id
+            return rcTarget;
+        };
+    }
+
+
+    // withBadCacheFilter (returns something other than a closure)
+    function withBadCacheFilter( event, rc, prc ) 
+        cache        ="true"
+        cacheTimeout ="10"
+        cacheFilter  ="filterNoClosure" 
+    {
+
+        param rc.slug = "";
+
+        prc.data = [
+            { id : createUUID(), name : "luis" },
+            { id : createUUID(), name : "lucas" },
+            { id : createUUID(), name : "fernando" }
+        ];
+
+        return prc.data;
+    }
+
+    // filterNoClosure: returns something other than a closure
+    private function filterNoClosure() {
+        return {
+            "slug" : "foo",
+            "id"   : 1
+        };
     }
 
 

--- a/tests/specs/cache/util/EventsURLFacadeTest.cfc
+++ b/tests/specs/cache/util/EventsURLFacadeTest.cfc
@@ -35,7 +35,21 @@
 				var context = createMock( "coldbox.system.web.context.RequestContext" )
 					.setRoutedStruct( routedStruct )
 					.setContext( { event : "main.index", id : "123" } );
-				var testHash = facade.getUniqueHash( context );
+                
+                // Since everything is mocked and you don't have a real HandlerService or ehBean here,
+                // you can simulate the eventDictionary as it would be returned from getEventCachingMetadata.
+                // This is a simplified version, assuming you have a method to get the event metadata.
+                var eventDictionary = {
+                    "context"      : context.getContext(),
+                    "cacheFilter": "",
+                    "cacheInclude" : "*", // Assuming you want to include all keys
+                    "cacheExclude" : "", // Assuming no keys to exclude
+                    "suffix" : "unittest"
+                };
+
+                // Optionally, if your facade expects more keys, add them here.
+
+				var testHash = facade.getUniqueHash( context, eventDictionary );
 				expect( testhash ).notToBeEmpty();
 			} );
 
@@ -61,8 +75,20 @@
 				var context = createMock( "coldbox.system.web.context.RequestContext" );
 				context.setRoutedStruct( { "name" : "majano" } ).setContext( { event : "main.index", id : "123" } );
 
-				var testCacheKey = facade.buildEventKey( "unittest", "main.index", context );
-				var uniqueHash   = facade.getUniqueHash( context );
+				// Since everything is mocked and you don't have a real HandlerService or ehBean here,
+                // you can simulate the eventDictionary as it would be returned from getEventCachingMetadata.
+                // This is a simplified version, assuming you have a method to get the event metadata.
+                var eventDictionary = {
+                    "context"      : context.getContext(),
+                    "cacheFilter": "",
+                    "cacheInclude" : "*", // Assuming you want to include all keys
+                    "cacheExclude" : "", // Assuming no keys to exclude
+                    "suffix" : "unittest"
+                };
+                
+                var testCacheKey = facade.buildEventKey( "main.index", context, eventDictionary );
+
+				var uniqueHash   = facade.getUniqueHash( context, eventDictionary );
 				var targetKey    = cm.getEventCacheKeyPrefix() & "main.index-unittest-" & uniqueHash;
 
 				expect( testCacheKey ).toBe( targetKey );

--- a/tests/specs/integration/EventCachingSpec.cfc
+++ b/tests/specs/integration/EventCachingSpec.cfc
@@ -327,7 +327,7 @@
 
                 var prc2 = event2.getPrivateCollection();
 
-                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheExclude" );
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheFilter" );
 				expect( prc2.cbox_eventCacheableEntry.cacheFilter ).toBe( "filterUtmParams" );
 
                 // because we ignored 'all utm params in the method', the cache key should match

--- a/tests/specs/integration/EventCachingSpec.cfc
+++ b/tests/specs/integration/EventCachingSpec.cfc
@@ -303,6 +303,17 @@
 
 			} );
 
+            it( "requires cacheFilter to be a closure", function(){
+                
+                expect( () => {
+                    execute( 
+                        event = "eventcaching.withBadCacheFilter", 
+                        renderResults = true
+                    )
+                } ).toThrow( type="HandlerInvalidCacheFilterException" );
+
+			} );
+
 
             it( "can filter RC keys based on cacheFilter", function(){
 

--- a/tests/specs/integration/EventCachingSpec.cfc
+++ b/tests/specs/integration/EventCachingSpec.cfc
@@ -44,9 +44,6 @@
                 );
 				var prc1 = event1.getPrivateCollection();
 
-                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
-				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "*" );
-
                 // reset to simulate another request with a different rc scope
                 setup();
 
@@ -58,30 +55,29 @@
 
                 var prc2 = event2.getPrivateCollection();
 
-                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
-				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "*" );
-
                 // because the default cache considers the rc scope, the cache keys should be different
                 expect( prc1.cbox_eventCacheableEntry.cacheKey ).notToBe( prc2.cbox_eventCacheableEntry.cacheKey );
 
 			} );
 
-            it( "can handle the cacheIncludeRcKeys metadata", function(){
+            // Cache Includes
+
+            it( "can handle the cacheInclude metadata", function(){
 
                 // execute an event and specify a queryString variable
                 var event1 = execute( 
-                    event = "eventcaching.withIncludeAllRcKeys", 
+                    event = "eventcaching.withIncludeOneRcKey", 
                     renderResults = true,
                     queryString="id=1" 
                 );
 				var prc1 = event1.getPrivateCollection();
 
-                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
-				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "*" );
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheInclude" );
+				expect( prc1.cbox_eventCacheableEntry.cacheInclude ).toBe( "slug" );
 
 			} );
 
-            it( "can ignore the rc scope", function(){
+            it( "can ignore the rc scope with an empty cacheInclude", function(){
 
                 // execute an event and specify a queryString variable
                 var event1 = execute( 
@@ -91,8 +87,8 @@
                 );
 				var prc1 = event1.getPrivateCollection();
 
-                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
-				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "" );
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheInclude" );
+				expect( prc1.cbox_eventCacheableEntry.cacheInclude ).toBe( "" );
 
                 // reset to simulate another request
                 setup();
@@ -105,8 +101,8 @@
 
                 var prc2 = event2.getPrivateCollection();
 
-                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
-				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "" );
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheInclude" );
+				expect( prc2.cbox_eventCacheableEntry.cacheInclude ).toBe( "" );
 
                 // because we ignore the RC, the cache key should match
                 expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
@@ -123,8 +119,8 @@
                 );
 				var prc1 = event1.getPrivateCollection();
 
-                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
-				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug" );
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheInclude" );
+				expect( prc1.cbox_eventCacheableEntry.cacheInclude ).toBe( "slug" );
 
                 // reset to simulate another request
                 setup();
@@ -137,8 +133,8 @@
 
                 var prc2 = event2.getPrivateCollection();
 
-                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
-				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug" );
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheInclude" );
+				expect( prc2.cbox_eventCacheableEntry.cacheInclude ).toBe( "slug" );
 
                 // because we ignore the RC, the cache key should match
                 expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
@@ -155,9 +151,9 @@
                 );
 				var prc1 = event1.getPrivateCollection();
 
-                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
-				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug,id" );
-
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheInclude" );
+				expect( prc1.cbox_eventCacheableEntry.cacheInclude ).toBe( "slug,id" );
+                
                 // reset to simulate another request
                 setup();
 
@@ -169,11 +165,210 @@
 
                 var prc2 = event2.getPrivateCollection();
 
-                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
-				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug,id" );
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheInclude" );
+				expect( prc2.cbox_eventCacheableEntry.cacheInclude ).toBe( "slug,id" );
 
                 // because we ignore the RC, the cache key should match
                 expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
+
+			} );
+
+            // Cache Excludes
+
+            it( "can handle the cacheExclude metadata", function(){
+
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withExcludeOneRcKey", 
+                    renderResults = true,
+                    queryString="id=1" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheExclude" );
+				expect( prc1.cbox_eventCacheableEntry.cacheExclude ).toBe( "slug" );
+
+			} );
+
+            it( "will include the entire rc scope with an empty cacheExclude", function(){
+
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withExcludeNoRcKeys", 
+                    renderResults = true,
+                    queryString="id=1" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheExclude" );
+				expect( prc1.cbox_eventCacheableEntry.cacheExclude ).toBe( "" );
+
+                // reset to simulate another request
+                setup();
+
+                var event2 = execute( 
+                    event = "eventcaching.withExcludeNoRcKeys", 
+                    renderResults = true,
+                    queryString="id=2" 
+                );
+
+                var prc2 = event2.getPrivateCollection();
+
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheExclude" );
+				expect( prc2.cbox_eventCacheableEntry.cacheExclude ).toBe( "" );
+
+                // because we allowed the entire RC, the cache key should not match
+                expect( prc1.cbox_eventCacheableEntry.cacheKey ).notToBe( prc2.cbox_eventCacheableEntry.cacheKey );
+
+			} );
+
+            it( "can ignore a specific RC scope key and allow the rest", function(){
+
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withExcludeOneRcKey", 
+                    renderResults = true,
+                    queryString="id=1&slug=foo" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheExclude" );
+				expect( prc1.cbox_eventCacheableEntry.cacheExclude ).toBe( "slug" );
+
+                // reset to simulate another request
+                setup();
+
+                var event2 = execute( 
+                    event = "eventcaching.withExcludeOneRcKey", 
+                    renderResults = true,
+                    queryString="id=1&slug=bar" 
+                );
+
+                var prc2 = event2.getPrivateCollection();
+
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheExclude" );
+				expect( prc2.cbox_eventCacheableEntry.cacheExclude ).toBe( "slug" );
+
+                // because we ignored 'slug', the cache key should match
+                expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
+
+			} );
+
+            it( "can handle a list of specific RC scope keys to exclude", function(){
+
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withExcludeRcKeyList", 
+                    renderResults = true,
+                    queryString="id=1&slug=foo&source=google" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheExclude" );
+				expect( prc1.cbox_eventCacheableEntry.cacheExclude ).toBe( "slug,id" );
+
+                // reset to simulate another request
+                setup();
+
+                var event2 = execute( 
+                    event = "eventcaching.withExcludeRcKeyList", 
+                    renderResults = true,
+                    queryString="id=2&slug=bar&source=google" 
+                );
+
+                var prc2 = event2.getPrivateCollection();
+
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheExclude" );
+				expect( prc2.cbox_eventCacheableEntry.cacheExclude ).toBe( "slug,id" );
+
+                // because we ignored 'id and slug', the cache key should match
+                expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
+
+			} );
+
+            // includeFilter
+
+            it( "can handle the cacheFilter metadata", function(){
+
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withFilterClosure", 
+                    renderResults = true,
+                    queryString="id=1&utm_source=google&utm_medium=cpc" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheFilter" );
+				expect( prc1.cbox_eventCacheableEntry.cacheFilter ).toBe( "filterUtmParams" );
+
+			} );
+
+
+            it( "can filter RC keys based on cacheFilter", function(){
+
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withFilterClosure", 
+                    renderResults = true,
+                    queryString="id=1&utm_source=google&utm_medium=cpc" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheFilter" );
+				expect( prc1.cbox_eventCacheableEntry.cacheFilter ).toBe( "filterUtmParams" );
+
+                setup();
+
+                var event2 = execute( 
+                    event = "eventcaching.withFilterClosure", 
+                    renderResults = true,
+                    queryString="id=1&utm_source=bing&utm_medium=organic" 
+                );
+
+                var prc2 = event2.getPrivateCollection();
+
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheExclude" );
+				expect( prc2.cbox_eventCacheableEntry.cacheFilter ).toBe( "filterUtmParams" );
+
+                // because we ignored 'all utm params in the method', the cache key should match
+                expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
+
+			} );
+
+
+            it( "can filter RC keys based on cacheFilter, cacheInclude, and cacheExclude working together", function(){
+
+                // execute an event and specify a queryString variable
+                // in this test we know that the cacheFilter will randomize the slug and id keys
+                var event1 = execute( 
+                    event = "eventcaching.withAllFilters", 
+                    renderResults = true,
+                    queryString="id=1&slug=foo&utm_source=google" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheFilter,cacheInclude,cacheExclude" );
+				expect( prc1.cbox_eventCacheableEntry.cacheFilter ).toBe( "filterMutateParams" );
+                expect( prc1.cbox_eventCacheableEntry.cacheInclude ).toBe( "slug,id" );
+                expect( prc1.cbox_eventCacheableEntry.cacheExclude ).toBe( "id" );
+
+                setup();
+
+                var event2 = execute( 
+                    event = "eventcaching.withAllFilters", 
+                    renderResults = true,
+                    queryString="id=1&slug=foo&utm_source=bing" 
+                );
+
+                var prc2 = event2.getPrivateCollection();
+
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheExclude,cacheInclude,cacheExclude" );
+				expect( prc2.cbox_eventCacheableEntry.cacheFilter ).toBe( "filterMutateParams" );
+                expect( prc2.cbox_eventCacheableEntry.cacheInclude ).toBe( "slug,id" );
+                expect( prc2.cbox_eventCacheableEntry.cacheExclude ).toBe( "id" );
+
+                // because we forced the cacheFilter to mutate the slug and id keys, the cache key should never match
+                expect( prc1.cbox_eventCacheableEntry.cacheKey ).notToBe( prc2.cbox_eventCacheableEntry.cacheKey );
 
 			} );
 

--- a/tests/specs/integration/EventCachingSpec.cfc
+++ b/tests/specs/integration/EventCachingSpec.cfc
@@ -299,7 +299,7 @@
 				var prc1 = event1.getPrivateCollection();
 
                 expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheFilter" );
-				expect( prc1.cbox_eventCacheableEntry.cacheFilter ).toBe( "filterUtmParams" );
+				expect( isCustomFunction( prc1.cbox_eventCacheableEntry.cacheFilter ) ).toBeTrue();
 
 			} );
 
@@ -315,7 +315,7 @@
 				var prc1 = event1.getPrivateCollection();
 
                 expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheFilter" );
-				expect( prc1.cbox_eventCacheableEntry.cacheFilter ).toBe( "filterUtmParams" );
+				expect( isCustomFunction( prc1.cbox_eventCacheableEntry.cacheFilter ) ).toBeTrue();
 
                 setup();
 
@@ -328,7 +328,7 @@
                 var prc2 = event2.getPrivateCollection();
 
                 expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheFilter" );
-				expect( prc2.cbox_eventCacheableEntry.cacheFilter ).toBe( "filterUtmParams" );
+				expect( isCustomFunction( prc2.cbox_eventCacheableEntry.cacheFilter ) ).toBeTrue();
 
                 // because we ignored 'all utm params in the method', the cache key should match
                 expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
@@ -348,7 +348,7 @@
 				var prc1 = event1.getPrivateCollection();
 
                 expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheFilter,cacheInclude,cacheExclude" );
-				expect( prc1.cbox_eventCacheableEntry.cacheFilter ).toBe( "filterMutateParams" );
+				expect( isCustomFunction( prc1.cbox_eventCacheableEntry.cacheFilter ) ).toBeTrue();
                 expect( prc1.cbox_eventCacheableEntry.cacheInclude ).toBe( "slug,id" );
                 expect( prc1.cbox_eventCacheableEntry.cacheExclude ).toBe( "id" );
 
@@ -363,7 +363,7 @@
                 var prc2 = event2.getPrivateCollection();
 
                 expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheExclude,cacheInclude,cacheExclude" );
-				expect( prc2.cbox_eventCacheableEntry.cacheFilter ).toBe( "filterMutateParams" );
+				expect( isCustomFunction( prc2.cbox_eventCacheableEntry.cacheFilter ) ).toBeTrue();
                 expect( prc2.cbox_eventCacheableEntry.cacheInclude ).toBe( "slug,id" );
                 expect( prc2.cbox_eventCacheableEntry.cacheExclude ).toBe( "id" );
 

--- a/tests/specs/integration/EventCachingSpec.cfc
+++ b/tests/specs/integration/EventCachingSpec.cfc
@@ -24,11 +24,157 @@
 
 
 			it( "can do cached events with custom provider annotations", function(){
-				var event = execute( event = "eventcaching.withProvider", renderResults = true );
+				var event = execute( 
+                    event = "eventcaching.withProvider", 
+                    renderResults = true 
+                );
 				var prc   = event.getPrivateCollection();
 
 				expect( prc.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "provider" );
 				expect( prc.cbox_eventCacheableEntry.provider ).toBe( "default" );
+			} );
+
+            it( "can handle different RC collections", function(){
+
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching", 
+                    renderResults = true,
+                    queryString="id=1" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "*" );
+
+                // reset to simulate another request with a different rc scope
+                setup();
+
+                var event2 = execute( 
+                    event = "eventcaching", 
+                    renderResults = true,
+                    queryString="id=2" 
+                );
+
+                var prc2 = event2.getPrivateCollection();
+
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "*" );
+
+                // because the default cache considers the rc scope, the cache keys should be different
+                expect( prc1.cbox_eventCacheableEntry.cacheKey ).notToBe( prc2.cbox_eventCacheableEntry.cacheKey );
+
+			} );
+
+            it( "can handle the cacheIncludeRcKeys metadata", function(){
+
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withIncludeAllRcKeys", 
+                    renderResults = true,
+                    queryString="id=1" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "*" );
+
+			} );
+
+            it( "can ignore the rc scope", function(){
+
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withIncludeNoRcKeys", 
+                    renderResults = true,
+                    queryString="id=1" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "" );
+
+                // reset to simulate another request
+                setup();
+
+                var event2 = execute( 
+                    event = "eventcaching.withIncludeNoRcKeys", 
+                    renderResults = true,
+                    queryString="id=2" 
+                );
+
+                var prc2 = event2.getPrivateCollection();
+
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "" );
+
+                // because we ignore the RC, the cache key should match
+                expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
+
+			} );
+
+            it( "can isolate specific RC scope keys and ignore the rest", function(){
+
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withIncludeOneRcKey", 
+                    renderResults = true,
+                    queryString="id=1&slug=foo" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug" );
+
+                // reset to simulate another request
+                setup();
+
+                var event2 = execute( 
+                    event = "eventcaching.withIncludeOneRcKey", 
+                    renderResults = true,
+                    queryString="id=2&slug=foo" 
+                );
+
+                var prc2 = event2.getPrivateCollection();
+
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug" );
+
+                // because we ignore the RC, the cache key should match
+                expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
+
+			} );
+
+            it( "can handle a list of specific RC scope keys and ignore the rest", function(){
+
+                // execute an event and specify a queryString variable
+                var event1 = execute( 
+                    event = "eventcaching.withIncludeRcKeyList", 
+                    renderResults = true,
+                    queryString="id=1&slug=foo&source=google" 
+                );
+				var prc1 = event1.getPrivateCollection();
+
+                expect( prc1.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc1.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug,id" );
+
+                // reset to simulate another request
+                setup();
+
+                var event2 = execute( 
+                    event = "eventcaching.withIncludeRcKeyList", 
+                    renderResults = true,
+                    queryString="id=1&slug=foo&source=bing" 
+                );
+
+                var prc2 = event2.getPrivateCollection();
+
+                expect( prc2.cbox_eventCacheableEntry ).toBeStruct().toHaveKey( "cacheIncludeRcKeys" );
+				expect( prc2.cbox_eventCacheableEntry.cacheIncludeRcKeys ).toBe( "slug,id" );
+
+                // because we ignore the RC, the cache key should match
+                expect( prc1.cbox_eventCacheableEntry.cacheKey ).toBe( prc2.cbox_eventCacheableEntry.cacheKey );
+
 			} );
 
 			var formats = [ "json", "xml", "pdf" ];


### PR DESCRIPTION
@lmajano 
This pull request is in response to [this discussion](https://community.ortussolutions.com/t/coldbox-6-4-event-caching-and-ignoring-rc-scope/8886) in the Coldbox community and is a revival of the original PR here: https://github.com/ColdBox/coldbox-platform/pull/503

This new feature for Coldbox gives developers more flexibility with event caching and different RC scopes. The end result should be more efficient caching and improved page load speed for many users.

**The Problem:**
Currently, event caching considers the entire RC scope when generating a cache key. This means that changing any URL or FORM variable on a request will force Coldbox to generate a new cache entry. This behavior is problematic for a few reasons:

A malicious attacker could take advantage and create an unlimited number of cache entries for the same page simply by adding a random URL variable.
Marketing efforts often require appending a unique tracking variable to a URL (e.g. utm_source). In this type of scenario, there is no need to create a new cached event for every unique URL.

**The Solution**
I was inspired by Wirebox's populator include/exclude arguments which lets developers specify a list of keys to consider when populating an entity. My idea was to create a new metadata property called cacheIncludeRcKeys which would allow specifying a list of RC keys to include when generating a cache key. All keys not in the list are ignored. To maintain backward compatibility, the default value for cacheIncludeRcKeys is * which considers all keys.

**How Does it Work?**
Simply include a new metadata attribute cacheIncludeRcKeys to a handler and specify a list of RC keys you want to be included in the cache key generation process. Here are some examples:

```
function show( event, rc, prc ) cache="true" cacheTimeout="10" cacheIncludeRcKeys="slug" {
  ...
}
```
The above code will ignore all RC keys except for slug when generating a cache key. So, if you had a route pages/:slug resolve to pages.show, the following URLs would all utilize the same cache key:
https://mysite.com/pages/foo
https://mysite.com/pages/foo?utm_source=google
https://mysite.com/pages/foo?utm_source=bing

You can also include multiple RC keys by specifying a list in the metadata attribute like this:

```
function show( event, rc, prc ) cache="true" cacheTimeout="10" cacheIncludeRcKeys="slug,id" {
  ...
}
```