### PR TITLE
Set default request statusCode to 200

### DIFF
--- a/system/web/context/RequestContext.cfc
+++ b/system/web/context/RequestContext.cfc
@@ -93,11 +93,12 @@ component serializable="false" accessors="true" {
 	/**
 	 * The last status code
 	 * This is used mostly for mocking and tracking multi-step responses in case repsonses are committed.
+     * Defaults to 200 (OK)
 	 */
 	property
 		name   ="statusCode"
 		type   ="numeric"
-		default="0";
+		default="200";
 
 	/**
 	 * The last status text


### PR DESCRIPTION
Matches Router.cfc behavior and assume default `statusCode` of 200.

# Description

Router handles the default status code by assuming it is 200 unless explicitly set otherwise.  The RequestContext and Router should be consistent in their default assumptions.  Additionally, a `statusCode` of 0 isn't valid in the HTML spec anyway.

## Jira Issues

https://ortussolutions.atlassian.net/browse/COLDBOX-1338

## Type of change

Please delete options that are not relevant.

- [x ] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
