### PR TITLE
Fix: getResponseHeaders() returns empty struct after setup()

### DIFF
--- a/system/testing/mock/web/context/MockRequestContext.cfc
+++ b/system/testing/mock/web/context/MockRequestContext.cfc
@@ -29,6 +29,8 @@ component
 		else if ( structKeyExists( arguments, "name" ) ) {
 			var headers                        = getValue( "cbox_headers", {} );
 			headers[ lCase( arguments.name ) ] = arguments.value;
+            // Keep variables.responseHeaders in sync so getResponseHeaders() works in tests
+			variables.responseHeaders[ arguments.name ] = arguments.value;
 			setValue( "cbox_headers", headers );
 		} else {
 			throw(

--- a/system/testing/mock/web/context/MockRequestContext.cfc
+++ b/system/testing/mock/web/context/MockRequestContext.cfc
@@ -29,7 +29,7 @@ component
 		else if ( structKeyExists( arguments, "name" ) ) {
 			var headers                        = getValue( "cbox_headers", {} );
 			headers[ lCase( arguments.name ) ] = arguments.value;
-            // Keep variables.responseHeaders in sync so getResponseHeaders() works in tests
+			// Keep variables.responseHeaders in sync so getResponseHeaders() works in tests
 			variables.responseHeaders[ arguments.name ] = arguments.value;
 			setValue( "cbox_headers", headers );
 		} else {

--- a/tests/specs/web/context/RequestContextTest.cfc
+++ b/tests/specs/web/context/RequestContextTest.cfc
@@ -591,6 +591,25 @@ component extends="coldbox.system.testing.BaseModelTest" {
 		event.setHTTPHeader( name = "expires", value = "#now()#" );
 	}
 
+    function testMockRequestContextPopulatesResponseHeaders(){
+        // MockRequestContext.setHTTPHeader() should populate variables.responseHeaders
+        // so that getResponseHeaders() works correctly in integration tests
+        var mockEvent = getMockBox().createMock( "coldbox.system.testing.mock.web.context.MockRequestContext" );
+        mockEvent.init( properties = props, controller = mockController );
+
+        // Set custom headers
+        mockEvent.setHTTPHeader( name = "x-custom-header", value = "test-value" );
+        mockEvent.setHTTPHeader( name = "cached-data", value = "false" );
+
+        // getResponseHeaders() should return the headers that were set
+        var headers = mockEvent.getResponseHeaders();
+        
+        expect( headers ).toHaveKey( "x-custom-header" );
+        expect( headers[ "x-custom-header" ] ).toBe( "test-value" );
+        expect( headers ).toHaveKey( "cached-data" );
+        expect( headers[ "cached-data" ] ).toBe( "false" );
+    }
+
 	function testGetHTTPContent(){
 		var event = getRequestContext();
 		test      = event.getHTTPContent();

--- a/tests/specs/web/context/RequestContextTest.cfc
+++ b/tests/specs/web/context/RequestContextTest.cfc
@@ -591,24 +591,24 @@ component extends="coldbox.system.testing.BaseModelTest" {
 		event.setHTTPHeader( name = "expires", value = "#now()#" );
 	}
 
-    function testMockRequestContextPopulatesResponseHeaders(){
-        // MockRequestContext.setHTTPHeader() should populate variables.responseHeaders
-        // so that getResponseHeaders() works correctly in integration tests
-        var mockEvent = getMockBox().createMock( "coldbox.system.testing.mock.web.context.MockRequestContext" );
-        mockEvent.init( properties = props, controller = mockController );
+	function testMockRequestContextPopulatesResponseHeaders(){
+		// MockRequestContext.setHTTPHeader() should populate variables.responseHeaders
+		// so that getResponseHeaders() works correctly in integration tests
+		var mockEvent = getMockBox().createMock( "coldbox.system.testing.mock.web.context.MockRequestContext" );
+		mockEvent.init( properties = props, controller = mockController );
 
-        // Set custom headers
-        mockEvent.setHTTPHeader( name = "x-custom-header", value = "test-value" );
-        mockEvent.setHTTPHeader( name = "cached-data", value = "false" );
+		// Set custom headers
+		mockEvent.setHTTPHeader( name = "x-custom-header", value = "test-value" );
+		mockEvent.setHTTPHeader( name = "cached-data", value = "false" );
 
-        // getResponseHeaders() should return the headers that were set
-        var headers = mockEvent.getResponseHeaders();
-        
-        expect( headers ).toHaveKey( "x-custom-header" );
-        expect( headers[ "x-custom-header" ] ).toBe( "test-value" );
-        expect( headers ).toHaveKey( "cached-data" );
-        expect( headers[ "cached-data" ] ).toBe( "false" );
-    }
+		// getResponseHeaders() should return the headers that were set
+		var headers = mockEvent.getResponseHeaders();
+		
+		expect( headers ).toHaveKey( "x-custom-header" );
+		expect( headers[ "x-custom-header" ] ).toBe( "test-value" );
+		expect( headers ).toHaveKey( "cached-data" );
+		expect( headers[ "cached-data" ] ).toBe( "false" );
+	}
 
 	function testGetHTTPContent(){
 		var event = getRequestContext();


### PR DESCRIPTION
MockRequestContext.getResponseHeaders() always returns an empty struct {} in integration tests, even after calling setHTTPHeader(). This causes test assertions on response headers to fail unexpectedly when setup() is called between tests.

Note: I didn't see a specific test file for MockRequestContext, so I added my test to RequestContextTest.

## Jira Issues

https://ortussolutions.atlassian.net/browse/COLDBOX-1380

## Type of change

Please delete options that are not relevant.

- [x ] Bug Fix

## Checklist

- [ x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
