### PR TITLE
feat: conversational context (userId/conversationId/threadId) on toAi() routes

### DIFF
--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -2368,6 +2368,26 @@ component
 	 *     .toAi( "ChatRunnable" );
 	 * </pre>
 	 *
+	 * ### Conversational context (invoke/stream/batch)
+	 *
+	 * Alongside `input`/`params`/`options`, the request body may carry `userId`, `conversationId`,
+	 * and `threadId`. Whatever's resolved is merged into `options` before the runnable is called
+	 * (`options.userId`, `options.conversationId`, `options.threadId`), and `threadId` is always
+	 * echoed back to the caller - as `threadId` on the JSON response (invoke/batch) and as an
+	 * `X-Thread-Id` response header on all three, plus a leading `thread` SSE frame on stream (since
+	 * EventSource clients can't read response headers):
+	 *
+	 * - `userId` - defaults to `Controller.getUserSessionIdentifier()` if not supplied
+	 * - `conversationId` - passed through only if supplied; no default is generated
+	 * - `threadId` - passed through if supplied, otherwise a new one is minted - always present in
+	 *   the response so a follow-up call can continue the same thread
+	 *
+	 * <pre>
+	 * // POST /api/chat/invoke  { "input": "hi", "threadId": "t-123" }
+	 * // → runnable.run( "hi", {}, { userId: "<session id>", threadId: "t-123" } )
+	 * // → { "output": ..., "success": true, "threadId": "t-123" }
+	 * </pre>
+	 *
 	 * @runnable A WireBox ID string or a live IAiRunnable instance
 	 *
 	 * @return Router instance for chaining
@@ -2428,12 +2448,18 @@ component
 				"response" : ( event, rc, prc ) => {
 					var runnableInstance = isSimpleValue( capturedRunnable ) ? getInstance( capturedRunnable ) : capturedRunnable
 					var body             = event.getHTTPContent( json: true )
+					var aiContext        = resolveAiContext( body )
 					var result           = runnableInstance.run(
 						body.input ?: {},
 						body.params ?: {},
-						body.options ?: {}
+						( body.options ?: {} ).append( aiContext, true )
 					)
-					return { "output" : result, "success" : true }
+					event.setHTTPHeader( name = "X-Thread-Id", value = aiContext.threadId )
+					return {
+						"output"   : result,
+						"success"  : true,
+						"threadId" : aiContext.threadId
+					}
 				}
 			} )
 
@@ -2458,8 +2484,19 @@ component
 				"response" : ( event, rc, prc ) => {
 					var runnableInstance = isSimpleValue( capturedRunnable ) ? getInstance( capturedRunnable ) : capturedRunnable;
 					var body             = event.getHTTPContent( json: true );
+					var aiContext        = resolveAiContext( body );
+					var options          = ( body.options ?: {} ).append( aiContext, true );
+
+					// Headers must go out before the stream opens
+					event.setHTTPHeader( name = "X-Thread-Id", value = aiContext.threadId );
+
 					SSE(
 						callback: ( emitter ) => {
+							// Lead with the resolved thread id - EventSource clients cannot read
+							// response headers, so this is the only way a browser caller learns a
+							// server-generated threadId in time to persist it for the next request.
+							emitter.send( { "threadId" : aiContext.threadId }, "thread" );
+
 							runnableInstance.stream(
 								( chunk ) => {
 									if ( !emitter.isClosed() ) {
@@ -2468,7 +2505,7 @@ component
 								},
 								body.input ?: {},
 								body.params ?: {},
-								body.options ?: {}
+								options
 							);
 							if ( !emitter.isClosed() ) {
 								emitter.send( "[DONE]", "done" );
@@ -2503,10 +2540,12 @@ component
 					var runnableInstance = isSimpleValue( capturedRunnable ) ? getInstance( capturedRunnable ) : capturedRunnable
 					var body             = event.getHTTPContent( json: true )
 					var params           = body.params ?: {}
-					var options          = body.options ?: {}
+					var aiContext        = resolveAiContext( body )
+					var options          = ( body.options ?: {} ).append( aiContext, true )
 					var inputs           = body.inputs ?: []
 
-					// Map the incoming outputs
+					// Map the incoming outputs - context is resolved once per request and shared
+					// by every item in the batch, same as params/options already are.
 					var outputs = inputs.map( ( input ) => {
 						try {
 							return {
@@ -2517,7 +2556,8 @@ component
 							return { error : e.message, success : false };
 						}
 					} )
-					return { "outputs" : outputs }
+					event.setHTTPHeader( name = "X-Thread-Id", value = aiContext.threadId )
+					return { "outputs" : outputs, "threadId" : aiContext.threadId }
 				}
 			} )
 
@@ -2581,6 +2621,35 @@ component
 		variables.thisRoute = initRouteDefinition()
 
 		return this;
+	}
+
+	/**
+	 * Resolve the conversational identity/thread context for an AI request - shared by the
+	 * invoke/stream/batch sub-routes toAi() registers.
+	 *
+	 * - `userId`: the request body's `userId` if provided, else the framework's own request/session
+	 *   tracking identifier (`Controller.getUserSessionIdentifier()`) - so every call is attributable
+	 *   to *someone* even when the caller doesn't manage its own user identity.
+	 * - `conversationId`: passed through as-is when provided. No default is generated - an absent
+	 *   conversationId means the caller isn't tracking conversations, and inventing one would imply
+	 *   a continuity that doesn't exist.
+	 * - `threadId`: the request body's `threadId` if provided, else a freshly generated one. Always
+	 *   present in the result so the caller can echo it back on the next request to continue the
+	 *   same thread, whether they supplied it or a new one had to be minted.
+	 *
+	 * @body The parsed JSON request body - invoke/stream/batch all pass their raw body here
+	 *
+	 * @return `{ userId, threadId, conversationId? }`
+	 */
+	private struct function resolveAiContext( required struct body ){
+		var ctx = {
+			"userId"   : len( arguments.body.userId ?: "" ) ? arguments.body.userId : variables.controller.getUserSessionIdentifier(),
+			"threadId" : len( arguments.body.threadId ?: "" ) ? arguments.body.threadId : createUUID()
+		};
+		if ( len( arguments.body.conversationId ?: "" ) ) {
+			ctx.conversationId = arguments.body.conversationId;
+		}
+		return ctx;
 	}
 
 	/**

--- a/system/web/routing/Router.cfc
+++ b/system/web/routing/Router.cfc
@@ -2449,11 +2449,9 @@ component
 					var runnableInstance = isSimpleValue( capturedRunnable ) ? getInstance( capturedRunnable ) : capturedRunnable
 					var body             = event.getHTTPContent( json: true )
 					var aiContext        = resolveAiContext( body )
-					var result           = runnableInstance.run(
-						body.input ?: {},
-						body.params ?: {},
-						( body.options ?: {} ).append( aiContext, true )
-					)
+					var options          = body.options ?: {}
+					options.append( aiContext, true )
+					var result = runnableInstance.run( body.input ?: {}, body.params ?: {}, options )
 					event.setHTTPHeader( name = "X-Thread-Id", value = aiContext.threadId )
 					return {
 						"output"   : result,
@@ -2485,7 +2483,8 @@ component
 					var runnableInstance = isSimpleValue( capturedRunnable ) ? getInstance( capturedRunnable ) : capturedRunnable;
 					var body             = event.getHTTPContent( json: true );
 					var aiContext        = resolveAiContext( body );
-					var options          = ( body.options ?: {} ).append( aiContext, true );
+					var options          = body.options ?: {};
+					options.append( aiContext, true );
 
 					// Headers must go out before the stream opens
 					event.setHTTPHeader( name = "X-Thread-Id", value = aiContext.threadId );
@@ -2541,8 +2540,9 @@ component
 					var body             = event.getHTTPContent( json: true )
 					var params           = body.params ?: {}
 					var aiContext        = resolveAiContext( body )
-					var options          = ( body.options ?: {} ).append( aiContext, true )
-					var inputs           = body.inputs ?: []
+					var options          = body.options ?: {}
+					options.append( aiContext, true )
+					var inputs = body.inputs ?: []
 
 					// Map the incoming outputs - context is resolved once per request and shared
 					// by every item in the batch, same as params/options already are.

--- a/tests/specs/web/routing/RouterAITest.cfc
+++ b/tests/specs/web/routing/RouterAITest.cfc
@@ -104,6 +104,62 @@ component extends="coldbox.system.testing.BaseModelTest" skip="notBoxlang" {
 				} )
 			} )
 
+			story( "I want conversational context resolution on toAi() sub-routes", function(){
+				beforeEach( function(){
+					makePublic( router, "resolveAiContext" )
+				} )
+
+				given( "no userId in the request body", function(){
+					then( "it defaults to the controller's session identifier", function(){
+						controller.$( "getUserSessionIdentifier" ).$results( "mock-session-id" )
+						var ctx = router.resolveAiContext( {} )
+						expect( ctx.userId ).toBe( "mock-session-id" )
+					} )
+				} )
+
+				given( "a userId in the request body", function(){
+					then( "it is passed through untouched", function(){
+						var ctx = router.resolveAiContext( { "userId" : "explicit-user" } )
+						expect( ctx.userId ).toBe( "explicit-user" )
+					} )
+				} )
+
+				given( "no conversationId in the request body", function(){
+					then( "the result carries no conversationId key at all", function(){
+						var ctx = router.resolveAiContext( {} )
+						expect( ctx ).notToHaveKey( "conversationId" )
+					} )
+				} )
+
+				given( "a conversationId in the request body", function(){
+					then( "it is passed through untouched", function(){
+						var ctx = router.resolveAiContext( { "conversationId" : "conv-42" } )
+						expect( ctx.conversationId ).toBe( "conv-42" )
+					} )
+				} )
+
+				given( "no threadId in the request body", function(){
+					then( "a new one is generated and always present in the result", function(){
+						var ctx = router.resolveAiContext( {} )
+						expect( ctx.threadId ).toBeString()
+						expect( ctx.threadId ).notToBeEmpty()
+					} )
+
+					then( "two separate calls generate two different thread ids", function(){
+						var first  = router.resolveAiContext( {} )
+						var second = router.resolveAiContext( {} )
+						expect( first.threadId ).notToBe( second.threadId )
+					} )
+				} )
+
+				given( "a threadId in the request body", function(){
+					then( "it is passed through untouched, not regenerated", function(){
+						var ctx = router.resolveAiContext( { "threadId" : "thread-99" } )
+						expect( ctx.threadId ).toBe( "thread-99" )
+					} )
+				} )
+			} )
+
 			story( "I want argument validation on toAi()", function(){
 				given( "a numeric value as runnable", function(){
 					then( "it should throw InvalidArgumentException", function(){


### PR DESCRIPTION
# Description

`toAi()` works great for single-shot inference but had no way to carry conversational identity across a multi-turn exchange - no `userId`, `conversationId`, or `threadId`. This adds all three to the `invoke`/`stream`/`batch` sub-routes `toAi()` registers.

## Jira Issues

[COLDBOX-1417](https://ortussolutions.atlassian.net/browse/COLDBOX-1417)

## Type of change

- [ ] Bug Fix
- [ ] Improvement
- [x] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---

### What changed

A new shared `resolveAiContext( body )` private method on `Router.cfc`, called by all three of `toAi()`'s runnable-invoking sub-routes:

- **`userId`** - the request body's `userId` if provided, else the framework's own `Controller.getUserSessionIdentifier()` (session id, or a cookie/URL-token-based tracking id as a fallback, or a per-request id as a last resort) - so every call is attributable to *someone* even when the caller doesn't manage its own user identity.
- **`conversationId`** - passed through as-is when the caller supplies one. **No default is generated** - an absent `conversationId` means the caller isn't tracking conversations, and inventing one would imply a continuity that doesn't exist.
- **`threadId`** - passed through if supplied, otherwise a new one is generated (`createUUID()`). **Always** present in the result, so a follow-up call can continue the same thread whether the caller supplied a threadId or a new one had to be minted.

All three resolved values are merged into the `options` struct passed to the runnable's `run()`/`stream()` calls (`options.userId`, `options.conversationId`, `options.threadId`), so an `IAiRunnable` implementation sees them without any interface changes.

### Request/response shape

```javascript
// POST /api/chat/invoke
// { "input": "hi", "threadId": "t-123" }

// → runnable.run( "hi", {}, { userId: "<session id>", threadId: "t-123" } )
// → { "output": ..., "success": true, "threadId": "t-123" }
// → response header: X-Thread-Id: t-123
```

`threadId` is echoed back three ways so it's usable from any client:
- On the JSON response body (`invoke`/`batch`)
- As an `X-Thread-Id` response header (all three sub-routes)
- As a leading `event: thread` SSE frame on `/stream`, sent before the runnable's own chunks - browser `EventSource` clients can't read response headers, so this is the only way they learn a server-generated `threadId` in time to persist it

`batch` resolves context once per request and shares it across every item in `inputs[]`, consistent with how `params`/`options` already work for batch.

### Example

```javascript
// A runnable reading the resolved context
component implements="bxModules.bxai.models.runnables.IAiRunnable" {
    function run( input, params = {}, options = {} ){
        var thread = conversationStore.loadOrCreate(
            userId         = options.userId,
            conversationId = options.conversationId ?: "",
            threadId       = options.threadId
        );
        return chatModel.reply( thread, input );
    }
}
```

### Files touched

- `system/web/routing/Router.cfc` - `resolveAiContext()` private method; wired into the `invoke`, `stream`, and `batch` sub-route response closures registered by `toAi()`; docblock updated with the new request body fields and response/header behavior
- `tests/specs/web/routing/RouterAITest.cfc` - new specs covering `resolveAiContext()`'s userId default/passthrough, conversationId passthrough/absence, and threadId passthrough/generation (via `makePublic()`, matching this file's existing testing conventions)

### Testing notes

`RouterAITest.cfc` extends `BaseModelTest` (`skip="notBoxlang"`, matching the existing AI/MCP routing test file) and exercises `resolveAiContext()` directly via `makePublic()`, with no servlet/database dependency, so it's runnable in CI as-is. The sandbox this PR was authored in has no reachable test database, so the full TestBox HTTP runner couldn't be exercised locally regardless of engine; instead, `Router.cfc` was verified to still parse and load correctly after every edit (arrow-function closure bodies are parsed eagerly in CFML/BoxLang, so a syntax error in the edited `invoke`/`stream`/`batch` closures would have surfaced immediately on instantiation, even without executing them), and `resolveAiContext()` was confirmed present on the compiled class via `getMetadata()`.

[COLDBOX-1417]: https://ortussolutions.atlassian.net/browse/COLDBOX-1417