### PR TITLE
Renderer.renderLayout throws "LayoutNotFoundException"

### DIFF
--- a/system/web/Renderer.cfc
+++ b/system/web/Renderer.cfc
@@ -605,20 +605,20 @@ component
 			}
 		}
 
-		// Discover the layout location + helpers
-		var layoutLocations = discoverViewPaths(
-			view          : cbox_currentLayout,
-			module        : arguments.module,
-			explicitModule: cbox_explicitModule,
-			isLayout      : true
-		);
+		// Layout location holder — only populated when layout is non-empty.
+		// discoverViewPaths throws on an empty layout name (regression vs ColdBox 7).
+		var layoutLocations = { viewPath : "", viewHelperPath : [] };
 
-		// If Layout is blank, then just delegate to the view
-		// No layout rendering.
+		// If Layout is blank, then just delegate to the view (no layout rendering).
 		if ( len( cbox_currentLayout ) eq 0 ) {
 			iData.renderedLayout = this.view();
 		} else {
-			// Render the layout with it's helpers
+			layoutLocations = discoverViewPaths(
+				view          : cbox_currentLayout,
+				module        : arguments.module,
+				explicitModule: cbox_explicitModule,
+				isLayout      : true
+			);
 			iData.renderedLayout = renderViewComposite(
 				view          : cbox_currentLayout,
 				viewPath      : layoutLocations.viewPath,


### PR DESCRIPTION
when called with an empty layout (regression vs 7.x)

Any caller that produces an empty cbox_currentLayout (e.g. event.setLayout("") for JSON endpoints, AJAX handlers, or nolayout-style flows) crashes during render with: The layout [] was not found in the module path: /<appMapping>/layouts/



IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.

## Jira Issues

All PRs must have an accompanied Jira issue. Please make sure you created it and linked it here.

https://ortussolutions.atlassian.net/browse/COLDBOX-1391


## Type of change

Please delete options that are not relevant.

- [x] Bug Fix

