### PR TITLE
fix: eliminate race condition in buildDSLDependency() for @-namespaced DSL

### DIFF
--- a/system/ioc/Builder.cfc
+++ b/system/ioc/Builder.cfc
@@ -678,9 +678,10 @@ component serializable="false" accessors="true" {
 			// If no DSL's found, let's try to use the name as the empty namespace
 			default: {
 				if ( len( DSLNamespace ) && left( DSLNamespace, 1 ) == "@" ) {
-					arguments.definition.dsl = arguments.definition.name & arguments.definition.dsl;
+					refLocal.dependency = variables.injector.getInstance( arguments.definition.name & arguments.definition.dsl );
+				} else {
+					refLocal.dependency = getModelDSL( argumentCollection = arguments );
 				}
-				refLocal.dependency = getModelDSL( argumentCollection = arguments );
 			}
 		}
 


### PR DESCRIPTION
Mutating the shared cached definition struct (arguments.definition.dsl)
under concurrent load caused double-concatenation and mis-wiring when
multiple threads resolved the same @-namespaced injection simultaneously
(e.g. inject="myService@moduleName").

Instead of writing back to the shared struct, call getInstance() directly
with the locally-computed concatenated name. The @-prefixed branch in
getModelDSL() always resolves to a plain getInstance() call (no colons
possible), so this is behaviourally identical but fully thread-safe.

https://claude.ai/code/session_015kUgi5MyDwtH2FWf5u5DDN