### PR TITLE
ObjectPopulator Class Lookup Fix

### DIFF
--- a/system/core/dynamic/ObjectPopulator.cfc
+++ b/system/core/dynamic/ObjectPopulator.cfc
@@ -557,11 +557,11 @@ component accessors="true" singleton {
 		var relationMetaClass = "";
 		// BoxLang Prime
 		if ( arguments.relationalMeta.properties[ arguments.key ].keyExists( "className" ) ) {
-			relationMetaClass = listLast( arguments.relationalMeta.properties[ arguments.key ].className, "." )
+			relationMetaClass = arguments.relationalMeta.properties[ arguments.key ].className;
 		}
 		// CFML Legacy
 		if ( arguments.relationalMeta.properties[ arguments.key ].keyExists( "cfc" ) ) {
-			relationMetaClass = listLast( arguments.relationalMeta.properties[ arguments.key ].cfc, "." )
+			relationMetaClass = arguments.relationalMeta.properties[ arguments.key ].cfc;
 		}
 
 		// 1.) name match
@@ -571,10 +571,10 @@ component accessors="true" singleton {
 		// 2.) attempt match on class metadata on the property:
 		// property name="role" cfc="security.Role"
 		// property name="role" class="security.Role"
-		else if ( validEntityNames.findNoCase( relationMetaClass ) ) {
-			targetEntityName = relationMetaClass;
+		else if ( validEntityNames.findNoCase( listLast( relationMetaClass, "." ) ) ) {
+			targetEntityName = listLast( relationMetaClass, "." );
 		}
-		// 3.) class lookup
+		// 3.) class lookup - this would only fire if the `cfc` or `className` attribute was pointing to a CFC, but the entity name was different than the file name
 		else {
 			var annotations = server.keyExists( "boxlang" ) ? getClassMetadata( relationMetaClass ).annotations : getComponentMetadata(
 				relationMetaClass


### PR DESCRIPTION
 Resolves incorrect metadata lookup when resolving a class that has a different entity name than the file name

## Description
Resolves new errors seen in [ContentBox builds](https://github.com/Ortus-Solutions/ContentBox/actions/runs/18203967350/job/51829665621) using `coldbox@be`

Please delete options that are not relevant.

- [X] Bug Fix

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
