### PR TITLE
Rename 'cfsqltype' to 'sqltype'

### DIFF
--- a/system/cache/store/JDBCStore.cfc
+++ b/system/cache/store/JDBCStore.cfc
@@ -237,9 +237,9 @@ component implements="coldbox.system.cache.store.IObjectStore" accessors="true" 
 				var qStats = queryExecute(
 					"#targetSQL#",
 					{
-						lastAccessed : { value : "#now()#", cfsqltype : "timestamp" },
-						id           : { value : "#normalizedID#", cfsqltype : "varchar" },
-						created      : { value : "#now()#", cfsqltype : "timestamp" }
+						lastAccessed : { value : "#now()#", sqltype : "timestamp" },
+						id           : { value : "#normalizedID#", sqltype : "varchar" },
+						created      : { value : "#now()#", sqltype : "timestamp" }
 					},
 					variables.queryOptions
 				);
@@ -360,18 +360,18 @@ component implements="coldbox.system.cache.store.IObjectStore" accessors="true" 
 					)
 					",
 					{
-						id                : { value : "#normalizedId#", cfsqltype : "varchar" },
-						objectKey         : { value : "#arguments.objectKey#", cfsqltype : "varchar" },
-						objectValue       : { value : "#arguments.object#", cfsqltype : "longvarchar" },
-						hits              : { value : "1", cfsqltype : "integer" },
-						timeout           : { value : "#arguments.timeout#", cfsqltype : "integer" },
+						id                : { value : "#normalizedId#", sqltype : "varchar" },
+						objectKey         : { value : "#arguments.objectKey#", sqltype : "varchar" },
+						objectValue       : { value : "#arguments.object#", sqltype : "longvarchar" },
+						hits              : { value : "1", sqltype : "integer" },
+						timeout           : { value : "#arguments.timeout#", sqltype : "integer" },
 						lastAccessTimeout : {
 							value     : "#arguments.lastAccessTimeout#",
-							cfsqltype : "integer"
+							sqltype : "integer"
 						},
-						now       : { value : now(), cfsqltype : "timestamp" },
-						isExpired : { value : "0", cfsqltype : "bit" },
-						isSimple  : { value : "#isSimple#", cfsqltype : "bit" }
+						now       : { value : now(), sqltype : "timestamp" },
+						isExpired : { value : "0", sqltype : "bit" },
+						isSimple  : { value : "#isSimple#", sqltype : "bit" }
 					},
 					variables.queryOptions
 				);
@@ -393,18 +393,18 @@ component implements="coldbox.system.cache.store.IObjectStore" accessors="true" 
 					WHERE id = :id
 				",
 				{
-					id                : { value : "#normalizedId#", cfsqltype : "varchar" },
-					objectKey         : { value : "#arguments.objectKey#", cfsqltype : "varchar" },
-					objectValue       : { value : "#arguments.object#", cfsqltype : "longvarchar" },
-					hits              : { value : "1", cfsqltype : "integer" },
-					timeout           : { value : "#arguments.timeout#", cfsqltype : "integer" },
+					id                : { value : "#normalizedId#", sqltype : "varchar" },
+					objectKey         : { value : "#arguments.objectKey#", sqltype : "varchar" },
+					objectValue       : { value : "#arguments.object#", sqltype : "longvarchar" },
+					hits              : { value : "1", sqltype : "integer" },
+					timeout           : { value : "#arguments.timeout#", sqltype : "integer" },
 					lastAccessTimeout : {
 						value     : "#arguments.lastAccessTimeout#",
-						cfsqltype : "integer"
+						sqltype : "integer"
 					},
-					now       : { value : now(), cfsqltype : "timestamp" },
-					isExpired : { value : "0", cfsqltype : "bit" },
-					isSimple  : { value : "#isSimple#", cfsqltype : "bit" }
+					now       : { value : now(), sqltype : "timestamp" },
+					isExpired : { value : "0", sqltype : "bit" },
+					isSimple  : { value : "#isSimple#", sqltype : "bit" }
 				},
 				variables.queryOptions
 			);

--- a/system/logging/appenders/DBAppender.cfc
+++ b/system/logging/appenders/DBAppender.cfc
@@ -169,7 +169,7 @@ component accessors="true" extends="coldbox.system.logging.AbstractAppender" {
 			",
 			{
 				datetime : {
-					cfsqltype : variables.queryParamDataTimeType,
+					sqltype : variables.queryParamDataTimeType,
 					value     : "#dateFormat( targetDate, "mm/dd/yyyy" )#"
 				}
 			},
@@ -230,31 +230,31 @@ component accessors="true" extends="coldbox.system.logging.AbstractAppender" {
 			",
 			{
 				uuid : {
-					cfsqltype : "varchar",
+					sqltype : "varchar",
 					value     : "#variables.uuid.randomUUID().toString()#"
 				},
 				severity : {
-					cfsqltype : "varchar",
+					sqltype : "varchar",
 					value     : "#arguments.data.severity#"
 				},
 				category : {
-					cfsqltype : "varchar",
+					sqltype : "varchar",
 					value     : "#arguments.data.category#"
 				},
 				timestamp : {
-					cfsqltype : variables.queryParamDataTimeType,
+					sqltype : variables.queryParamDataTimeType,
 					value     : "#arguments.data.timestamp#"
 				},
 				name : {
-					cfsqltype : "varchar",
+					sqltype : "varchar",
 					value     : "#left( getName(), 100 )#"
 				},
 				message : {
-					cfsqltype : "varchar",
+					sqltype : "varchar",
 					value     : "#arguments.data.message#"
 				},
 				extraInfo : {
-					cfsqltype : "varchar",
+					sqltype : "varchar",
 					value     : "#arguments.data.extraInfo#"
 				}
 			},


### PR DESCRIPTION
To pass a query param sql type _without `bx-compat-cfml` installed_, you _must_ use the `sqltype` notation. (Not `cfsqltype`.

This fixes the following error in the DB appender and JDBC store, caused by the query param not being recognized as a `datetime` type:

```
Caused by: com.mysql.cj.jdbc.exceptions.MysqlDataTruncation: Data truncation: Incorrect datetime value: '{ts '2025-06-10 19:35:29'}' for column 'logdate' at row 1
...
```