### PR TITLE
COLDBOX-1407 - Protect against url.results collision on cache results variable

### DIFF
--- a/system/cache/store/ConcurrentStore.cfc
+++ b/system/cache/store/ConcurrentStore.cfc
@@ -120,7 +120,7 @@ component implements="coldbox.system.cache.store.IObjectStore" accessors="true" 
 	function getQuiet( required objectKey ){
 		// retrieve from map
 		var results = variables.pool.get( arguments.objectKey );
-		if ( !isNull( results ) ) {
+		if ( !isNull( local.results ) ) {
 			return results.object;
 		}
 	}


### PR DESCRIPTION
# Description

Protect against url.results collision on cache results variable.

Loading any ColdBox page with `?results=0` breaks the UDF `cache.getOrSet()` call, ultimately resulting (no pun intended) in this error:

```
lucee.runtime.exp.ExpressionException: No matching property [OBJECT] found in [string],
	at lucee.runtime.reflection.Reflector.getGetter(Reflector.java:986),
	at lucee.runtime.reflection.Reflector.callGetter(Reflector.java:1020),
	at lucee.runtime.reflection.Reflector.getProperty(Reflector.java:1230),
	at lucee.runtime.util.VariableUtilImpl.get(VariableUtilImpl.java:347),
	at lucee.runtime.PageContextImpl.get(PageContextImpl.java:1568),
	at coldbox.system.cache.store.concurrentstore_cfc$cf.udfCall1(/coldbox/system/cache/store/ConcurrentStore.cfc:124),
	at coldbox.system.cache.store.concurrentstore_cfc$cf.udfCall(/coldbox/system/cache/store/ConcurrentStore.cfc),
```

## Jira Issues

https://ortussolutions.atlassian.net/browse/COLDBOX-1407

## Type of change

- [x] Bug Fix

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)