### PR TITLE
fix: interceptor short-circuit reporting and addRoute() key drift

### DIFF
--- a/system/web/context/InterceptorState.cfc
+++ b/system/web/context/InterceptorState.cfc
@@ -120,7 +120,8 @@ component accessors="true" extends="coldbox.system.core.events.EventPool" {
 	}
 
 	/**
-	 * Process this state's interceptors. If you use the asynchronous facilities, you will get a thread structure report as a result
+	 * Process this state's interceptors. If you use the asynchronous facilities, you will get a thread structure report as a result.
+	 * On the synchronous path (the default), returns true if an interceptor short-circuited the chain by returning true; false otherwise.
 	 *
 	 * @event            The event context object.
 	 * @data             A data structure used to pass intercepted information.
@@ -151,7 +152,7 @@ component accessors="true" extends="coldbox.system.core.events.EventPool" {
 		} else if ( arguments.asyncAll AND !variables.utility.inThread() ) {
 			return processAsyncAll( argumentCollection = arguments )
 		} else {
-			processSync(
+			return processSync(
 				event  = arguments.event,
 				data   = arguments.data,
 				buffer = arguments.buffer
@@ -345,8 +346,10 @@ component accessors="true" extends="coldbox.system.core.events.EventPool" {
 	 * @event  The event context object.
 	 * @data   A data structure used to pass intercepted information.
 	 * @buffer hint="The request buffer object that can be used to produce output from interceptor chains
+	 *
+	 * @return True if an interceptor short-circuited the chain by returning true; false otherwise
 	 */
-	function processSync( required event, required data, required buffer ){
+	boolean function processSync( required event, required data, required buffer ){
 		var interceptorChain = variables.interceptorChain
 		var interceptorCount = interceptorChain.len()
 		var log              = getLogger()
@@ -362,11 +365,12 @@ component accessors="true" extends="coldbox.system.core.events.EventPool" {
 			if ( canDebug ) {
 				log.debug( "Finished '#state#' execution chain" )
 			}
-			return
+			return false
 		}
 
-		var currentEvent   = ""
-		var invocationArgs = {
+		var currentEvent      = ""
+		var wasShortCircuited = false
+		var invocationArgs    = {
 			"event"         : arguments.event,
 			"data"          : arguments.data,
 			"interceptData" : arguments.data, // Remove by ColdBox 7 DEPRECATED
@@ -418,6 +422,7 @@ component accessors="true" extends="coldbox.system.core.events.EventPool" {
 					log                  = log
 				)
 			) {
+				wasShortCircuited = true
 				break;
 			}
 		}
@@ -426,6 +431,8 @@ component accessors="true" extends="coldbox.system.core.events.EventPool" {
 		if ( canDebug ) {
 			log.debug( "Finished '#state#' execution chain" )
 		}
+
+		return wasShortCircuited
 	}
 
 	/**
@@ -589,7 +596,7 @@ component accessors="true" extends="coldbox.system.core.events.EventPool" {
 
 		// Closure or object?
 		if ( arguments.interceptorIsClosure ) {
-			arguments.interceptor( argumentCollection = arguments.invocationArgs )
+			var results = arguments.interceptor( argumentCollection = arguments.invocationArgs )
 		} else {
 			var results = invoke(
 				arguments.interceptor,

--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -793,7 +793,11 @@ component
 		string layoutModule           = "",
 		struct meta                   = {},
 		boolean sse                   = "false",
-		any sseCallback               = ""
+		any sseCallback               = "",
+		boolean ai                    = "false",
+		any aiRunnable                = "",
+		boolean mcp                   = "false",
+		string mcpServer              = ""
 	){
 		// The route construct we will save
 		var thisRoute = {};

--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -1155,7 +1155,15 @@ component
 		if ( !variables.onGroup ) {
 			variables.withClosure = {};
 		}
-		// Return a new route definition
+		return routeDefinitionShape();
+	}
+
+	/**
+	 * The canonical struct shape of a registered route. Side-effect free - used both to seed a
+	 * new route definition (initRouteDefinition()) and for pure introspection
+	 * (getRouteDefinitionKeys()), which must not reset any in-flight fluent registration state.
+	 */
+	private struct function routeDefinitionShape(){
 		return {
 			"action"                : "", // The action to execute
 			"append"                : true, // Was this route appended or pre/prended
@@ -1196,6 +1204,18 @@ component
 			"mcp"                   : false, // Flag indicating this is an MCP server route
 			"mcpServer"             : "" // The MCP server name to expose
 		};
+	}
+
+	/**
+	 * Get the full set of keys that make up a registered route's canonical struct shape.
+	 *
+	 * Useful for route table introspection/tooling, and used to guard against addRoute()'s
+	 * parameters drifting out of sync with this definition - a parameter missing here means
+	 * that key is silently absent (not defaulted) from any route registered without explicitly
+	 * passing it.
+	 */
+	array function getRouteDefinitionKeys(){
+		return routeDefinitionShape().keyArray();
 	}
 
 	/**

--- a/system/web/services/InterceptorService.cfc
+++ b/system/web/services/InterceptorService.cfc
@@ -184,6 +184,11 @@ component extends="coldbox.system.web.services.BaseService" accessors="true" {
 	/**
 	 * Announce an interception to the system. If you use the asynchronous facilities, you will get a thread structure report as a result.
 	 *
+	 * On the default synchronous path, returns true if an interceptor short-circuited the chain by
+	 * returning true from its handler; false otherwise. Interceptors that never return a boolean, and
+	 * states with no registered interceptors, resolve to false. Use this to detect that an interceptor
+	 * consumed/rejected the announcement, e.g. `if ( interceptorService.announce( "preSSEConnection", data ) ) { ... }`.
+	 *
 	 * This is needed so interceptors can write to the page output buffer
 	 *
 	 * @output           true

--- a/tests/specs/web/context/InterceptorStateTest.cfc
+++ b/tests/specs/web/context/InterceptorStateTest.cfc
@@ -115,6 +115,171 @@
 		this.state.unregister( "nothing baby" );
 	}
 
+	function testProcessReturnsFalseWhenNoInterceptorShortCircuits(){
+		mockBuffer = createStub();
+		var result = this.state.process(
+			event  = this.event,
+			data   = structNew(),
+			buffer = mockBuffer
+		);
+
+		assertFalse( result );
+	}
+
+	function testProcessReturnsFalseWhenChainIsEmpty(){
+		this.state.unregister( this.key );
+		mockBuffer = createStub();
+		var result = this.state.process(
+			event  = this.event,
+			data   = structNew(),
+			buffer = mockBuffer
+		);
+
+		assertFalse( result );
+	}
+
+	function testProcessReturnsTrueWhenAnObjectInterceptorShortCircuits(){
+		this.state.unregister( this.key );
+		var shortCircuitInterceptor = createMock( "coldbox.tests.resources.MockInterceptor" )
+			.$( "unitTest" )
+			.$results( true );
+		this.state.register(
+			this.key,
+			shortCircuitInterceptor,
+			{
+				async         : false,
+				asyncPriority : "normal",
+				eventPattern  : ""
+			}
+		);
+
+		mockBuffer = createStub();
+		var result = this.state.process(
+			event  = this.event,
+			data   = structNew(),
+			buffer = mockBuffer
+		);
+
+		assertTrue( result );
+	}
+
+	function testProcessReturnsTrueWhenAClosureInterceptorShortCircuits(){
+		this.state.unregister( this.key );
+		var shortCircuitClosure = function( event, data ){
+			return true;
+		};
+		this.state.register(
+			this.key,
+			shortCircuitClosure,
+			{
+				async         : false,
+				asyncPriority : "normal",
+				eventPattern  : ""
+			}
+		);
+
+		mockBuffer = createStub();
+		var result = this.state.process(
+			event  = this.event,
+			data   = structNew(),
+			buffer = mockBuffer
+		);
+
+		assertTrue( result );
+	}
+
+	function testProcessStopsRemainingInterceptorsOnceShortCircuited(){
+		this.state.unregister( this.key );
+
+		var laterInterceptorRan = false;
+		var shortCircuitClosure = function( event, data ){
+			return true;
+		};
+		var laterClosure = function( event, data ){
+			laterInterceptorRan = true;
+		};
+
+		this.state.register(
+			this.key,
+			shortCircuitClosure,
+			{
+				async         : false,
+				asyncPriority : "normal",
+				eventPattern  : ""
+			}
+		);
+		this.state.register(
+			"cbox_interceptor_later",
+			laterClosure,
+			{
+				async         : false,
+				asyncPriority : "normal",
+				eventPattern  : ""
+			}
+		);
+
+		mockBuffer = createStub();
+		this.state.process(
+			event  = this.event,
+			data   = structNew(),
+			buffer = mockBuffer
+		);
+
+		assertFalse( laterInterceptorRan );
+	}
+
+	function testInvokerCapturesAClosureInterceptorsReturnValue(){
+		makepublic( this.state, "invoker" );
+		mockEvent  = getMockRequestContext().$( "getCollection", {} ).$( "getPrivateCollection", {} );
+		mockBuffer = createStub();
+
+		var result = this.state.invoker(
+			interceptor = function( event, data, buffer, rc, prc ){
+				return true;
+			},
+			interceptorKey = "closureShortCircuit",
+			invocationArgs = {
+				event         : mockEvent,
+				data          : {},
+				interceptData : {},
+				buffer        : mockBuffer,
+				rc            : {},
+				prc           : {}
+			},
+			canDebug = false,
+			state    = this.state.getState(),
+			log      = mockLogger
+		);
+
+		assertTrue( result );
+	}
+
+	function testInvokerReturnsFalseWhenAClosureInterceptorReturnsNothing(){
+		makepublic( this.state, "invoker" );
+		mockEvent  = getMockRequestContext().$( "getCollection", {} ).$( "getPrivateCollection", {} );
+		mockBuffer = createStub();
+
+		var result = this.state.invoker(
+			interceptor = function( event, data, buffer, rc, prc ){
+				// intentionally does not return anything
+			},
+			interceptorKey = "closureNoReturn",
+			invocationArgs = {
+				event         : mockEvent,
+				data          : {},
+				interceptData : {},
+				buffer        : mockBuffer,
+				rc            : {},
+				prc           : {}
+			},
+			canDebug = false,
+			state    = this.state.getState(),
+			log      = mockLogger
+		);
+
+		assertFalse( result );
+	}
+
 	function testInvoker(){
 		// debug( this.state.getState() );
 

--- a/tests/specs/web/routing/RouterSSETest.cfc
+++ b/tests/specs/web/routing/RouterSSETest.cfc
@@ -78,9 +78,11 @@ component extends="coldbox.system.testing.BaseModelTest" skip="notBoxlang" {
 			} );
 
 			it( "returns nothing for media types that have no alias", function(){
-				// Built via concatenation rather than the literal "*/*" - a literal */ sequence
-				// inside a string breaks the CFScript parser on Adobe ColdFusion 2023, which
-				// appears to scan for comment terminators without full string-literal awareness.
+				// Built via concatenation rather than the literal wildcard media type string.
+				// Writing the two characters that close a block comment anywhere in CFScript
+				// source - even inside a string, or inside a line comment like this one - breaks
+				// the parser on Adobe ColdFusion 2023, which appears to scan for comment
+				// terminators without full context awareness.
 				var wildcardMediaType = "*" & "/" & "*";
 
 				[
@@ -95,8 +97,8 @@ component extends="coldbox.system.testing.BaseModelTest" skip="notBoxlang" {
 
 			it( "does not let sse shadow the formats a browser actually asks for", function(){
 				// A browser's default Accept header must still resolve exactly as it did before.
-				// Built via concatenation - see the comment above on why a literal "*/*" is unsafe
-				// in CFScript source on Adobe ColdFusion 2023.
+				// Built via concatenation - see the comment above on why the literal wildcard
+				// media type string is unsafe in CFScript source on Adobe ColdFusion 2023.
 				var wildcardMediaType = "*" & "/" & "*";
 				var browserAccept     = "text/html,application/xhtml+xml,application/xml;q=0.9,#wildcardMediaType#;q=0.8";
 

--- a/tests/specs/web/routing/RouterSSETest.cfc
+++ b/tests/specs/web/routing/RouterSSETest.cfc
@@ -50,7 +50,11 @@ component extends="coldbox.system.testing.BaseModelTest" skip="notBoxlang" {
 			} );
 
 			it( "keeps every pre-existing extension valid", function(){
-				[
+				// Assigned to a variable rather than calling .each() straight off the array
+				// literal - chaining a member function directly onto a bracket literal breaks
+				// the parser on Adobe ColdFusion 2023 (RouterAITest.cfc's already-working .each()
+				// calls are all on variables, never literals).
+				var preExistingExtensions = [
 					"json",
 					"jsont",
 					"xml",
@@ -60,7 +64,9 @@ component extends="coldbox.system.testing.BaseModelTest" skip="notBoxlang" {
 					"htm",
 					"rss",
 					"pdf"
-				].each( ( ext ) => {
+				];
+
+				preExistingExtensions.each( ( ext ) => {
 					expect( variables.router.isValidExtension( ext ) ).toBeTrue();
 				} );
 			} );
@@ -83,14 +89,15 @@ component extends="coldbox.system.testing.BaseModelTest" skip="notBoxlang" {
 				// source - even inside a string, or inside a line comment like this one - breaks
 				// the parser on Adobe ColdFusion 2023, which appears to scan for comment
 				// terminators without full context awareness.
-				var wildcardMediaType = "*" & "/" & "*";
-
-				[
+				var wildcardMediaType     = "*" & "/" & "*";
+				var mediaTypesWithNoAlias = [
 					"application/json",
 					"text/html",
 					wildcardMediaType,
 					""
-				].each( ( mediaType ) => {
+				];
+
+				mediaTypesWithNoAlias.each( ( mediaType ) => {
 					expect( variables.router.getMimeExtensionAlias( mediaType ) ).toBeEmpty();
 				} );
 			} );
@@ -99,14 +106,13 @@ component extends="coldbox.system.testing.BaseModelTest" skip="notBoxlang" {
 				// A browser's default Accept header must still resolve exactly as it did before.
 				// Built via concatenation - see the comment above on why the literal wildcard
 				// media type string is unsafe in CFScript source on Adobe ColdFusion 2023.
-				var wildcardMediaType = "*" & "/" & "*";
-				var browserAccept     = "text/html,application/xhtml+xml,application/xml;q=0.9,#wildcardMediaType#;q=0.8";
+				var wildcardMediaType    = "*" & "/" & "*";
+				var browserAccept        = "text/html,application/xhtml+xml,application/xml;q=0.9,#wildcardMediaType#;q=0.8";
+				var browserAcceptEntries = browserAccept.listToArray();
 
-				browserAccept
-					.listToArray()
-					.each( ( thisAccept ) => {
-						expect( variables.router.getMimeExtensionAlias( thisAccept ) ).toBeEmpty();
-					} );
+				browserAcceptEntries.each( ( thisAccept ) => {
+					expect( variables.router.getMimeExtensionAlias( thisAccept ) ).toBeEmpty();
+				} );
 			} );
 		} );
 

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -174,6 +174,33 @@ component extends="coldbox.system.testing.BaseModelTest" {
 				} );
 			} );
 
+			story( "I want addRoute() and initRouteDefinition() to never drift apart", function(){
+				given( "the canonical route definition shape and addRoute()'s declared parameters", function(){
+					then( "every settable key in the shape has a matching addRoute() parameter", function(){
+						// Keys that are computed internally during registration rather than accepted as
+						// caller input - these are legitimately absent from addRoute()'s signature.
+						var computedOnlyKeys = [ "responsePlaceholders" ];
+
+						var definitionKeys = router.getRouteDefinitionKeys();
+						var addRouteParams = getMetadata( router ).functions.filter( function( fn ){
+							return fn.name == "addRoute";
+						} )[ 1 ].parameters.map( function( param ){
+							return param.name;
+						} );
+
+						for ( var key in definitionKeys ) {
+							if ( computedOnlyKeys.findNoCase( key ) ) {
+								continue;
+							}
+							expect( addRouteParams ).toInclude(
+								key,
+								"initRouteDefinition() key '#key#' has no matching addRoute() parameter - it will be silently absent (not defaulted) from any route that doesn't explicitly pass it"
+							);
+						}
+					} );
+				} );
+			} );
+
 			story( "I want to register fluent routes with no modifiers or terminators", function(){
 				given( "no inline target", function(){
 					then( "it should store the route pointer", function(){

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -156,6 +156,24 @@ component extends="coldbox.system.testing.BaseModelTest" {
 				} );
 			} );
 
+			story( "I want every registered route to carry the full route definition shape", function(){
+				given( "an ordinary route with no AI/MCP/SSE modifiers", function(){
+					then( "it still carries defaulted ai, aiRunnable, mcp and mcpServer keys", function(){
+						router.route( "/luis", "main.index" );
+						var thisRoute = router.getRoutes()[ 1 ];
+
+						expect( thisRoute ).toHaveKey( "ai" );
+						expect( thisRoute.ai ).toBeFalse();
+						expect( thisRoute ).toHaveKey( "aiRunnable" );
+						expect( thisRoute.aiRunnable ).toBe( "" );
+						expect( thisRoute ).toHaveKey( "mcp" );
+						expect( thisRoute.mcp ).toBeFalse();
+						expect( thisRoute ).toHaveKey( "mcpServer" );
+						expect( thisRoute.mcpServer ).toBe( "" );
+					} );
+				} );
+			} );
+
 			story( "I want to register fluent routes with no modifiers or terminators", function(){
 				given( "no inline target", function(){
 					then( "it should store the route pointer", function(){

--- a/tests/specs/web/routing/RouterTest.cfc
+++ b/tests/specs/web/routing/RouterTest.cfc
@@ -182,11 +182,21 @@ component extends="coldbox.system.testing.BaseModelTest" {
 						var computedOnlyKeys = [ "responsePlaceholders" ];
 
 						var definitionKeys = router.getRouteDefinitionKeys();
-						var addRouteParams = getMetadata( router ).functions.filter( function( fn ){
-							return fn.name == "addRoute";
-						} )[ 1 ].parameters.map( function( param ){
-							return param.name;
-						} );
+						var routerMetadata = getMetadata( router );
+						var addRouteParams = [];
+
+						// Plain for-in loops rather than .filter()/.map() member calls - the array
+						// nested inside a function's metadata (fn.parameters) isn't guaranteed to
+						// support CF array member functions on every engine (observed missing on
+						// Adobe ColdFusion).
+						for ( var fn in routerMetadata.functions ) {
+							if ( fn.name == "addRoute" ) {
+								for ( var param in fn.parameters ) {
+									addRouteParams.append( param.name );
+								}
+								break;
+							}
+						}
 
 						for ( var key in definitionKeys ) {
 							if ( computedOnlyKeys.findNoCase( key ) ) {

--- a/tests/specs/web/services/InterceptorserviceTest.cfc
+++ b/tests/specs/web/services/InterceptorserviceTest.cfc
@@ -115,6 +115,56 @@
 		assertFalse( called );
 	}
 
+	function testAnnounceReturnsTrueWhenAnInterceptorShortCircuits(){
+		iService.listen( function( event, data ){
+			return true;
+		}, "onCall" );
+
+		var result = iService.announce( "onCall" );
+
+		assertTrue( result );
+	}
+
+	function testAnnounceReturnsFalseWhenNoInterceptorShortCircuits(){
+		var ran = false;
+		iService.listen( function( event, data ){
+			ran = true;
+			return false;
+		}, "onCall" );
+
+		var result = iService.announce( "onCall" );
+
+		assertTrue( ran );
+		assertFalse( result );
+	}
+
+	function testAnnounceReturnsFalseWhenTheRegisteredStateHasNoInterceptors(){
+		// listen()/unlisten() creates the state container but leaves it with no interceptors
+		var listener = function(){
+		};
+		iService.listen( listener, "onEmptyState" );
+		iService.unlisten( listener, "onEmptyState" );
+
+		var result = iService.announce( "onEmptyState" );
+
+		assertFalse( result );
+	}
+
+	function testAnnounceStopsLaterInterceptorsOnceOneShortCircuits(){
+		var laterInterceptorRan = false;
+
+		iService.listen( function( event, data ){
+			return true;
+		}, "onCall" );
+		iService.listen( function( event, data ){
+			laterInterceptorRan = true;
+		}, "onCall" );
+
+		iService.announce( "onCall" );
+
+		assertFalse( laterInterceptorRan );
+	}
+
 	function testAnnounceFlushesBufferedInterceptorOutput(){
 		iService.listen( function( event, data, buffer ){
 			arguments.buffer.append( "buffered output" )


### PR DESCRIPTION
# Description

Three small, related fixes to the interceptor chain and the router, found while working on the SSE streaming feature (#676) and while exploring what ColdBox already offers as middleware-like composition.

1. **Interceptor chain now reports and honors short-circuiting.** `InterceptorState.processSync()` (and therefore `process()`/`InterceptorService.announce()`) previously always returned void on the synchronous path, so callers had no way to detect that an interceptor consumed/rejected an announcement (e.g. a `preSSEConnection` listener aborting a stream). `processSync()` now returns `true` when an interceptor short-circuits the chain by returning `true`, `false` otherwise.

   While adding tests for this, found a second, related bug in `invoker()`: the closure-interceptor branch never captured its return value, so a `listen()`-registered closure returning `true` could never actually short-circuit the chain — only object interceptors could. Fixed by capturing the closure's result the same way the object branch already does.

2. **`addRoute()` was missing the `ai`/`aiRunnable`/`mcp`/`mcpServer` parameters.** `initRouteDefinition()` defines these four keys as part of the canonical route shape, but `addRoute()` never declared them as named parameters. A parameter's declared default is what backfills that key onto callers who don't explicitly pass it, so every route registered without those keys explicitly supplied — i.e. every route except `toAi()`/`toMCP()`'s own — ended up missing `ai`/`aiRunnable`/`mcp`/`mcpServer` entirely rather than defaulting to `false`/`""`. This is the same bug class the `sse`/`sseCallback` route keys hit before being declared on `addRoute()` in #676.

3. **Guard against this recurring.** Split the route struct's canonical shape out of `initRouteDefinition()` into a side-effect-free `routeDefinitionShape()`, exposed via a new public `getRouteDefinitionKeys()` accessor (also handy for route table introspection tooling). Added a `getMetadata()`-reflection-based test that asserts every key in that shape has a matching `addRoute()` parameter, so a future route feature that repeats this footgun fails a test instead of silently dropping a key. Verified the guard actually catches drift (not vacuous) by temporarily removing a declared parameter and confirming the test failed as expected, before reverting.

All three commits were verified against the local BoxLang test suite with no new failures against the pre-existing baseline.

## Jira Issues

No pre-existing Jira issue — these are small internal fixes discovered as a byproduct of other work rather than reported bugs.

## Type of change

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_016kCmPkBvNZZhU6iuDcG4NR)_