### PR TITLE
Add new LogBox configuration option to disallow serializing complex objectts

### DIFF
--- a/system/logging/LogBox.cfc
+++ b/system/logging/LogBox.cfc
@@ -179,10 +179,11 @@ component accessors="true" {
 		var rootConfig = variables.config.getRoot();
 		// Create Root Logger
 		var args       = {
-			category  : "ROOT",
-			levelMin  : rootConfig.levelMin,
-			levelMax  : rootConfig.levelMax,
-			appenders : getAppendersMap( rootConfig.appenders )
+			category                       : "ROOT",
+			levelMin                       : rootConfig.levelMin,
+			levelMax                       : rootConfig.levelMax,
+			appenders                      : getAppendersMap( rootConfig.appenders ),
+			allowSerializingComplexObjects : variables.config.getAllowSerializingComplexObjects()
 		};
 
 		// Save in Registry
@@ -257,9 +258,10 @@ component accessors="true" {
 			root = locateCategoryParentLogger( arguments.category );
 			// Build it out as per Root logger
 			args = {
-				category : arguments.category,
-				levelMin : root.getLevelMin(),
-				levelMax : root.getLevelMax()
+				category                       : arguments.category,
+				levelMin                       : root.getLevelMin(),
+				levelMax                       : root.getLevelMax(),
+				allowSerializingComplexObjects : variables.config.getAllowSerializingComplexObjects()
 			};
 		}
 

--- a/system/logging/config/LogBoxConfig.cfc
+++ b/system/logging/config/LogBoxConfig.cfc
@@ -26,6 +26,14 @@ component accessors="true" {
 	 */
 	property name="rootLogger" type="struct";
 
+	/**
+	 * Flag to allow serializing complex objects in `extraInfo`.
+	 */
+	property
+		name   ="allowSerializingComplexObjects"
+		type   ="boolean"
+		default="true";
+
 	// The log levels enum as a public property
 	this.logLevels = new coldbox.system.logging.LogLevels();
 	// Startup the configuration
@@ -126,6 +134,10 @@ component accessors="true" {
 		}
 		if ( structKeyExists( logBoxDSL, "off" ) ) {
 			OFF( argumentCollection = getUtil().arrayToStruct( logBoxDSL.off ) );
+		}
+
+		if ( structKeyExists( logBoxDSL, "allowSerializingComplexObjects" ) ) {
+			variables.allowSerializingComplexObjects = logBoxDSL.allowSerializingComplexObjects;
 		}
 
 		return this;

--- a/tests/specs/logging/LoggerTest.cfc
+++ b/tests/specs/logging/LoggerTest.cfc
@@ -128,6 +128,69 @@
 					expect( mockAppender.$callLog().logmessage ).toBeEmpty();
 				} );
 			} );
+
+			describe( "can control serializing complex objects", function(){
+				beforeEach( function( currentSpec ){
+					// MockAppender
+					mockAppender = createStub()
+						.$( "getName", "MockAppender" )
+						.$( "isInitialized", true )
+						.$( "canLog", true )
+						.$( "getProperty", false )
+						.$( "logmessage" );
+					logger.addAppender( mockAppender );
+				} );
+
+				afterEach( function(){
+					logger.setAllowSerializingComplexObjects( true ); // reset to default
+				} );
+
+				it( "allows serializing complex objects by default", function(){
+					expect( function(){
+						logger.logMessage(
+							"This is a closure message",
+							"info",
+							new tests.resources.base1()
+						);
+					} ).notToThrow( type = "Logger.SerializingComplexObjectException" );
+				} );
+
+				it( "can disallow serializing complex objects", function(){
+					logger.setAllowSerializingComplexObjects( false );
+					expect( function(){
+						logger.logMessage(
+							"This is a closure message",
+							"info",
+							new tests.resources.base1()
+						);
+					} ).toThrow( type = "Logger.SerializingComplexObjectException" );
+				} );
+
+				it( "can find complex objects inside structs", () => {
+					logger.setAllowSerializingComplexObjects( false );
+					expect( function(){
+						logger.logMessage(
+							"This is a closure message",
+							"info",
+							{
+								"simple" : "value",
+								"nested" : { "array" : [ "values", "are", "okay" ] }
+							}
+						);
+					} ).notToThrow( type = "Logger.SerializingComplexObjectException" );
+
+					expect( function(){
+						logger.logMessage(
+							"This is a closure message",
+							"info",
+							{
+								"simple" : "value",
+								"nested" : { "complex" : new tests.resources.base1() }
+							}
+						);
+					} ).toThrow( type = "Logger.SerializingComplexObjectException" );
+				} );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
# Description

A new top level config item named `allowSerializingComplexObjects` controls whether LogBox will attempt to serialize and log out complex objects in `extraInfo` arguments.  Defaults to `true`.  Turning this to `false` can catch instances where you are using lots of processing time converting objects to XML or JSON unnecessarily.  Removing these can increase performance and stability of running applications.

## Jira Issues

https://ortussolutions.atlassian.net/browse/LOGBOX-83


## Type of change

Please delete options that are not relevant.

- [ ] Bug Fix
- [x] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
