### PR TITLE
JSON should be utf-8 encoded

### DIFF
--- a/system/Bootstrap.cfc
+++ b/system/Bootstrap.cfc
@@ -307,7 +307,7 @@ component serializable="false" accessors="true" {
 						// ColdBox does native JSON if you return a complex object.
 						else {
 							renderedContent = cbController.getUtil().toJson( local.refResults.results );
-							getPageContextResponse().setContentType( "application/json" );
+							getPageContextResponse().setContentType( "application/json;charset=utf-8" );
 						}
 					}
 					// Render Layout/View pair via set variable to eliminate whitespace


### PR DESCRIPTION
# Description

When ColdBox handlers return complex data then ColdBox automatically converts it to JSON and serves it with the `application/json` content type. As JSON should be utf-8 encoded then append the charset to the header to ensure characters are encoded correctly.

JSON Spec: https://www.rfc-editor.org/rfc/rfc8259#section-8.1

Note that event.renderData() already defaults to utf-8 encoding 


## Jira Issues

https://ortussolutions.atlassian.net/browse/COLDBOX-1370

## Type of change

Please delete options that are not relevant.

- [x] Improvement
