### PR TITLE
Fix module settings param for Lucee 6 - COLDBOX-1385

### DIFF
--- a/system/web/services/ModuleService.cfc
+++ b/system/web/services/ModuleService.cfc
@@ -1316,7 +1316,9 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 			var globalModuleSettings = controller
 				.getSetting( "ColdBoxConfig" )
 				.getPropertyMixin( "moduleSettings", "variables", {} );
-			param name="globalModuleSettings[ mConfig.modelNamespace ]" default="#structNew()#";
+			if( !globalModuleSettings.keyExists( mConfig.modelNamespace ) ) {
+				globalModuleSettings[ mConfig.modelNamespace ] = structNew();
+			}
 			mConfig.settings.append( globalModuleSettings[ mConfig.modelNamespace ], true );
 
 			// config/{mConfig.modelNamespace}.cfc overrides


### PR DESCRIPTION
# Description

Lucee 6.2.5+48 does not like [this syntax in coldbox's ModuleService](https://github.com/ColdBox/coldbox-platform/blame/development/system/web/services/ModuleService.cfc#L1319):

```
param name="globalModuleSettings[ mConfig.modelNamespace ]" default="#structNew()#";
```

## Jira Issues

https://ortussolutions.atlassian.net/browse/COLDBOX-1385

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix

## Checklist

- [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
