### PR TITLE
Fix for COLDBOX-1348

### DIFF
--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -605,19 +605,23 @@ component
 			}
 		}
 
-		// Discover the layout location + helpers
-		var layoutLocations = discoverViewPaths(
-			view          : cbox_currentLayout,
-			module        : arguments.module,
-			explicitModule: cbox_explicitModule,
-			isLayout      : true
-		);
-
 		// If Layout is blank, then just delegate to the view
 		// No layout rendering.
 		if ( len( cbox_currentLayout ) eq 0 ) {
 			iData.renderedLayout = this.view();
+			// Announce
+			if ( not arguments.prePostExempt ) {
+				announce( "postLayoutRender", iData );
+			}
 		} else {
+			// Discover the layout location + helpers
+			var layoutLocations = discoverViewPaths(
+				view          : cbox_currentLayout,
+				module        : arguments.module,
+				explicitModule: cbox_explicitModule,
+				isLayout      : true
+			);
+
 			// Render the layout with it's helpers
 			iData.renderedLayout = renderViewComposite(
 				view          : cbox_currentLayout,
@@ -626,11 +630,11 @@ component
 				args          : args,
 				viewVariables : arguments.viewVariables
 			);
-		}
 
-		// Announce
-		if ( not arguments.prePostExempt ) {
-			announce( "postLayoutRender", iData.append( { viewPath : layoutLocations.viewPath } ) );
+			// Announce
+			if ( not arguments.prePostExempt ) {
+				announce( "postLayoutRender", iData.append( { viewPath : layoutLocations.viewPath } ) );
+			}
 		}
 
 		return iData.renderedLayout;


### PR DESCRIPTION
Problem

 After upgrading to ColdBox 7.5.2, the Renderer.cfc was calling discoverViewPaths() to locate a layout before checking if the layout name was
  empty. When a module had layoutParentLookup = true and called event.noLayout() (which sets the layout to an empty string), the framework tried to
  locate a layout with an empty name, causing the error:

  The layout [] was not found in the module path: [/modules_app/akibase/layouts/]

  Solution

  I reorganized the code in /coldbox/system/web/Renderer.cfc:608-637 to:
  1. First check if the layout is empty (len( cbox_currentLayout ) eq 0)
  2. If empty, just render the view without any layout discovery
  3. Only call discoverViewPaths() when we know the layout is not empty

