### PR TITLE
avoid Can't cast Component [Optional] to String in scheduler

### DIFF
--- a/system/async/tasks/ScheduledTask.cfc
+++ b/system/async/tasks/ScheduledTask.cfc
@@ -778,8 +778,17 @@ component accessors="true" {
 	 *
 	 * @return The last result of the task as an Optional
 	 */
-	function getLastResult(){
-		return variables.stats.lastResult;
+	function getLastResult() {
+		var result = variables.lastResult;
+		// Unwrap Java Optional if present
+		if ( isObject( result ) && structKeyExists( result, "isPresent" ) && structKeyExists( result, "get" ) ) {
+			if ( result.isPresent() ) {
+				return result.get();
+			} else {
+				return "";
+			}
+		}
+		return result;
 	}
 
 	/**


### PR DESCRIPTION
When running async scheduler tests on Lucee 6.2.3.32, the following error occurred:

```
[ERROR] Stacktrace for task (test1) : lucee.runtime.exp.ExpressionException: Can't cast Component [Optional] to String
        at lucee.runtime.ComponentImpl.castToString(ComponentImpl.java:1363)
        at lucee.runtime.ComponentImpl.castToString(ComponentImpl.java:1341)
        at lucee.runtime.op.Caster.toString(Caster.java:2135)
        at specs.async.tasks.schedulerspec_cfc$cf.udfCall2(/tests/specs/async/tasks/SchedulerSpec.cfc:75)
        at specs.async.tasks.schedulerspec_cfc$cf.udfCall(/tests/specs/async/tasks/SchedulerSpec.cfc)
        at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:112)
        at lucee.runtime.type.UDFImpl._call(UDFImpl.java:357)
        at lucee.runtime.type.UDFImpl.call(UDFImpl.java:224)
        at lucee.runtime.type.EnvUDF.call(EnvUDF.java:119)
        at lucee.runtime.ComponentScopeShadow.call(ComponentScopeShadow.java:314)
        at lucee.runtime.util.VariableUtilImpl.callFunctionWithoutNamedValues(VariableUtilImpl.java:773)
        at lucee.runtime.PageContextImpl.getFunction(PageContextImpl.java:2081)
        at system.async.tasks.scheduledtask_cfc$cf.udfCall3(/coldbox/system/async/tasks/ScheduledTask.cfc:725)
        at system.async.tasks.scheduledtask_cfc$cf.udfCall(/coldbox/system/async/tasks/ScheduledTask.cfc)
        at lucee.runtime.type.UDFImpl.implementation(UDFImpl.java:112)
        at lucee.runtime.type.UDFImpl._call(UDFImpl.java:357)
        at lucee.runtime.type.UDFImpl.callWithNamedValues(UDFImpl.java:214)
        at lucee.runtime.ComponentImpl._call(ComponentImpl.java:732)
        at lucee.runtime.ComponentImpl._call(ComponentImpl.java:604)
        at lucee.runtime.ComponentImpl.callWithNamedValues(ComponentImpl.java:2129)
        at lucee.runtime.util.VariableUtilImpl.callFunctionWithNamedValues(VariableUtilImpl.java:896)
        at lucee.runtime.functions.dynamicEvaluation.Invoke.call(Invoke.java:54)
        at lucee.runtime.functions.dynamicEvaluation.Invoke.call(Invoke.java:37)
        at system.async.cbproxies.models.callable_cfc$cf.udfCall(/coldbox/system/async/cbproxies/models/Callable.cfc:13)
```

This happens because the async framework stores task results as a Java Optional, but the test and other consumers expect a plain value (e.g., a string). Attempting to use the Optional directly as a string causes a cast error.

Updated ScheduledTask.cfc#getLastResult() to detect and unwrap Java Optional results. If the result is an Optional and present, it returns the underlying value; otherwise, it returns an empty string. This ensures that consumers always receive the expected value type, preventing cast errors. Stacktrace
Impact
Async scheduler tests now pass on Lucee 6.x and other engines that may return Optional. No breaking changes; only the return value of getLastResult() is affected, and it is now safer for all consumers.
