### PR TITLE
Fix ConcurrentModificationException

### DIFF
--- a/system/ioc/config/Mapping.cfc
+++ b/system/ioc/config/Mapping.cfc
@@ -441,8 +441,11 @@ component accessors="true" {
 		delegateIncludes = []
 	){
 		// check if already registered, if it is, just return
-		for ( var thisProperty in variables.DIProperties ) {
-			if ( thisProperty.name eq arguments.name ) {
+		for ( var x = 1; x lte arrayLen( variables.DIProperties ); x++ ) {
+			if (
+				structKeyExists( variables.DIProperties[ x ], "name" ) AND
+				variables.DIProperties[ x ].name == arguments.name
+			) {
 				return this;
 			}
 		}


### PR DESCRIPTION
ConcurrentModificationException in DI property registration was caused by iterating DIProperties with a fail-fast iterator while metadata processing could mutate the same array during startup.
The fix replaces iterator-style traversal with an index-based loop and adds a defensive structKeyExists check before reading name. This avoids iterator